### PR TITLE
fix: Allow removal of invalid audited selectors

### DIFF
--- a/apps/builder/app/builder/features/style-panel/shared/use-style-data.test.ts
+++ b/apps/builder/app/builder/features/style-panel/shared/use-style-data.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "vitest";
 import { registerContainers, serverSyncStore } from "~/shared/sync/sync-stores";
 import {
   $selectedBreakpointId,
+  $selectedStyleState,
   $selectedStyleSources,
 } from "~/shared/nano-states";
 import { createDefaultPages } from "@webstudio-is/project-build";
@@ -50,6 +51,7 @@ const setupBaseStores = () => {
   selectInstance(["body"]);
   $breakpoints.set(new Map([["base", { id: "base", label: "Base" }]]));
   $selectedBreakpointId.set("base");
+  $selectedStyleState.set(undefined);
   $styles.set(new Map());
 };
 
@@ -74,6 +76,15 @@ const setupSelection = (styleSource: {
   );
   $selectedStyleSources.set(new Map([["body", styleSource.id]]));
 };
+
+const invalidState = "::-webkit-search-cancel-button";
+const createInvalidStyleDecl = (styleSourceId: string): StyleDecl => ({
+  breakpointId: "base",
+  styleSourceId,
+  property: "color",
+  state: invalidState,
+  value: { type: "keyword", value: "red" },
+});
 
 describe("use-style-data", () => {
   test("does not write styles for locked tokens", () => {
@@ -129,6 +140,35 @@ describe("use-style-data", () => {
         state: undefined,
       },
     ]);
+  });
+
+  test("deletes an existing token declaration with an invalid state", () => {
+    setupSelection({ id: "token1", type: "token", name: "Primary" });
+    const styleDecl = createInvalidStyleDecl("token1");
+    $styles.set(new Map([[getStyleDeclKey(styleDecl), styleDecl]]));
+    $selectedStyleState.set(invalidState);
+
+    deleteProperty("color");
+
+    expect($styles.get().size).toBe(0);
+  });
+
+  test("deletes an existing local declaration with an invalid state", () => {
+    setupBaseStores();
+    const styleDecl = createInvalidStyleDecl("local1");
+    $styleSources.set(
+      new Map([["local1", { id: "local1", type: "local" as const }]])
+    );
+    $styleSourceSelections.set(
+      new Map([["body", { instanceId: "body", values: ["local1"] }]])
+    );
+    $selectedStyleSources.set(new Map());
+    $styles.set(new Map([[getStyleDeclKey(styleDecl), styleDecl]]));
+    $selectedStyleState.set(invalidState);
+
+    deleteProperty("color");
+
+    expect($styles.get().size).toBe(0);
   });
 
   test("writes styles for implicit local source through runtime generated ids", () => {

--- a/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
+++ b/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
@@ -62024,6 +62024,9 @@ export const runtimeOperationContractData = [
               },
               state: {
                 type: "string",
+                minLength: 1,
+                description:
+                  "Exact state selector to delete. An invalid selector is accepted only when it identifies an existing declaration with the same style source, breakpoint, property, and state.",
               },
             },
             required: ["instanceId", "property"],
@@ -62162,6 +62165,9 @@ export const runtimeOperationContractData = [
               },
               state: {
                 type: "string",
+                minLength: 1,
+                description:
+                  "Exact state selector to delete. An invalid selector is accepted only when it identifies an existing declaration with the same style source, breakpoint, property, and state.",
               },
               styleSourceId: {
                 type: "string",
@@ -62988,7 +62994,7 @@ export const runtimeOperationContractData = [
                 type: "string",
                 minLength: 1,
                 description:
-                  "Exact state selector to delete. Use the selector reported by the style audit; an invalid selector is accepted only when it identifies an existing declaration with the same token, breakpoint, property, and state.",
+                  "Exact state selector to delete. An invalid selector is accepted only when it identifies an existing declaration with the same style source, breakpoint, property, and state.",
               },
             },
             required: ["property"],

--- a/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
+++ b/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
@@ -62986,6 +62986,9 @@ export const runtimeOperationContractData = [
               },
               state: {
                 type: "string",
+                minLength: 1,
+                description:
+                  "Exact state selector to delete. Use the selector reported by the style audit; an invalid selector is accepted only when it identifies an existing declaration with the same token, breakpoint, property, and state.",
               },
             },
             required: ["property"],

--- a/packages/project-build/src/runtime/audit.test.ts
+++ b/packages/project-build/src/runtime/audit.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, test } from "vitest";
 import {
+  getStyleDeclKey,
   type Instance,
   type Page,
   type Prop,
   type StyleDecl,
 } from "@webstudio-is/sdk";
