### PR TITLE
feat: move authorization token role permissions to SQL

### DIFF
--- a/packages/authorization-token/src/db/authorization-token.test.ts
+++ b/packages/authorization-token/src/db/authorization-token.test.ts
@@ -14,79 +14,12 @@ import {
   create,
   update,
   remove,
-  __testing__,
 } from "./authorization-token";
 import { authorizationTokenRouter } from "../trpc/authorization-tokens-router";
 
-const { applyTokenPermissions } = __testing__;
-
 // ---------------------------------------------------------------------------
-// applyTokenPermissions — pure logic tests
-// Verifies the business rules that override stored DB values by relation.
+// getTokenProjectPermits — pure logic tests
 // ---------------------------------------------------------------------------
-
-const baseToken = {
-  token: "tok-1",
-  projectId: "proj-1",
-  name: "test",
-  createdAt: "2024-01-01T00:00:00.000Z",
-  canClone: false,
-  canCopy: false,
-  canPublish: true,
-  canUseApi: false,
-};
-
-describe("applyTokenPermissions", () => {
-  test("viewers: canPublish forced to false, canClone/canCopy unchanged", () => {
-    const result = applyTokenPermissions({ ...baseToken, relation: "viewers" });
-    expect(result.canPublish).toBe(false);
-    expect(result.canClone).toBe(false);
-    expect(result.canCopy).toBe(false);
-  });
-
-  test("editors: canClone forced to false, canCopy forced to true, canPublish unchanged", () => {
-    const result = applyTokenPermissions({
-      ...baseToken,
-      relation: "editors",
-      canClone: true,
-      canPublish: false,
-    });
-    expect(result.canClone).toBe(false);
-    expect(result.canCopy).toBe(true);
-    expect(result.canPublish).toBe(false);
-  });
-
-  test("builders: canClone/canCopy true, canPublish forced to false", () => {
-    const result = applyTokenPermissions({
-      ...baseToken,
-      relation: "builders",
-      canPublish: true,
-    });
-    expect(result.canClone).toBe(true);
-    expect(result.canCopy).toBe(true);
-    expect(result.canPublish).toBe(false);
-  });
-
-  test("administrators: canClone/canCopy true, canPublish forced to true", () => {
-    const result = applyTokenPermissions({
-      ...baseToken,
-      relation: "administrators",
-      canPublish: false,
-    });
-    expect(result.canClone).toBe(true);
-    expect(result.canCopy).toBe(true);
-    expect(result.canPublish).toBe(true);
-  });
-
-  test("preserves explicit API capability", () => {
-    const result = applyTokenPermissions({
-      ...baseToken,
-      relation: "viewers",
-      canUseApi: true,
-    });
-    expect(result.canUseApi).toBe(true);
-  });
-});
 
 describe("getTokenProjectPermits", () => {
   test("maps token relation to project permits", () => {
@@ -137,20 +70,20 @@ const tokenRow = {
   projectId: "proj-1",
   name: "My Token",
   relation: "builders",
-  canClone: false,
-  canCopy: false,
-  canPublish: true,
+  canClone: true,
+  canCopy: true,
+  canPublish: false,
   canUseApi: false,
   createdAt: "2024-01-01T00:00:00.000Z",
 };
 
 describe("getTokenInfo (msw)", () => {
   // getTokenInfo does not call hasProjectPermit — no Project handler needed.
-  test("returns token with permissions applied for builders relation", async () => {
+  test("returns the builders token with DB-normalized permissions", async () => {
     server.use(db.get("AuthorizationToken", () => json(tokenRow)));
 
     const result = await getTokenInfo("tok-abc", createContext());
-    // builders rule: canClone=true, canCopy=true, canPublish=false
+    // builders are normalized in SQL: canClone=true, canCopy=true, canPublish=false
     expect(result.canClone).toBe(true);
     expect(result.canCopy).toBe(true);
     expect(result.canPublish).toBe(false);
@@ -166,21 +99,21 @@ describe("getTokenInfo (msw)", () => {
 });
 
 describe("findMany (msw)", () => {
-  test("returns tokens with permissions applied, ordered by createdAt", async () => {
+  test("returns tokens with DB-normalized permissions, ordered by createdAt", async () => {
     server.use(
       projectOwnershipHandler,
       db.get("AuthorizationToken", ({ request }) => {
         const url = new URL(request.url);
         expect(url.searchParams.get("projectId")).toBe("eq.proj-1");
         return json([
-          { ...tokenRow, relation: "administrators", canPublish: false },
+          { ...tokenRow, relation: "administrators", canPublish: true },
         ]);
       })
     );
 
     const result = await findMany({ projectId: "proj-1" }, createContext());
     expect(result).toHaveLength(1);
-    // administrators rule: canPublish=true
+    // administrators are normalized in SQL: canPublish=true
     expect(result[0].canPublish).toBe(true);
   });
 });

--- a/packages/authorization-token/src/db/authorization-token.ts
+++ b/packages/authorization-token/src/db/authorization-token.ts
@@ -11,56 +11,6 @@ import {
 type AuthorizationToken =
   Database["public"]["Tables"]["AuthorizationToken"]["Row"];
 
-const applyTokenPermissions = (
-  token: AuthorizationToken
-): AuthorizationToken => {
-  let result = token;
-
-  // @todo: fix this on SQL level
-  if (token.relation === "editors") {
-    result = {
-      ...result,
-      canClone: false,
-      canCopy: true,
-    };
-  }
-
-  // @todo: fix this on SQL level
-  if (token.relation === "builders" || token.relation === "administrators") {
-    result = {
-      ...result,
-      canClone: true,
-      canCopy: true,
-    };
-  }
-
-  // @todo: fix this on SQL level
-  if (token.relation === "viewers") {
-    result = {
-      ...result,
-      canPublish: false,
-    };
-  }
-
-  // @todo: fix this on SQL level
-  if (token.relation === "builders") {
-    result = {
-      ...result,
-      canPublish: false,
-    };
-  }
-
-  // @todo: fix this on SQL level
-  if (token.relation === "administrators") {
-    result = {
-      ...result,
-      canPublish: true,
-    };
-  }
-
-  return result;
-};
-
 export const findMany = async (
   props: { projectId: string },
   context: AppContext
@@ -88,7 +38,7 @@ export const findMany = async (
     throw dbTokens.error;
   }
 
-  return dbTokens.data.map(applyTokenPermissions);
+  return dbTokens.data;
 };
 
 export const tokenDefaultPermissions = {
@@ -149,7 +99,7 @@ export const getTokenInfo = async (
     throw new AuthorizationError("Authorization token not found");
   }
 
-  return applyTokenPermissions(dbToken.data);
+  return dbToken.data;
 };
 
 export const getTokenPermissions = async (
@@ -293,5 +243,3 @@ export const remove = async (
 
   return dbToken.data;
 };
-
-export const __testing__ = { applyTokenPermissions };

--- a/packages/postgrest/supabase/tests/authorization-token.sql
+++ b/packages/postgrest/supabase/tests/authorization-token.sql
@@ -1,0 +1,599 @@
+BEGIN;
+
+SET
+    LOCAL search_path = pgtap,
+    public;
+
+-- Initialize the testing environment without planning any specific number of tests
+SELECT
+    no_plan();
+
+-- Insert a user and a project to satisfy the AuthorizationToken projectId FK
+INSERT INTO
+    "public"."User" ("id", "createdAt", "email", "username")
+VALUES
+    (
+        'token-user-1',
+        '2023-01-01 00:00:00+00',
+        'token-user-1@517cce32-9af3-example.com',
+        'token-user-1'
+    );
+
+INSERT INTO
+    "public"."Project" (
+        "id",
+        "title",
+        "domain",
+        "userId",
+        "isDeleted",
+        "createdAt"
+    )
+VALUES
+    (
+        'token-project-1',
+        'Token Project',
+        '517cce32-9af3-token-project-domain',
+        'token-user-1',
+        false,
+        '2023-01-01 00:00:00+00'
+    );
+
+-- These tests verify the role -> permission truth table enforced by the
+-- role_permissions_trigger. The table itself lives in migration
+-- 20260807000000_authorization_token_role_permissions and is the single
+-- source of truth: assert against that table rather than restating it here.
+
+-------------------------------------------------------------------------------
+-- Test Case 1: Insert normalization per relation
+-------------------------------------------------------------------------------
+-- Deliberately insert wrong values; the trigger must correct the fixed fields.
+INSERT INTO
+    "public"."AuthorizationToken" (
+        "token",
+        "projectId",
+        "name",
+        "relation",
+        "canClone",
+        "canCopy",
+        "canPublish",
+        "canUseApi"
+    )
+VALUES
+    (
+        'viewer-token-1',
+        'token-project-1',
+        'Viewer Token',
+        'viewers',
+        FALSE,
+        FALSE,
+        TRUE,
+        FALSE
+    ),
+    (
+        'editor-token-1',
+        'token-project-1',
+        'Editor Token',
+        'editors',
+        TRUE,
+        FALSE,
+        FALSE,
+        FALSE
+    ),
+    (
+        'builder-token-1',
+        'token-project-1',
+        'Builder Token',
+        'builders',
+        FALSE,
+        FALSE,
+        TRUE,
+        FALSE
+    ),
+    (
+        'admin-token-1',
+        'token-project-1',
+        'Admin Token',
+        'administrators',
+        FALSE,
+        FALSE,
+        FALSE,
+        FALSE
+    );
+
+SELECT
+    is(
+        (
+            SELECT
+                "canPublish"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'viewer-token-1'
+        ),
+        FALSE,
+        'viewers insert: canPublish forced to false'
+    );
+
+SELECT
+    is(
+        (
+            SELECT
+                "canClone"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'viewer-token-1'
+        ),
+        FALSE,
+        'viewers insert: canClone preserved'
+    );
+
+SELECT
+    is(
+        (
+            SELECT
+                "canCopy"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'viewer-token-1'
+        ),
+        FALSE,
+        'viewers insert: canCopy preserved'
+    );
+
+SELECT
+    is(
+        (
+            SELECT
+                "canClone"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'editor-token-1'
+        ),
+        FALSE,
+        'editors insert: canClone forced to false'
+    );
+
+SELECT
+    is(
+        (
+            SELECT
+                "canCopy"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'editor-token-1'
+        ),
+        TRUE,
+        'editors insert: canCopy forced to true'
+    );
+
+SELECT
+    is(
+        (
+            SELECT
+                "canPublish"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'editor-token-1'
+        ),
+        FALSE,
+        'editors insert: canPublish preserved'
+    );
+
+SELECT
+    is(
+        (
+            SELECT
+                "canClone"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'builder-token-1'
+        ),
+        TRUE,
+        'builders insert: canClone forced to true'
+    );
+
+SELECT
+    is(
+        (
+            SELECT
+                "canCopy"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'builder-token-1'
+        ),
+        TRUE,
+        'builders insert: canCopy forced to true'
+    );
+
+SELECT
+    is(
+        (
+            SELECT
+                "canPublish"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'builder-token-1'
+        ),
+        FALSE,
+        'builders insert: canPublish forced to false'
+    );
+
+SELECT
+    is(
+        (
+            SELECT
+                "canClone"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'admin-token-1'
+        ),
+        TRUE,
+        'administrators insert: canClone forced to true'
+    );
+
+SELECT
+    is(
+        (
+            SELECT
+                "canCopy"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'admin-token-1'
+        ),
+        TRUE,
+        'administrators insert: canCopy forced to true'
+    );
+
+SELECT
+    is(
+        (
+            SELECT
+                "canPublish"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'admin-token-1'
+        ),
+        TRUE,
+        'administrators insert: canPublish forced to true'
+    );
+
+-------------------------------------------------------------------------------
+-- Test Case 2: Tunable fields preserved on UPDATE
+-------------------------------------------------------------------------------
+-- Editors can toggle canPublish; the trigger must not reset it.
+UPDATE
+    "public"."AuthorizationToken"
+SET
+    "canPublish" = TRUE
+WHERE
+    "token" = 'editor-token-1';
+
+SELECT
+    is(
+        (
+            SELECT
+                "canPublish"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'editor-token-1'
+        ),
+        TRUE,
+        'editors update: tunable canPublish preserved'
+    );
+
+-- Viewers can toggle canClone/canCopy; the trigger must not reset them.
+UPDATE
+    "public"."AuthorizationToken"
+SET
+    "canClone" = TRUE,
+    "canCopy" = TRUE
+WHERE
+    "token" = 'viewer-token-1';
+
+SELECT
+    is(
+        (
+            SELECT
+                "canClone"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'viewer-token-1'
+        ),
+        TRUE,
+        'viewers update: tunable canClone preserved'
+    );
+
+SELECT
+    is(
+        (
+            SELECT
+                "canCopy"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'viewer-token-1'
+        ),
+        TRUE,
+        'viewers update: tunable canCopy preserved'
+    );
+
+-- canUseApi is never touched by the trigger.
+UPDATE
+    "public"."AuthorizationToken"
+SET
+    "canUseApi" = TRUE
+WHERE
+    "token" = 'builder-token-1';
+
+SELECT
+    is(
+        (
+            SELECT
+                "canUseApi"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'builder-token-1'
+        ),
+        TRUE,
+        'canUseApi preserved on update'
+    );
+
+-------------------------------------------------------------------------------
+-- Test Case 3: Role change re-normalizes fixed permissions on UPDATE
+-------------------------------------------------------------------------------
+-- builders -> editors: canClone must drop to false, canCopy stays true,
+-- canPublish is now tunable and preserved at its current value (false).
+UPDATE
+    "public"."AuthorizationToken"
+SET
+    "relation" = 'editors'
+WHERE
+    "token" = 'builder-token-1';
+
+SELECT
+    is(
+        (
+            SELECT
+                "canClone"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'builder-token-1'
+        ),
+        FALSE,
+        'role change -> editors: canClone re-normalized to false'
+    );
+
+SELECT
+    is(
+        (
+            SELECT
+                "canPublish"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'builder-token-1'
+        ),
+        FALSE,
+        'role change -> editors: canPublish becomes tunable and stays false'
+    );
+
+-- editors -> administrators: all fixed permissions become true.
+UPDATE
+    "public"."AuthorizationToken"
+SET
+    "relation" = 'administrators'
+WHERE
+    "token" = 'builder-token-1';
+
+SELECT
+    is(
+        (
+            SELECT
+                "canPublish"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'builder-token-1'
+        ),
+        TRUE,
+        'role change -> administrators: canPublish re-normalized to true'
+    );
+
+SELECT
+    is(
+        (
+            SELECT
+                "canUseApi"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'builder-token-1'
+        ),
+        TRUE,
+        'role change: canUseApi untouched'
+    );
+
+-------------------------------------------------------------------------------
+-- Test Case 4: Backfill normalizes pre-existing divergent rows
+-------------------------------------------------------------------------------
+-- Simulate rows that predate the trigger: disable it, insert divergent
+-- values, re-enable. These must be fixed by the migration backfill, whose
+-- divergence WHERE-clause and trigger-driven SET body match migration
+-- 20260807000000_authorization_token_role_permissions.
+ALTER TABLE
+    "public"."AuthorizationToken" DISABLE TRIGGER role_permissions_trigger;
+
+INSERT INTO
+    "public"."AuthorizationToken" (
+        "token",
+        "projectId",
+        "name",
+        "relation",
+        "canClone",
+        "canCopy",
+        "canPublish",
+        "canUseApi"
+    )
+VALUES
+    (
+        'legacy-viewer-token',
+        'token-project-1',
+        'Legacy Viewer',
+        'viewers',
+        FALSE,
+        FALSE,
+        TRUE,
+        FALSE
+    ),
+    (
+        'legacy-editor-token',
+        'token-project-1',
+        'Legacy Editor',
+        'editors',
+        TRUE,
+        FALSE,
+        TRUE,
+        FALSE
+    );
+
+ALTER TABLE
+    "public"."AuthorizationToken" ENABLE TRIGGER role_permissions_trigger;
+
+-- Confirm the legacy rows are still divergent at this point.
+SELECT
+    is(
+        (
+            SELECT
+                "canPublish"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'legacy-viewer-token'
+        ),
+        TRUE,
+        'legacy rows stay divergent while the trigger is disabled'
+    );
+
+-- Apply the same backfill UPDATE used in migration 20260807000000.
+UPDATE
+    "public"."AuthorizationToken"
+SET
+    "canUseApi" = "canUseApi"
+WHERE
+    (
+        "relation" = 'viewers'
+        AND "canPublish" = TRUE
+    )
+    OR (
+        "relation" = 'editors'
+        AND ("canClone" = TRUE OR "canCopy" = FALSE)
+    )
+    OR (
+        "relation" = 'builders'
+        AND (
+            "canClone" = FALSE
+            OR "canCopy" = FALSE
+            OR "canPublish" = TRUE
+        )
+    )
+    OR (
+        "relation" = 'administrators'
+        AND (
+            "canClone" = FALSE
+            OR "canCopy" = FALSE
+            OR "canPublish" = FALSE
+        )
+    );
+
+SELECT
+    is(
+        (
+            SELECT
+                "canPublish"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'legacy-viewer-token'
+        ),
+        FALSE,
+        'backfill: legacy viewers canPublish normalized to false'
+    );
+
+SELECT
+    is(
+        (
+            SELECT
+                "canClone"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'legacy-editor-token'
+        ),
+        FALSE,
+        'backfill: legacy editors canClone normalized to false'
+    );
+
+SELECT
+    is(
+        (
+            SELECT
+                "canCopy"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'legacy-editor-token'
+        ),
+        TRUE,
+        'backfill: legacy editors canCopy normalized to true'
+    );
+
+-- canUseApi is never part of the divergence logic, so the backfill preserves it.
+SELECT
+    is(
+        (
+            SELECT
+                "canUseApi"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'legacy-editor-token'
+        ),
+        FALSE,
+        'backfill: canUseApi preserved'
+    );
+
+-- Already-conforming rows are excluded by the backfill predicate.
+SELECT
+    is(
+        (
+            SELECT
+                "canPublish"
+            FROM
+                "public"."AuthorizationToken"
+            WHERE
+                "token" = 'admin-token-1'
+        ),
+        TRUE,
+        'backfill: already-conforming administrator row left in place'
+    );
+
+-- Finalize the tests
+SELECT
+    finish();
+
+ROLLBACK;

--- a/packages/prisma-client/prisma/migrations/20260807000000_authorization_token_role_permissions/migration.sql
+++ b/packages/prisma-client/prisma/migrations/20260807000000_authorization_token_role_permissions/migration.sql
@@ -1,0 +1,76 @@
+-- Enforce role -> permission mapping on the SQL level.
+
+-- The role/permission mapping used to live in TS (applyTokenPermissions),
+-- which risked diverging from the intended SQL behavior. This migration moves
+-- it into a BEFORE trigger so writes are always normalized, plus a backfill
+-- for pre-existing rows.
+
+-- Truth table (fixed fields per relation; fields not listed are user-tunable
+-- and left untouched). This is the single source of truth — the pgTAP tests
+-- reference it:
+--
+--   relation        | canClone | canCopy | canPublish
+--   viewers         |   --     |   --    | false
+--   editors         |   false  |  true   |   --
+--   builders        |   true   |  true   | false
+--   administrators  |   true   |  true   | true
+--
+-- canUseApi is always user-controlled and never touched by the trigger.
+--
+-- CONVENTION: if a new value is ever added to the AuthorizationRelation enum,
+-- this trigger function MUST be extended to handle it. The ELSE branch fails
+-- loudly on any unhandled relation so a new role cannot silently bypass
+-- permission normalization.
+
+CREATE OR REPLACE FUNCTION enforce_authorization_token_role_permissions()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  -- Preserve user-tunable fields by only setting the fixed ones per role.
+  IF NEW."relation" = 'viewers' THEN
+    NEW."canPublish" := FALSE;
+  ELSIF NEW."relation" = 'editors' THEN
+    NEW."canClone" := FALSE;
+    NEW."canCopy" := TRUE;
+  ELSIF NEW."relation" = 'builders' THEN
+    NEW."canClone" := TRUE;
+    NEW."canCopy" := TRUE;
+    NEW."canPublish" := FALSE;
+  ELSIF NEW."relation" = 'administrators' THEN
+    NEW."canClone" := TRUE;
+    NEW."canCopy" := TRUE;
+    NEW."canPublish" := TRUE;
+  ELSE
+    RAISE EXCEPTION 'Unhandled AuthorizationToken relation: %', NEW."relation";
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+-- Keep this migration re-runnable: drop any pre-existing trigger before
+-- creating it. The migration runner does not wrap custom SQL here, so a
+-- mid-file failure (e.g. a lock timeout in the backfill below) could leave
+-- the function and trigger in place while the migration is marked failed.
+DROP TRIGGER IF EXISTS role_permissions_trigger ON "AuthorizationToken";
+
+CREATE TRIGGER role_permissions_trigger
+BEFORE INSERT OR UPDATE ON "AuthorizationToken"
+FOR EACH ROW
+EXECUTE FUNCTION enforce_authorization_token_role_permissions();
+
+-- Backfill pre-existing rows that diverge from the enforced mapping.
+--
+-- The WHERE clause restricts the UPDATE to rows that do not yet conform, so we
+-- never rewrite a new tuple into the heap for already-correct rows. The SET
+-- body is a no-op assignment that only serves to fire the BEFORE UPDATE
+-- trigger, which performs the actual normalization. This keeps the truth table
+-- in exactly one place (the trigger function above) instead of duplicating the
+-- CASE logic here.
+UPDATE "AuthorizationToken"
+SET "canUseApi" = "canUseApi"
+WHERE
+  ("relation" = 'viewers' AND "canPublish" = TRUE)
+  OR ("relation" = 'editors' AND ("canClone" = TRUE OR "canCopy" = FALSE))
+  OR ("relation" = 'builders' AND ("canClone" = FALSE OR "canCopy" = FALSE OR "canPublish" = TRUE))
+  OR ("relation" = 'administrators' AND ("canClone" = FALSE OR "canCopy" = FALSE OR "canPublish" = FALSE));


### PR DESCRIPTION

## Description

Move authorization token role→permission mapping into SQL

The role→permission mapping for AuthorizationToken previously lived in TS (applyTokenPermissions), recomputed on every read and at risk of diverging from the intended SQL behavior. This PR codifies it in the database as the single source of truth.

## Code Review

- [x] hi @kof, I need you to do
  - conceptual review (architecture, feature-correctness)
  - detailed review (read every line)
  - test it on preview

## Before requesting a review

- [x] made a self-review
- [x] added inline comments where things may be not obvious (the "why", not "what")

## Before merging

- [x] tested locally and on preview environment (preview dev login: 0000)
- [x] updated [test cases](https://github.com/webstudio-is/webstudio/blob/main/apps/builder/docs/test-cases.md) document
- [X] added tests
- [X] if any new env variables are added, added them to `.env` file
