### PR TITLE
feat: stream s3 upload

### DIFF
--- a/packages/asset-uploader/src/clients/s3/request-headers.ts
+++ b/packages/asset-uploader/src/clients/s3/request-headers.ts
@@ -21,14 +21,12 @@ export const signS3Request = async ({
   url,
   method,
   headers,
-  body,
   query,
 }: {
   signer: SignatureV4;
   url: URL;
   method: string;
   headers: Record<string, string>;
-  body?: ArrayBuffer | Uint8Array;
   query?: Record<string, string>;
 }) =>
   await signer.sign({
@@ -38,5 +36,4 @@ export const signS3Request = async ({
     path: url.pathname,
     ...(query === undefined ? {} : { query }),
     headers: createS3SigningHeaders(url, headers),
-    ...(body === undefined ? {} : { body }),
   });

--- a/packages/asset-uploader/src/clients/s3/upload.test.ts
+++ b/packages/asset-uploader/src/clients/s3/upload.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, test, vi } from "vitest";
+import { readdir } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import { tmpdir } from "node:os";
+import { Readable } from "node:stream";
+import type { SignatureV4 } from "@smithy/signature-v4";
+import { AssetUploadSizeLimitError } from "../../utils/size-limiter";
+import { uploadToS3 } from "./upload";
+
+afterEach(() => vi.unstubAllGlobals());
+
+const leftoverTempFiles = async () =>
+  (await readdir(tmpdir())).filter((entry) =>
+    entry.startsWith("webstudio-asset-")
+  );
+
+describe("uploadToS3", () => {
+  test("spools the stream and uploads it with a known Content-Length", async () => {
+    const sign = vi.fn(async (request: unknown) => request);
+    const fetch = vi.fn(async () => new Response("ok", { status: 200 }));
+    vi.stubGlobal("fetch", fetch);
+
+    const data = {
+      async *[Symbol.asyncIterator]() {
+        yield new TextEncoder().encode("Post body");
+      },
+    };
+
+    const result = await uploadToS3({
+      signer: { sign } as unknown as SignatureV4,
+      name: "folder/post.md",
+      type: "text/markdown",
+      data,
+      maxSize: 1024,
+      endpoint: "https://storage.example",
+      bucket: "assets",
+      assetInfoFallback: undefined,
+    });
+
+    expect(result).toEqual({ size: 9, format: "md", meta: {} });
+    expect(fetch).toHaveBeenCalledTimes(1);
+    // The signer must not receive the body: it is never consumed or destroyed,
+    // so passing a stream here would leak a file descriptor per upload.
+    expect(sign.mock.calls[0][0]).toMatchObject({
+      headers: expect.objectContaining({
+        "x-amz-content-sha256": "UNSIGNED-PAYLOAD",
+      }),
+    });
+    expect((sign.mock.calls[0][0] as { body?: unknown }).body).toBeUndefined();
+    const [, init] = fetch.mock.calls[0] as unknown as [string, RequestInit];
+    expect(init.method).toBe("PUT");
+    expect(init.headers).toBeInstanceOf(Headers);
+    expect((init.headers as Headers).get("content-length")).toBe("9");
+    expect((init.headers as Headers).get("x-amz-content-sha256")).toBe(
+      "UNSIGNED-PAYLOAD"
+    );
+    expect(init.body).toBeInstanceOf(Readable);
+    expect(await leftoverTempFiles()).toEqual([]);
+  });
+
+  test("aborts the upload when the stream exceeds the size limit", async () => {
+    const fetch = vi.fn(async () => new Response("ok", { status: 200 }));
+    vi.stubGlobal("fetch", fetch);
+
+    const data = {
+      async *[Symbol.asyncIterator]() {
+        yield new Uint8Array(2048);
+      },
+    };
+
+    await expect(
+      uploadToS3({
+        signer: {
+          sign: async (request: unknown) => request,
+        } as unknown as SignatureV4,
+        name: "post.md",
+        type: "text/markdown",
+        data,
+        maxSize: 1024,
+        endpoint: "https://storage.example",
+        bucket: "assets",
+        assetInfoFallback: undefined,
+      })
+    ).rejects.toBeInstanceOf(AssetUploadSizeLimitError);
+    expect(fetch).not.toHaveBeenCalled();
+    expect(await leftoverTempFiles()).toEqual([]);
+  });
+
+  test("throws when the storage rejects the upload", async () => {
+    const fetch = vi.fn(async () => new Response("nope", { status: 403 }));
+    vi.stubGlobal("fetch", fetch);
+
+    const data = {
+      async *[Symbol.asyncIterator]() {
+        yield new TextEncoder().encode("Post body");
+      },
+    };
+
+    await expect(
+      uploadToS3({
+        signer: {
+          sign: async (request: unknown) => request,
+        } as unknown as SignatureV4,
+        name: "post.md",
+        type: "text/markdown",
+        data,
+        maxSize: 1024,
+        endpoint: "https://storage.example",
+        bucket: "assets",
+        assetInfoFallback: undefined,
+      })
+    ).rejects.toThrow("Cannot upload file post.md");
+    expect(await leftoverTempFiles()).toEqual([]);
+  });
+});
+
+const createBodyCollectingServer = async () => {
+  const received: { contentLength: string | undefined; chunks: Buffer[] } = {
+    contentLength: undefined,
+    chunks: [],
+  };
+  const server: Server = createServer((request, response) => {
+    received.contentLength = request.headers["content-length"];
+    request.on("data", (chunk: Buffer) => received.chunks.push(chunk));
+    request.on("end", () => {
+      response.writeHead(200);
+      response.end("ok");
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    server.close();
+    throw new Error("Test server did not bind a TCP port");
+  }
+  return {
+    endpoint: `http://127.0.0.1:${address.port}`,
+    received,
+    close: () =>
+      new Promise<void>((resolve) => {
+        server.closeAllConnections();
+        server.close(() => resolve());
+      }),
+  };
+};
+
+describe("uploadToS3 against a real server", () => {
+  test("streams the body over the real fetch with duplex: half", async () => {
+    const { endpoint, received, close } = await createBodyCollectingServer();
+    try {
+      const result = await uploadToS3({
+        signer: {
+          sign: async (request: unknown) => request,
+        } as unknown as SignatureV4,
+        name: "folder/post.md",
+        type: "text/markdown",
+        data: {
+          async *[Symbol.asyncIterator]() {
+            yield new TextEncoder().encode("Post body");
+          },
+        },
+        maxSize: 1024,
+        endpoint,
+        bucket: "assets",
+        assetInfoFallback: undefined,
+      });
+
+      expect(result).toEqual({ size: 9, format: "md", meta: {} });
+      expect(received.contentLength).toBe("9");
+      expect(Buffer.concat(received.chunks)).toEqual(Buffer.from("Post body"));
+      expect(await leftoverTempFiles()).toEqual([]);
+    } finally {
+      await close();
+    }
+  });
+});

--- a/packages/asset-uploader/src/clients/s3/upload.ts
+++ b/packages/asset-uploader/src/clients/s3/upload.ts
@@ -1,4 +1,8 @@
-import { arrayBuffer } from "node:stream/consumers";
+import { randomUUID } from "node:crypto";
+import { createReadStream } from "node:fs";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { SignatureV4 } from "@smithy/signature-v4";
 import {
   applyAssetDataOverride,
@@ -7,10 +11,14 @@ import {
   getAssetData,
 } from "../../utils/get-asset-data";
 import { createSizeLimiter } from "../../utils/size-limiter";
+import { spoolToFile } from "../../utils/spool-to-file";
 import { getMimeTypeByFilename } from "@webstudio-is/sdk";
 import { createS3ObjectUrl } from "./object-url";
 import { createS3FetchHeaders, signS3Request } from "./request-headers";
 import type { AssetInfoFallback } from "../../client";
+
+const getAssetDataType = (type: string) =>
+  type.startsWith("image") ? "image" : type === "font" ? "font" : "file";
 
 export const uploadToS3 = async ({
   signer,
@@ -37,70 +45,101 @@ export const uploadToS3 = async ({
 }): Promise<AssetData> => {
   const limitSize = createSizeLimiter(maxSize, name);
 
-  // @todo this is going to put the entire file in memory
-  // this has to be a stream that goes directly to s3
-  // Size check has to happen as you stream and interrupted when size is too big
-  // Also check if S3 client has an option to check the size limit
-  const data = await arrayBuffer(limitSize(dataStream));
+  // The incoming stream has an unknown length while S3 requires either a
+  // known Content-Length or AWS SigV4 streaming-chunked encoding (which still
+  // needs the decoded content length up front). Spool the stream to a temp
+  // file first so the size is known and the PUT body can be streamed from
+  // disk instead of buffering the whole file in memory. The size check runs
+  // while spooling and aborts as soon as the limit is exceeded.
+  //
+  // The temp file name is a random UUID, decoupled from the object key: the
+  // key is user-influenced (slashes, encoding, up to 1024 bytes) and must not
+  // be treated as a filesystem path.
+  const tempDirectory = await mkdtemp(join(tmpdir(), "webstudio-asset-"));
+  const tempPath = join(tempDirectory, randomUUID());
 
-  const url = createS3ObjectUrl({
-    endpoint,
-    bucket,
-    key: name,
-  });
+  try {
+    const size = await spoolToFile(limitSize(dataStream), tempPath);
 
-  // Use proper MIME type based on file extension instead of generic type category
-  const contentType = getMimeTypeByFilename(name);
+    const url = createS3ObjectUrl({
+      endpoint,
+      bucket,
+      key: name,
+    });
 
-  const assetData = applyAssetDataOverride(
-    type.startsWith("video") && assetInfoFallback !== undefined
-      ? {
-          size: data.byteLength,
-          format: assetInfoFallback.format,
-          meta: {
-            width: assetInfoFallback.width,
-            height: assetInfoFallback.height,
-          },
-        }
-      : await getAssetData({
-          type: type.startsWith("image")
-            ? "image"
-            : type === "font"
-              ? "font"
-              : "file",
-          size: data.byteLength,
-          data: new Uint8Array(data),
-          name,
-        }),
-    assetDataOverride
-  );
+    // Use proper MIME type based on file extension instead of generic type category
+    const contentType = getMimeTypeByFilename(name);
 
-  const s3Request = await signS3Request({
-    signer,
-    url,
-    method: "PUT",
-    headers: {
-      "Content-Type": contentType,
-      "Content-Length": `${data.byteLength}`,
-      "Cache-Control": "public, max-age=31536004,immutable",
-      "x-amz-content-sha256": "UNSIGNED-PAYLOAD",
-      // encodeURIComponent is needed to support special characters like Cyrillic
-      "x-amz-meta-filename": encodeURIComponent(name),
-      // when no ACL passed we do not default since some providers do not support it
-      ...(acl ? { "x-amz-acl": acl } : {}),
-    },
-    body: data,
-  });
+    const assetType = getAssetDataType(type);
 
-  const response = await fetch(url, {
-    method: s3Request.method,
-    headers: createS3FetchHeaders(s3Request.headers),
-    body: data,
-  });
+    const assetData = applyAssetDataOverride(
+      type.startsWith("video") && assetInfoFallback !== undefined
+        ? {
+            size,
+            format: assetInfoFallback.format,
+            meta: {
+              width: assetInfoFallback.width,
+              height: assetInfoFallback.height,
+            },
+          }
+        : await getAssetData({
+            type: assetType,
+            size,
+            data:
+              assetType === "image" || assetType === "font"
+                ? await readFile(tempPath)
+                : new Uint8Array(),
+            name,
+          }),
+      assetDataOverride
+    );
 
-  if (response.status !== 200) {
-    throw Error(`Cannot upload file ${name}`);
+    // x-amz-content-sha256: UNSIGNED-PAYLOAD makes @smithy/signature-v4 skip
+    // hashing the body (getPayloadHash returns the header value), so no body
+    // is passed to the signer. Passing a stream here would leak its file
+    // descriptor, because the signer never consumes or destroys it.
+    const s3Request = await signS3Request({
+      signer,
+      url,
+      method: "PUT",
+      headers: {
+        "Content-Type": contentType,
+        "Content-Length": `${size}`,
+        "Cache-Control": "public, max-age=31536004,immutable",
+        "x-amz-content-sha256": "UNSIGNED-PAYLOAD",
+        // encodeURIComponent is needed to support special characters like Cyrillic
+        "x-amz-meta-filename": encodeURIComponent(name),
+        // when no ACL passed we do not default since some providers do not support it
+        ...(acl ? { "x-amz-acl": acl } : {}),
+      },
+    });
+
+    // Image and font metadata is derived from the full file, so it is read
+    // into memory transiently and released before the PUT below. Reading only
+    // the header would be unsafe: image-meta rejects truncated buffers for
+    // formats whose dimensions live past the leading bytes (e.g. AVIF/TIFF).
+    // The S3 transfer itself streams from disk, which bounds memory for the
+    // large-file cases (videos, files).
+    //
+    // duplex: "half" is required by undici when the body is a stream; without
+    // it the PUT fails at runtime with "duplex option is required".
+    const response = await fetch(url, {
+      method: s3Request.method,
+      headers: createS3FetchHeaders(s3Request.headers),
+      body: createReadStream(tempPath) as unknown as BodyInit,
+      duplex: "half",
+    } as RequestInit);
+
+    if (response.status !== 200) {
+      throw Error(`Cannot upload file ${name}`);
+    }
+
+    return assetData;
+  } finally {
+    try {
+      await rm(tempDirectory, { recursive: true, force: true });
+    } catch {
+      // ignore cleanup failure
+    }
   }
-
-  return assetData;
 };

--- a/packages/asset-uploader/src/utils/spool-to-file.ts
+++ b/packages/asset-uploader/src/utils/spool-to-file.ts
@@ -1,0 +1,22 @@
+import { mkdir, open } from "node:fs/promises";
+import { dirname } from "node:path";
+
+export const spoolToFile = async (
+  data: AsyncIterable<Uint8Array>,
+  filepath: string
+): Promise<number> => {
+  await mkdir(dirname(filepath), { recursive: true });
+  const fileHandle = await open(filepath, "w");
+  try {
+    let size = 0;
+    for await (const chunk of data) {
+      size += chunk.byteLength;
+      // One write syscall per chunk; coalescing many tiny chunks would speed
+      // this up, but incoming upload chunks are already reasonably sized.
+      await fileHandle.write(chunk);
+    }
+    return size;
+  } finally {
+    await fileHandle.close();
+  }
+};


### PR DESCRIPTION
## Problem:
 uploadToS3 read the entire file into memory before PUTting it to S3 — a spike for large uploads (notably videos), flagged in an existing todo.

## Why not naive streaming:
 S3 rejects plain Transfer-Encoding: chunked and its streaming-chunked mode requires the total size up front; our incoming streams have unknown length. Multipart and @aws-sdk/lib-storage were rejected — multipart buffers sub-5MB uploads (the whole default case) and adds 3+ signed calls, while lib-storage buffers parts in memory and breaks the package's minimal hand-rolled signer design.

## Approach:
 Spool the stream to a temp file (bounded memory, size limit aborts mid-stream, key-independent random filename), then PUT via fs.createReadStream with a known Content-Length and duplex: "half". Temp dir cleaned up in finally.

## Also fixed:
 dropped the dead body arg from signS3Request (the UNSIGNED-PAYLOAD header short-circuits hashing; passing a stream there leaked an fd per upload).

## Tests:
 unit tests (size/Content-Length, oversize abort, signer gets no body, cleanup) plus a real node:http integration test exercising the actual undici fetch + stream path.