+import type { BuilderRuntimeMutation } from "./mutation";
 import { executeBuilderRuntimeOperation } from "./registry";
 import { setImageDescriptions } from "./assets";
 import { analyzeProject, searchProject } from "./search";
@@ -2756,6 +2758,88 @@ describe("project audit and analysis", () => {
           }),
         }),
       ])
+    );
+  });
+
+  test("deletes an invalid design token selector reported by the style audit", () => {
+    const invalidState = "::-webkit-search-cancel-button";
+    const declaration: StyleDecl = {
+      styleSourceId: "token",
+      breakpointId: "base",
+      property: "color",
+      state: invalidState,
+      value: { type: "keyword", value: "red" },
+    };
+    const styles = new Map<string, StyleDecl>(state.styles);
+    styles.set(getStyleDeclKey(declaration), declaration);
+    const project = {
+      ...state,
+      styles,
+    } satisfies BuilderState;
+    const before = audit(
+      project,
+      { scopes: ["styles"], verbose: true },
+      { projectVersion: 1 }
+    );
+    const finding = before.findings.find(
+      ({ ruleId }) => ruleId === "invalid-style-state-selector"
+    );
+    expect(finding?.location).toMatchObject({
+      styleSourceId: "token",
+      breakpointId: "base",
+      stateSelector: invalidState,
+      styleProperty: "color",
+    });
+
+    const mutation = executeBuilderRuntimeOperation({
+      id: "designTokens.deleteStyles",
+      state: project,
+      input: {
+        designTokenId: "token",
+        deletions: [
+          {
+            breakpoint: "base",
+            property: "color",
+            state: invalidState,
+          },
+        ],
+      },
+      context,
+    }) as BuilderRuntimeMutation;
+    const { state: updatedProject } = applyBuilderPatchTransactions(project, [
+      { id: "delete-invalid-selector", payload: mutation.payload },
+    ]);
+
+    expect(
+      audit(
+        updatedProject,
+        { scopes: ["styles"], verbose: true },
+        { projectVersion: 2 }
+      ).findings
+    ).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ ruleId: "invalid-style-state-selector" }),
+      ])
+    );
+
+    expect(() =>
+      executeBuilderRuntimeOperation({
+        id: "designTokens.deleteStyles",
+        state: updatedProject,
+        input: {
+          designTokenId: "token",
+          deletions: [
+            {
+              breakpoint: "base",
+              property: "color",
+              state: ":not-a-real-selector",
+            },
+          ],
+        },
+        context,
+      })
+    ).toThrow(
+      "An invalid state selector can only delete an existing declaration"
     );
   });
 

