### PR TITLE
fix: Complete interrupted preview workflows

### DIFF
--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -21,6 +21,7 @@ const {
   getLoadedProjectSessionSnapshot,
   getMcpOperationInput,
   reportMcpRunTermination,
+  createMcpRunTerminationController,
   parseMcpRunCalls,
   parseMcpRunInput,
   parseMcpSingleOpCallInput,
@@ -725,7 +726,7 @@ test("preserves completed calls when a run terminates during an asset query prev
   const writeResult = vi.fn();
   const setExitCode = vi.fn();
   reportMcpRunTermination({
-    exitCode: 0,
+    termination: { type: "beforeExit", exitCode: 0 },
     activeCall: { number: 4, tool: "preview-asset-query" },
     totalCalls: 4,
     results: completedResults,
@@ -754,6 +755,93 @@ test("preserves completed calls when a run terminates during an asset query prev
     },
   });
   expect(setExitCode).toHaveBeenCalledWith(1);
+});
+
+test("identifies a signal that terminates preview.start", () => {
+  const writeResult = vi.fn();
+  const setExitCode = vi.fn();
+  const options = {
+    termination: { type: "signal" as const, signal: "SIGTERM" as const },
+    activeCall: { number: 1, tool: "preview.start" },
+    totalCalls: 4,
+    results: [],
+    elapsedMs: 123,
+    writeStatus: vi.fn(),
+    writeResult,
+    setExitCode,
+  };
+
+  reportMcpRunTermination(options);
+
+  expect(writeResult).toHaveBeenCalledWith({
+    ok: false,
+    error: {
+      code: "MCP_RUN_TERMINATED",
+      message:
+        "MCP run terminated before call 1/4 preview.start returned a result.",
+    },
+    data: {
+      completedCalls: 0,
+      unfinishedCall: { number: 1, tool: "preview.start" },
+      totalCalls: 4,
+      results: [],
+    },
+    meta: {
+      elapsedMs: 123,
+      termination: { type: "signal", signal: "SIGTERM" },
+    },
+  });
+  expect(setExitCode).not.toHaveBeenCalled();
+});
+
+test("disposes the preview owner before completing signal termination", async () => {
+  const disposeHost = vi.fn(async () => undefined);
+  const reportTermination = vi.fn();
+  const exitWithSignal = vi.fn();
+  const controller = createMcpRunTerminationController({
+    getActiveCall: () => ({ number: 1, tool: "preview.start" }),
+    totalCalls: 4,
+    results: [],
+    startedAt: Date.now(),
+    disposeHost,
+    reportTermination,
+    exitWithSignal,
+  });
+
+  controller.signal("SIGTERM");
+  await vi.waitFor(() => expect(exitWithSignal).toHaveBeenCalledOnce());
+  controller.signal("SIGINT");
+
+  expect(reportTermination).toHaveBeenCalledWith(
+    expect.objectContaining({
+      termination: { type: "signal", signal: "SIGTERM" },
+      activeCall: { number: 1, tool: "preview.start" },
+      totalCalls: 4,
+      results: [],
+    })
+  );
+  expect(disposeHost).toHaveBeenCalledOnce();
+  expect(exitWithSignal).toHaveBeenCalledWith("SIGTERM");
+});
+
+test("completes signal termination when preview cleanup stalls", async () => {
+  const exitWithSignal = vi.fn();
+  const controller = createMcpRunTerminationController({
+    getActiveCall: () => ({ number: 1, tool: "preview.start" }),
+    totalCalls: 4,
+    results: [],
+    startedAt: Date.now(),
+    disposeHost: () => new Promise<never>(() => undefined),
+    reportTermination: vi.fn(),
+    cleanupTimeout: 1,
+    exitWithSignal,
+  });
+
+  controller.signal("SIGTERM");
+
+  await vi.waitFor(() =>
+    expect(exitWithSignal).toHaveBeenCalledWith("SIGTERM")
+  );
 });
 
 test("preserves already structured MCP run errors", () => {

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -61,6 +61,7 @@ import {
 import { readCliDoc } from "../docs";
 import { printJson } from "../json-output";
 import { isPlainRecord } from "../type-utils";
+import { withTimeout } from "../async-utils";
 import { LOCAL_DATA_FILE } from "../config";
 import {
   assertMcpBatchMutationApproved,
@@ -694,8 +695,14 @@ type ActiveMcpRunCall = {
   tool: string;
 };
 
+type McpRunTermination =
+  | { type: "beforeExit"; exitCode: number }
+  | { type: "signal"; signal: NodeJS.Signals };
+
+const mcpRunTerminationCleanupTimeout = 5000;
+
 const reportMcpRunTermination = ({
-  exitCode,
+  termination,
   activeCall,
   totalCalls,
   results,
@@ -706,7 +713,7 @@ const reportMcpRunTermination = ({
     process.exitCode = code;
   },
 }: {
-  exitCode: number;
+  termination: McpRunTermination;
   activeCall: ActiveMcpRunCall;
   totalCalls: number;
   results: unknown[];
@@ -736,10 +743,69 @@ const reportMcpRunTermination = ({
     data: { ...payload.data, unfinishedCall: activeCall },
     meta: {
       ...payload.meta,
-      termination: { type: "beforeExit", exitCode },
+      termination,
     },
   });
-  setExitCode(1);
+  if (termination.type === "beforeExit") {
+    setExitCode(1);
+  }
+};
+
+const createMcpRunTerminationController = ({
+  getActiveCall,
+  totalCalls,
+  results,
+  startedAt,
+  disposeHost,
+  reportTermination = reportMcpRunTermination,
+  cleanupTimeout = mcpRunTerminationCleanupTimeout,
+  exitWithSignal = (signal) => {
+    process.kill(process.pid, signal);
+  },
+}: {
+  getActiveCall: () => ActiveMcpRunCall | undefined;
+  totalCalls: number;
+  results: unknown[];
+  startedAt: number;
+  disposeHost: () => Promise<void>;
+  reportTermination?: typeof reportMcpRunTermination;
+  cleanupTimeout?: number;
+  exitWithSignal?: (signal: NodeJS.Signals) => void;
+}) => {
+  let isTerminating = false;
+  const beginTermination = (termination: McpRunTermination) => {
+    if (isTerminating) {
+      return;
+    }
+    const activeCall = getActiveCall();
+    if (activeCall === undefined && termination.type === "beforeExit") {
+      return;
+    }
+    isTerminating = true;
+    if (activeCall !== undefined) {
+      reportTermination({
+        termination,
+        activeCall,
+        totalCalls,
+        results,
+        elapsedMs: Date.now() - startedAt,
+      });
+    }
+    const cleanup = withTimeout(
+      Promise.resolve().then(disposeHost),
+      cleanupTimeout,
+      () => new Error("MCP run cleanup timed out.")
+    ).catch(() => undefined);
+    if (termination.type === "signal") {
+      void cleanup.finally(() => exitWithSignal(termination.signal));
+    }
+  };
+  return {
+    beforeExit: (exitCode: number) =>
+      beginTermination({ type: "beforeExit", exitCode }),
+    signal: (signal: NodeJS.Signals) =>
+      beginTermination({ type: "signal", signal }),
+  };
 };
 
 const installMcpRunTerminationHandlers = ({
@@ -747,29 +813,44 @@ const installMcpRunTerminationHandlers = ({
   totalCalls,
   results,
   startedAt,
+  disposeHost,
 }: {
   getActiveCall: () => ActiveMcpRunCall | undefined;
   totalCalls: number;
   results: unknown[];
   startedAt: number;
+  disposeHost: () => Promise<void>;
 }) => {
+  const controller = createMcpRunTerminationController({
+    getActiveCall,
+    totalCalls,
+    results,
+    startedAt,
+    disposeHost,
+  });
+  const terminationSignals = ["SIGHUP", "SIGINT", "SIGTERM"] as const;
+  const signalHandlers = new Map<NodeJS.Signals, () => void>();
   const beforeExit = (exitCode: number) => {
-    const activeCall = getActiveCall();
-    if (activeCall === undefined) {
-      return;
+    dispose();
+    controller.beforeExit(exitCode);
+  };
+  const dispose = () => {
+    process.off("beforeExit", beforeExit);
+    for (const [signal, handler] of signalHandlers) {
+      process.off(signal, handler);
     }
-    reportMcpRunTermination({
-      exitCode,
-      activeCall,
-      totalCalls,
-      results,
-      elapsedMs: Date.now() - startedAt,
-    });
+    signalHandlers.clear();
   };
   process.once("beforeExit", beforeExit);
-  return () => {
-    process.off("beforeExit", beforeExit);
-  };
+  for (const signal of terminationSignals) {
+    const handler = () => {
+      dispose();
+      controller.signal(signal);
+    };
+    signalHandlers.set(signal, handler);
+    process.once(signal, handler);
+  }
+  return dispose;
 };
 
 const reportMcpRunPreflightFailure = ({
@@ -835,9 +916,11 @@ const assertSingleOpCallToolSupported = (tool: string) => {
 const createCliMcpHost = async ({
   projectRoot = cwd(),
   projectId,
+  managePreviewProcessSignals = true,
 }: {
   projectRoot?: string;
   projectId?: string;
+  managePreviewProcessSignals?: boolean;
 } = {}) => {
   const connection = await resolveApiConnection(
     undefined,
@@ -869,7 +952,11 @@ const createCliMcpHost = async ({
     getCliProjectRestorePointsFile(projectRoot, projectId)
   );
   await prepareMcpProjectSession(session);
-  const preview = createPreviewController({ host: "127.0.0.1", port: 5173 });
+  const preview = createPreviewController(
+    { host: "127.0.0.1", port: 5173 },
+    undefined,
+    { manageProcessSignals: managePreviewProcessSignals }
+  );
   const previewFreshness = createPreviewFreshness();
   const previewHandlers = createMcpPreviewHandlers({
     preview,
@@ -1424,6 +1511,7 @@ export const mcpRun = async (options: McpRunOptions) => {
   try {
     const mcpHost = await createCliMcpHost({
       projectId: options.project,
+      managePreviewProcessSignals: false,
     });
     const { host, apiContract } = mcpHost;
     disposeHost = mcpHost.dispose;
@@ -1447,6 +1535,7 @@ export const mcpRun = async (options: McpRunOptions) => {
     totalCalls: calls.length,
     results,
     startedAt,
+    disposeHost: () => disposeHost(),
   });
   try {
     for (const [index, call] of calls.entries()) {
@@ -1665,6 +1754,7 @@ export const __testing__ = {
   }),
   createMcpRunErrorPayload,
   reportMcpRunTermination,
+  createMcpRunTerminationController,
   createMcpRunCheckpointStopPayload,
   getLoadedProjectSessionSnapshot,
   getMcpOperationInput,

--- a/packages/cli/src/preview-server.test.ts
+++ b/packages/cli/src/preview-server.test.ts
@@ -700,6 +700,33 @@ test("preview controller stops its process group before propagating termination"
   expect(controller.status().running).toBe(false);
 });
 
+test("lets an outer lifecycle owner manage process signals", async () => {
+  const process = createPreviewProcess();
+  const parentProcess = {
+    pid: 456,
+    once: vi.fn(),
+    off: vi.fn(),
+    kill: vi.fn(() => true),
+  };
+  const controller = createPreviewController(
+    {
+      host: "127.0.0.1",
+      port: 5173,
+      cwd: "/tmp/preview",
+      mode: "iterative",
+    },
+    createDependencies({
+      spawn: vi.fn(() => process) as never,
+      parentProcess,
+    }),
+    { manageProcessSignals: false }
+  );
+
+  await controller.start();
+
+  expect(parentProcess.once).not.toHaveBeenCalled();
+});
+
 test("preview controller reuses custom running options when start has no options", async () => {
   const process = createPreviewProcess();
   const buildProcess = createPreviewProcess();

--- a/packages/cli/src/preview-server.ts
+++ b/packages/cli/src/preview-server.ts
@@ -538,7 +538,8 @@ const formatPreviewServerStartupError = ({
 
 export const createPreviewController = (
   defaults: PreviewServerOptions,
-  dependencies = defaultPreviewServerDependencies
+  dependencies = defaultPreviewServerDependencies,
+  { manageProcessSignals = true }: { manageProcessSignals?: boolean } = {}
 ) => {
   let server: PreviewServerResult | undefined;
   let currentOptions = defaults;
@@ -554,7 +555,7 @@ export const createPreviewController = (
     terminationHandlers.clear();
   };
   const installTerminationHandlers = () => {
-    if (terminationHandlers.size > 0) {
+    if (manageProcessSignals === false || terminationHandlers.size > 0) {
       return;
     }
     for (const signal of terminationSignals) {


### PR DESCRIPTION
## Summary

`webstudio mcp run` now emits a terminal structured error when the process is interrupted while an MCP call such as `preview.start` is still active. It preserves completed call results, identifies the unfinished call and terminating signal, attempts preview cleanup, and then propagates the original signal.

The MCP runner owns process termination for this workflow so the preview controller cannot race it or propagate the same signal twice. Cleanup is bounded to five seconds so a stalled preview startup cannot prevent termination.

## Todo

- [x] Reproduce the missing terminal result for an interrupted `preview.start` call
- [x] Report the active call and original signal in structured output
- [x] Preserve completed results from the shared MCP session
- [x] Clean up preview resources before propagating the signal
- [x] Prevent competing MCP-run and preview-controller signal handlers
- [x] Add regression coverage and verify it fails before the fix and passes after it
- [x] Review for DRY violations and unnecessary abstractions
- [x] Review documentation impact; existing CLI documentation already describes the restored terminal JSON behavior
- [x] Review fixture impact; no fixture inputs or generated fixture bundles are affected
- [x] Run CLI tests, typecheck, lint, package-boundary checks, generated API checks, and generated docs checks
- [x] Verify CI; all checks pass or are intentionally skipped except the requested Lost Pixel exemption
- [ ] Run the complete local agent evaluation suite (requires explicit user approval)

## Verification

- `pnpm --filter webstudio test` — 60 files, 972 tests passed
- `pnpm --filter webstudio typecheck`
- `pnpm lint`
- `pnpm check:package-boundaries`
- `pnpm check:generated-api`
- `pnpm check:generated-docs`
- `pnpm exec oxfmt --check packages/cli/src/commands/mcp.ts packages/cli/src/commands/mcp.test.ts packages/cli/src/preview-server.ts packages/cli/src/preview-server.test.ts`
- `git diff --check`
- GitHub CI — all checks passed or skipped except Lost Pixel, which is explicitly excluded

Closes #6075