--- a/packages/project-build/src/runtime/styles.test.ts
+++ b/packages/project-build/src/runtime/styles.test.ts
@@ -1068,20 +1068,13 @@ const instance = (id: string): Instance => ({
 
 describe("runtime style operations", () => {
   test.each([":hover, body", ":hover > div", "body:hover"])(
-    "rejects state selectors that escape the styled element: %s",
+    "rejects state selectors that escape the styled element when writing: %s",
     (state) => {
       expect(
         styleUpdateInput.safeParse({
           instanceId: "box",
           property: "color",
           value: { type: "keyword", value: "red" },
-          state,
-        })
-      ).toMatchObject({ success: false });
-      expect(
-        styleDeleteInput.safeParse({
-          instanceId: "box",
-          property: "color",
           state,
         })
       ).toMatchObject({ success: false });
@@ -1099,6 +1092,16 @@ describe("runtime style operations", () => {
       ).toMatchObject({ success: false });
     }
   );
+
+  test("accepts an invalid state as an existing declaration deletion coordinate", () => {
+    expect(
+      styleDeleteInput.safeParse({
+        instanceId: "box",
+        property: "color",
+        state: "::-webkit-search-cancel-button",
+      })
+    ).toMatchObject({ success: true });
+  });
 
   test("preserves an editable compound state through mutation and generated CSS", () => {
     const state = ":hover:focus-visible";

--- a/packages/project-build/src/runtime/styles.ts
+++ b/packages/project-build/src/runtime/styles.ts
@@ -2776,6 +2776,20 @@ export const createDesignTokenStyleUpdatePayload = ({
   };
 };
 
+const getDesignTokenStyleDeletionKey = ({
+  designTokenId,
+  deletion,
+}: {
+  designTokenId: StyleSource["id"];
+  deletion: z.infer<typeof designTokenStyleDeletionInput>;
+}) =>
+  getStyleDeclKeyFromInput({
+    styleSourceId: designTokenId,
+    breakpoint: deletion.breakpoint,
+    state: deletion.state,
+    property: deletion.property,
+  });
+
 export const createDesignTokenStyleDeletePayload = ({
   designTokenId,
   deletions,
@@ -2789,12 +2803,7 @@ export const createDesignTokenStyleDeletePayload = ({
     Array.from(styles, (styleDecl) => getStyleDeclKey(styleDecl))
   );
   const styleKeys = deletions.flatMap((deletion) => {
-    const key = getStyleDeclKeyFromInput({
-      styleSourceId: designTokenId,
-      breakpoint: deletion.breakpoint,
-      state: deletion.state,
-      property: deletion.property,
-    });
+    const key = getDesignTokenStyleDeletionKey({ designTokenId, deletion });
     return existingStyleKeys.has(key) ? [key] : [];
   });
 
@@ -3837,19 +3846,20 @@ export const deleteDesignTokenStyles = (
   const deletions = input.deletions.map((deletion) =>
     withValidatedBreakpoint(deletion, state.breakpoints)
   );
-  const existingStyleKeys = new Set(
-    Array.from(styleState.styles.values(), getStyleDeclKey)
-  );
+  const { payload, styleKeys } = createDesignTokenStyleDeletePayload({
+    designTokenId: input.designTokenId,
+    deletions,
+    styles: styleState.styles.values(),
+  });
+  const matchedStyleKeys = new Set(styleKeys);
   for (const deletion of deletions) {
     if (
       deletion.state !== undefined &&
       validateSelector(deletion.state).success === false &&
-      existingStyleKeys.has(
-        getStyleDeclKeyFromInput({
-          styleSourceId: input.designTokenId,
-          breakpoint: deletion.breakpoint,
-          property: deletion.property,
-          state: deletion.state,
+      matchedStyleKeys.has(
+        getDesignTokenStyleDeletionKey({
+          designTokenId: input.designTokenId,
+          deletion,
         })
       ) === false
     ) {
@@ -3859,11 +3869,6 @@ export const deleteDesignTokenStyles = (
       );
     }
   }
-  const { payload, styleKeys } = createDesignTokenStyleDeletePayload({
-    designTokenId: input.designTokenId,
-    deletions,
-    styles: styleState.styles.values(),
-  });
   return createRuntimeMutation({
     payload,
     result: { designTokenId: input.designTokenId, styleKeys },

--- a/packages/project-build/src/runtime/styles.ts
+++ b/packages/project-build/src/runtime/styles.ts
@@ -1250,9 +1250,20 @@ export const designTokenStyleUpdatesInput = z.object({
   updates: jsonArrayInput(designTokenStyleInput),
 });
 
+const existingStyleStateDeletionInput = z
+  .string()
+  .min(1)
+  .describe(
+    "Exact state selector to delete. Use the selector reported by the style audit; an invalid selector is accepted only when it identifies an existing declaration with the same token, breakpoint, property, and state."
+  );
+
+export const designTokenStyleDeletionInput = styleDeleteInput
+  .omit({ instanceId: true })
+  .extend({ state: existingStyleStateDeletionInput.optional() });
+
 export const designTokenStyleDeletionsInput = z.object({
   designTokenId: z.string(),
-  deletions: jsonArrayInput(styleDeleteInput.omit({ instanceId: true })),
+  deletions: jsonArrayInput(designTokenStyleDeletionInput),
 });
 
 export const designTokenAttachInput = z.object({
@@ -2771,7 +2782,7 @@ export const createDesignTokenStyleDeletePayload = ({
   styles,
 }: {
   designTokenId: StyleSource["id"];
-  deletions: Array<Omit<z.infer<typeof styleDeleteInput>, "instanceId">>;
+  deletions: Array<z.infer<typeof designTokenStyleDeletionInput>>;
   styles: Iterable<StyleDecl>;
 }) => {
   const existingStyleKeys = new Set(
@@ -3823,11 +3834,34 @@ export const deleteDesignTokenStyles = (
 ) => {
   const styleState = getRequiredStyleState(state);
   getDesignTokenOrThrow(styleState.styleSources.values(), input.designTokenId);
+  const deletions = input.deletions.map((deletion) =>
+    withValidatedBreakpoint(deletion, state.breakpoints)
+  );
+  const existingStyleKeys = new Set(
+    Array.from(styleState.styles.values(), getStyleDeclKey)
+  );
+  for (const deletion of deletions) {
+    if (
+      deletion.state !== undefined &&
+      validateSelector(deletion.state).success === false &&
+      existingStyleKeys.has(
+        getStyleDeclKeyFromInput({
+          styleSourceId: input.designTokenId,
+          breakpoint: deletion.breakpoint,
+          property: deletion.property,
+          state: deletion.state,
+        })
+      ) === false
+    ) {
+      return throwBuilderRuntimeError(
+        "BAD_REQUEST",
+        "An invalid state selector can only delete an existing declaration. Use the exact state selector, breakpoint, and property reported by the style audit."
+      );
+    }
+  }
   const { payload, styleKeys } = createDesignTokenStyleDeletePayload({
     designTokenId: input.designTokenId,
-    deletions: input.deletions.map((deletion) =>
-      withValidatedBreakpoint(deletion, state.breakpoints)
-    ),
+    deletions,
     styles: styleState.styles.values(),
   });
   return createRuntimeMutation({

--- a/packages/project-build/src/runtime/styles.ts
+++ b/packages/project-build/src/runtime/styles.ts
@@ -301,6 +301,13 @@ const styleStateInput = z.string().superRefine((state, context) => {
   }
 });
 
+const existingStyleStateDeletionInput = z
+  .string()
+  .min(1)
+  .describe(
+    "Exact state selector to delete. An invalid selector is accepted only when it identifies an existing declaration with the same style source, breakpoint, property, and state."
+  );
+
 const styleValueExample = { type: "keyword", value: "red" } as const;
 const typedStyleValueInput = z
   .object({ type: z.string() })
@@ -337,7 +344,7 @@ export const styleDeleteInput = z.object({
   instanceId: z.string(),
   property: z.string(),
   breakpoint: z.string().optional(),
-  state: styleStateInput.optional(),
+  state: existingStyleStateDeletionInput.optional(),
 });
 
 const jsonArrayStringInput = (value: unknown) => {
@@ -1250,20 +1257,9 @@ export const designTokenStyleUpdatesInput = z.object({
   updates: jsonArrayInput(designTokenStyleInput),
 });
 
-const existingStyleStateDeletionInput = z
-  .string()
-  .min(1)
-  .describe(
-    "Exact state selector to delete. Use the selector reported by the style audit; an invalid selector is accepted only when it identifies an existing declaration with the same token, breakpoint, property, and state."
-  );
-
-export const designTokenStyleDeletionInput = styleDeleteInput
-  .omit({ instanceId: true })
-  .extend({ state: existingStyleStateDeletionInput.optional() });
-
 export const designTokenStyleDeletionsInput = z.object({
   designTokenId: z.string(),
-  deletions: jsonArrayInput(designTokenStyleDeletionInput),
+  deletions: jsonArrayInput(styleDeleteInput.omit({ instanceId: true })),
 });
 
 export const designTokenAttachInput = z.object({
@@ -1962,6 +1958,44 @@ export const getStyleDeclKeyFromInput = ({
     state,
     property: normalizeStyleProperty(property),
   });
+
+const getExistingStyleDeletionKeys = <
+  Deletion extends { state?: StyleDecl["state"] },
+>({
+  deletions,
+  styles,
+  getStyleKey,
+}: {
+  deletions: readonly Deletion[];
+  styles: Iterable<StyleDecl>;
+  getStyleKey: (deletion: Deletion) => string | undefined;
+}) => {
+  const existingStyleKeys = new Set(
+    Array.from(styles, (styleDecl) => getStyleDeclKey(styleDecl))
+  );
+  const matchedStyleKeys = new Set<string>();
+
+  for (const deletion of deletions) {
+    const styleKey = getStyleKey(deletion);
+    const exists =
+      styleKey !== undefined && existingStyleKeys.has(styleKey) === true;
+    if (
+      deletion.state !== undefined &&
+      validateSelector(deletion.state).success === false &&
+      exists === false
+    ) {
+      return throwBuilderRuntimeError(
+        "BAD_REQUEST",
+        "An invalid state selector can only delete an existing declaration. Use the exact target, state selector, breakpoint, and property reported by the style audit."
+      );
+    }
+    if (exists) {
+      matchedStyleKeys.add(styleKey);
+    }
+  }
+
+  return Array.from(matchedStyleKeys);
+};
 
 export const updateStyleDecl = (
   declaration: StyleDecl,
@@ -2776,35 +2810,25 @@ export const createDesignTokenStyleUpdatePayload = ({
   };
 };
 
-const getDesignTokenStyleDeletionKey = ({
-  designTokenId,
-  deletion,
-}: {
-  designTokenId: StyleSource["id"];
-  deletion: z.infer<typeof designTokenStyleDeletionInput>;
-}) =>
-  getStyleDeclKeyFromInput({
-    styleSourceId: designTokenId,
-    breakpoint: deletion.breakpoint,
-    state: deletion.state,
-    property: deletion.property,
-  });
-
 export const createDesignTokenStyleDeletePayload = ({
   designTokenId,
   deletions,
   styles,
 }: {
   designTokenId: StyleSource["id"];
-  deletions: Array<z.infer<typeof designTokenStyleDeletionInput>>;
+  deletions: Array<Omit<z.infer<typeof styleDeleteInput>, "instanceId">>;
   styles: Iterable<StyleDecl>;
 }) => {
-  const existingStyleKeys = new Set(
-    Array.from(styles, (styleDecl) => getStyleDeclKey(styleDecl))
-  );
-  const styleKeys = deletions.flatMap((deletion) => {
-    const key = getDesignTokenStyleDeletionKey({ designTokenId, deletion });
-    return existingStyleKeys.has(key) ? [key] : [];
+  const styleKeys = getExistingStyleDeletionKeys({
+    deletions,
+    styles,
+    getStyleKey: (deletion) =>
+      getStyleDeclKeyFromInput({
+        styleSourceId: designTokenId,
+        breakpoint: deletion.breakpoint,
+        state: deletion.state,
+        property: deletion.property,
+      }),
   });
 
   return {
@@ -3015,41 +3039,35 @@ export const createStyleDeclarationDeletePayload = ({
   styleSourceSelections: Iterable<StyleSourceSelection>;
   styles: Iterable<StyleDecl>;
 }) => {
-  const styleKeys = new Set<string>();
   const styleSourceSelectionByInstanceId = new Map(
     Array.from(styleSourceSelections, (selection) => [
       selection.instanceId,
       selection,
     ])
   );
-  const existingStyleKeys = new Set(
-    Array.from(styles, (styleDecl) => getStyleDeclKey(styleDecl))
-  );
-
-  for (const deletion of deletions) {
-    const styleSourceId = getLocalStyleSourceIdWithCreated({
-      createdLocalSourceIds: new Map(),
-      instanceId: deletion.instanceId,
-      styleSources,
-      styleSourceSelection: styleSourceSelectionByInstanceId.get(
-        deletion.instanceId
-      ),
-    });
-    if (styleSourceId === undefined) {
-      continue;
-    }
-    const key = getStyleDeclKeyFromInput({
-      styleSourceId,
-      breakpoint: deletion.breakpoint,
-      state: deletion.state,
-      property: deletion.property,
-    });
-    if (existingStyleKeys.has(key)) {
-      styleKeys.add(key);
-    }
-  }
-
-  const removedStyleKeys = Array.from(styleKeys);
+  const removedStyleKeys = getExistingStyleDeletionKeys({
+    deletions,
+    styles,
+    getStyleKey: (deletion) => {
+      const styleSourceId = getLocalStyleSourceIdWithCreated({
+        createdLocalSourceIds: new Map(),
+        instanceId: deletion.instanceId,
+        styleSources,
+        styleSourceSelection: styleSourceSelectionByInstanceId.get(
+          deletion.instanceId
+        ),
+      });
+      if (styleSourceId === undefined) {
+        return;
+      }
+      return getStyleDeclKeyFromInput({
+        styleSourceId,
+        breakpoint: deletion.breakpoint,
+        state: deletion.state,
+        property: deletion.property,
+      });
+    },
+  });
   return {
     payload: createStyleRemovePayload(removedStyleKeys),
     styleKeys: removedStyleKeys,
@@ -3187,17 +3205,16 @@ export const createSelectedStyleDeclarationDeletePayload = ({
   >;
   styles: Iterable<StyleDecl>;
 }) => {
-  const existingStyleKeys = new Set(
-    Array.from(styles, (styleDecl) => getStyleDeclKey(styleDecl))
-  );
-  const styleKeys = deletions.flatMap((deletion) => {
-    const styleKey = getStyleDeclKeyFromInput({
-      styleSourceId: deletion.styleSourceId,
-      breakpoint: deletion.breakpoint,
-      state: deletion.state,
-      property: deletion.property,
-    });
-    return existingStyleKeys.has(styleKey) ? [styleKey] : [];
+  const styleKeys = getExistingStyleDeletionKeys({
+    deletions,
+    styles,
+    getStyleKey: (deletion) =>
+      getStyleDeclKeyFromInput({
+        styleSourceId: deletion.styleSourceId,
+        breakpoint: deletion.breakpoint,
+        state: deletion.state,
+        property: deletion.property,
+      }),
   });
   return {
     payload: createStyleRemovePayload(styleKeys),
@@ -3851,24 +3868,6 @@ export const deleteDesignTokenStyles = (
     deletions,
     styles: styleState.styles.values(),
   });
-  const matchedStyleKeys = new Set(styleKeys);
-  for (const deletion of deletions) {
-    if (
-      deletion.state !== undefined &&
-      validateSelector(deletion.state).success === false &&
-      matchedStyleKeys.has(
-        getDesignTokenStyleDeletionKey({
-          designTokenId: input.designTokenId,
-          deletion,
-        })
-      ) === false
-    ) {
-      return throwBuilderRuntimeError(
-        "BAD_REQUEST",
-        "An invalid state selector can only delete an existing declaration. Use the exact state selector, breakpoint, and property reported by the style audit."
-      );
-    }
-  }
   return createRuntimeMutation({
     payload,
     result: { designTokenId: input.designTokenId, styleKeys },


### PR DESCRIPTION
## Summary

Allow all targeted style-deletion paths to remove an invalid state selector that already exists, including Builder UI deletion of local and token declarations and CLI/MCP design-token remediation. Creation and update validation remain strict.

## Root cause

The style audit reads legacy declarations directly and can report selectors that the current selector validator rejects. Deletion reused the creation/update validator, so the system could identify an invalid stored declaration but could not represent its coordinates for targeted removal. The first fix addressed only design-token deletion, leaving Builder UI and the generic style APIs inconsistent.

## Implementation

- [x] Give style deletions a shared deletion-only state-selector contract.
- [x] Accept an invalid selector only when the exact target, breakpoint, property, and state already exist.
- [x] Reject arbitrary invalid selectors that do not identify an existing declaration.
- [x] Reuse one matcher for local, selected/token, and design-token deletions.
- [x] Keep creation and update selector validation strict.
- [x] Add Builder UI regression coverage for token and local declaration deletion.
- [x] Add an audit regression that deletes the reported design-token selector, applies the patch, and confirms the warning is cleared.
- [x] Regenerate the public runtime operation contract.
- [x] Complete the DRY review: deletion matching, validation, key deduplication, and stored-style scanning are centralized.
- [x] Review documentation impact: no authored documentation changes are required; generated operation contracts describe the behavior.
- [x] Review fixture impact: no fixture inputs or generated fixture bundles are affected.
- [x] Run relevant tests, typechecks, lint, formatting, package-boundary, generated-API, and generated-documentation checks.
- [ ] Agent evaluations — not run because repository policy requires separate explicit approval.

## Verification

- The two Builder UI regression tests failed with `Operation input is invalid` before the shared fix and passed afterward.
- Project-build suite: 82 files, 2,097 tests passed.
- CLI suite: 60 files, 968 tests passed.
- Builder style-data target: 7 tests passed.
- Audit and styles targets: 195 tests passed.
- Project-build, Builder, and CLI typechecks passed.
- Full repository lint passed.
- Package-boundary, generated-API, and generated-documentation checks passed.
- Formatting and `git diff --check` passed.

Closes #6062
