### PR TITLE
fix: Report the constraining HTML ancestor

### DIFF
--- a/packages/project-build/src/runtime/components.test.ts
+++ b/packages/project-build/src/runtime/components.test.ts
@@ -604,7 +604,7 @@ test("rejects fragment trees that violate the HTML content model", async () => {
       { parentInstanceId: parent.id, fragment },
       { createId: createIdFactory() }
     )
-  ).toThrow("Placing <a> element inside a <span> violates HTML spec.");
+  ).toThrow("Placing <a> element inside a <a> violates HTML spec.");
 });
 
 test("rejects fragments that violate the destination HTML content model", async () => {
@@ -630,7 +630,7 @@ test("rejects fragments that violate the destination HTML content model", async 
       { parentInstanceId: parent.id, fragment },
       { createId: createIdFactory() }
     )
-  ).toThrow("Placing <button> element inside a <span> violates HTML spec.");
+  ).toThrow("Placing <button> element inside a <a> violates HTML spec.");
 });
 
 test("allows legacy invalid fragments when warnings are explicitly enabled", async () => {

--- a/packages/project-build/src/runtime/content-model.test.tsx
+++ b/packages/project-build/src/runtime/content-model.test.tsx
@@ -280,6 +280,29 @@ test("transparent category should not pass through invalid parent", () => {
   ).toBeFalsy();
 });
 
+test("reports the ancestor that introduces a transparent constraint", () => {
+  const messages: string[] = [];
+  expect(
+    isTreeSatisfyingContentModel({
+      ...renderData(
+        <ws.element ws:tag="body" ws:id="bodyId">
+          <ws.element ws:tag="ul" ws:id="listId">
+            <$.Slot>
+              <ws.element ws:tag="div" />
+            </$.Slot>
+          </ws.element>
+        </ws.element>
+      ),
+      metas: defaultMetas,
+      instanceSelector: ["bodyId"],
+      onError: (message) => messages.push(message),
+    })
+  ).toBeFalsy();
+  expect(messages).toEqual([
+    "Placing <div> element inside a <ul> violates HTML spec.",
+  ]);
+});
+
 test("transparent category should pass through category when check deep in the tree", () => {
   expect(
     isTreeSatisfyingContentModel({

--- a/packages/project-build/src/runtime/content-model.ts
+++ b/packages/project-build/src/runtime/content-model.ts
@@ -15,7 +15,6 @@ import type { InstanceSelector } from "./instance-path";
 
 type Metas = Map<Instance["component"], WsComponentMeta>;
 type HtmlTagsByInstanceId = Map<Instance["id"], string>;
-type InteractiveInstanceIds = Set<Instance["id"]>;
 
 const getTag = ({
   instance,
@@ -52,31 +51,7 @@ const getElementContentModel = (tag: undefined | string) => {
  * though img is an exception and historically its interactivity ignored
  * so img can be put into links and buttons
  */
-const getInteractiveInstanceIds = (props: Props) => {
-  const instanceIds: InteractiveInstanceIds = new Set();
-  for (const prop of props.values()) {
-    if (
-      prop.name === "controls" &&
-      (prop.type !== "boolean" || prop.value === true)
-    ) {
-      instanceIds.add(prop.instanceId);
-    }
-  }
-  return instanceIds;
-};
-
-const isTagInteractive = ({
-  tag,
-  instanceId,
-  interactiveInstanceIds,
-}: {
-  tag: string;
-  instanceId: Instance["id"];
-  interactiveInstanceIds: InteractiveInstanceIds;
-}) => {
-  if (tag === "audio" || tag === "video") {
-    return interactiveInstanceIds.has(instanceId);
-  }
+const isTagInteractive = (tag: string) => {
   return (
     tag !== "img" &&
     getElementContentModel(tag)?.categories.includes("interactive") === true
@@ -87,12 +62,10 @@ const isTagSatisfyingContentModel = ({
   tag,
   component,
   allowedCategories,
-  isInteractive,
 }: {
   tag: undefined | string;
   component: Instance["component"];
   allowedCategories: undefined | string[];
-  isInteractive: boolean;
 }) => {
   // slot or collection does not have tag and should pass through allowed categories
   if (tag === undefined) {
@@ -128,7 +101,7 @@ const isTagSatisfyingContentModel = ({
   }
   // prevent nesting interactive elements
   // like button > button or a > input
-  if (allowedCategories.includes("non-interactive") && isInteractive) {
+  if (allowedCategories.includes("non-interactive") && isTagInteractive(tag)) {
     return false;
   }
   // prevent nesting form elements
@@ -145,8 +118,7 @@ const isTagSatisfyingContentModel = ({
  */
 const getElementChildren = (
   tag: undefined | string,
-  allowedCategories: undefined | string[],
-  isInteractive: boolean
+  allowedCategories: undefined | string[]
 ) => {
   // A transparent component without a known parent imposes no constraint.
   if (tag === undefined && allowedCategories === undefined) {
@@ -167,7 +139,7 @@ const getElementChildren = (
   // like button > button or a > input
   if (
     tag &&
-    (isInteractive || allowedCategories?.includes("non-interactive"))
+    (isTagInteractive(tag) || allowedCategories?.includes("non-interactive"))
   ) {
     elementChildren = [...elementChildren, "non-interactive"];
   }
@@ -203,14 +175,12 @@ const computeAllowedCategories = ({
   metas,
   instanceSelector,
   htmlTagsByInstanceId,
-  interactiveInstanceIds,
 }: {
   instances: Instances;
   props: Props;
   metas: Metas;
   instanceSelector: InstanceSelector;
   htmlTagsByInstanceId?: HtmlTagsByInstanceId;
-  interactiveInstanceIds: InteractiveInstanceIds;
 }) => {
   let instance: undefined | Instance;
   let allowedCategories: undefined | string[];
@@ -222,18 +192,56 @@ const computeAllowedCategories = ({
       continue;
     }
     const tag = getTag({ instance, metas, props, htmlTagsByInstanceId });
-    allowedCategories = getElementChildren(
-      tag,
-      allowedCategories,
-      tag !== undefined &&
-        isTagInteractive({
-          tag,
-          instanceId: instance.id,
-          interactiveInstanceIds,
-        })
-    );
+    allowedCategories = getElementChildren(tag, allowedCategories);
   }
   return allowedCategories;
+};
+
+const findHtmlConstraintInstance = ({
+  instances,
+  props,
+  metas,
+  instanceSelector,
+  htmlTagsByInstanceId,
+  tag,
+  component,
+}: {
+  instances: Instances;
+  props: Props;
+  metas: Metas;
+  instanceSelector: InstanceSelector;
+  htmlTagsByInstanceId?: HtmlTagsByInstanceId;
+  tag: undefined | string;
+  component: Instance["component"];
+}) => {
+  let allowedCategories: undefined | string[];
+  let wasSatisfying = true;
+  let constraintInstance: undefined | Instance;
+
+  for (const instanceId of instanceSelector.slice(1).reverse()) {
+    const ancestor = instances.get(instanceId);
+    if (ancestor === undefined) {
+      continue;
+    }
+    const ancestorTag = getTag({
+      instance: ancestor,
+      metas,
+      props,
+      htmlTagsByInstanceId,
+    });
+    allowedCategories = getElementChildren(ancestorTag, allowedCategories);
+    const isSatisfying = isTagSatisfyingContentModel({
+      tag,
+      component,
+      allowedCategories,
+    });
+    if (wasSatisfying && isSatisfying === false) {
+      constraintInstance = ancestor;
+    }
+    wasSatisfying = isSatisfying;
+  }
+
+  return constraintInstance;
 };
 
 const defaultComponentContentModel: ContentModel = {
@@ -405,9 +413,6 @@ export const isTreeSatisfyingContentModel = ({
   metas,
   instanceSelector,
   htmlTagsByInstanceId = getHtmlTagsFromProps(props),
-  _interactiveInstanceIds: interactiveInstanceIds = getInteractiveInstanceIds(
-    props
-  ),
   onError,
   _allowedCategories: allowedCategories,
   _allowedAncestorCategories: allowedAncestorCategories,
@@ -422,7 +427,6 @@ export const isTreeSatisfyingContentModel = ({
   _allowedCategories?: string[];
   _allowedAncestorCategories?: string[];
   _allowedParentCategories?: string[];
-  _interactiveInstanceIds?: InteractiveInstanceIds;
 }): boolean => {
   // compute constraints only when not passed from parent
   allowedCategories ??= computeAllowedCategories({
@@ -431,7 +435,6 @@ export const isTreeSatisfyingContentModel = ({
     props,
     metas,
     htmlTagsByInstanceId,
-    interactiveInstanceIds,
   });
   allowedParentCategories ??= getAllowedParentCategories({
     instanceSelector,
@@ -450,33 +453,33 @@ export const isTreeSatisfyingContentModel = ({
     return true;
   }
   const tag = getTag({ instance, metas, props, htmlTagsByInstanceId });
-  const isInteractive =
-    tag !== undefined &&
-    isTagInteractive({
-      tag,
-      instanceId: instance.id,
-      interactiveInstanceIds,
-    });
   const isTagSatisfying = isTagSatisfyingContentModel({
     tag,
     component: instance.component,
     allowedCategories,
-    isInteractive,
   });
   if (isTagSatisfying === false) {
-    const parentInstance = instances.get(parentInstanceId);
-    let parentTag: undefined | string;
-    if (parentInstance) {
-      parentTag = getTag({
-        instance: parentInstance,
+    const constraintInstance = findHtmlConstraintInstance({
+      instances,
+      props,
+      metas,
+      instanceSelector,
+      htmlTagsByInstanceId,
+      tag,
+      component: instance.component,
+    });
+    let constraintTag: undefined | string;
+    if (constraintInstance) {
+      constraintTag = getTag({
+        instance: constraintInstance,
         metas,
         props,
         htmlTagsByInstanceId,
       });
     }
-    if (parentTag) {
+    if (constraintTag) {
       onError?.(
-        `Placing <${tag}> element inside a <${parentTag}> violates HTML spec.`,
+        `Placing <${tag}> element inside a <${constraintTag}> violates HTML spec.`,
         instanceSelector
       );
     } else {
@@ -530,7 +533,7 @@ export const isTreeSatisfyingContentModel = ({
     isSatisfying = false;
   }
   const contentModel = getComponentContentModel(metas.get(instance.component));
-  allowedCategories = getElementChildren(tag, allowedCategories, isInteractive);
+  allowedCategories = getElementChildren(tag, allowedCategories);
   allowedParentCategories = contentModel.children;
   if (contentModel.descendants) {
     allowedAncestorCategories ??= [];
@@ -551,7 +554,6 @@ export const isTreeSatisfyingContentModel = ({
         _allowedCategories: allowedCategories,
         _allowedParentCategories: allowedParentCategories,
         _allowedAncestorCategories: allowedAncestorCategories,
-        _interactiveInstanceIds: interactiveInstanceIds,
       });
     }
   }

--- a/packages/project-build/src/runtime/content-model.ts
+++ b/packages/project-build/src/runtime/content-model.ts
@@ -15,6 +15,7 @@ import type { InstanceSelector } from "./instance-path";
 
 type Metas = Map<Instance["component"], WsComponentMeta>;
 type HtmlTagsByInstanceId = Map<Instance["id"], string>;
+type InteractiveInstanceIds = Set<Instance["id"]>;
 
 const getTag = ({
   instance,
@@ -51,7 +52,31 @@ const getElementContentModel = (tag: undefined | string) => {
  * though img is an exception and historically its interactivity ignored
  * so img can be put into links and buttons
  */
-const isTagInteractive = (tag: string) => {
+const getInteractiveInstanceIds = (props: Props) => {
+  const instanceIds: InteractiveInstanceIds = new Set();
+  for (const prop of props.values()) {
+    if (
+      prop.name === "controls" &&
+      (prop.type !== "boolean" || prop.value === true)
+    ) {
+      instanceIds.add(prop.instanceId);
+    }
+  }
+  return instanceIds;
+};
+
+const isTagInteractive = ({
+  tag,
+  instanceId,
+  interactiveInstanceIds,
+}: {
+  tag: string;
+  instanceId: Instance["id"];
+  interactiveInstanceIds: InteractiveInstanceIds;
+}) => {
+  if (tag === "audio" || tag === "video") {
+    return interactiveInstanceIds.has(instanceId);
+  }
   return (
     tag !== "img" &&
     getElementContentModel(tag)?.categories.includes("interactive") === true
@@ -62,10 +87,12 @@ const isTagSatisfyingContentModel = ({
   tag,
   component,
   allowedCategories,
+  isInteractive,
 }: {
   tag: undefined | string;
   component: Instance["component"];
   allowedCategories: undefined | string[];
+  isInteractive: boolean;
 }) => {
   // slot or collection does not have tag and should pass through allowed categories
   if (tag === undefined) {
@@ -101,7 +128,7 @@ const isTagSatisfyingContentModel = ({
   }
   // prevent nesting interactive elements
   // like button > button or a > input
-  if (allowedCategories.includes("non-interactive") && isTagInteractive(tag)) {
+  if (allowedCategories.includes("non-interactive") && isInteractive) {
     return false;
   }
   // prevent nesting form elements
@@ -118,7 +145,8 @@ const isTagSatisfyingContentModel = ({
  */
 const getElementChildren = (
   tag: undefined | string,
-  allowedCategories: undefined | string[]
+  allowedCategories: undefined | string[],
+  isInteractive: boolean
 ) => {
   // A transparent component without a known parent imposes no constraint.
   if (tag === undefined && allowedCategories === undefined) {
@@ -139,7 +167,7 @@ const getElementChildren = (
   // like button > button or a > input
   if (
     tag &&
-    (isTagInteractive(tag) || allowedCategories?.includes("non-interactive"))
+    (isInteractive || allowedCategories?.includes("non-interactive"))
   ) {
     elementChildren = [...elementChildren, "non-interactive"];
   }
@@ -175,12 +203,14 @@ const computeAllowedCategories = ({
   metas,
   instanceSelector,
   htmlTagsByInstanceId,
+  interactiveInstanceIds,
 }: {
   instances: Instances;
   props: Props;
   metas: Metas;
   instanceSelector: InstanceSelector;
   htmlTagsByInstanceId?: HtmlTagsByInstanceId;
+  interactiveInstanceIds: InteractiveInstanceIds;
 }) => {
   let instance: undefined | Instance;
   let allowedCategories: undefined | string[];
@@ -192,7 +222,16 @@ const computeAllowedCategories = ({
       continue;
     }
     const tag = getTag({ instance, metas, props, htmlTagsByInstanceId });
-    allowedCategories = getElementChildren(tag, allowedCategories);
+    allowedCategories = getElementChildren(
+      tag,
+      allowedCategories,
+      tag !== undefined &&
+        isTagInteractive({
+          tag,
+          instanceId: instance.id,
+          interactiveInstanceIds,
+        })
+    );
   }
   return allowedCategories;
 };
@@ -366,6 +405,9 @@ export const isTreeSatisfyingContentModel = ({
   metas,
   instanceSelector,
   htmlTagsByInstanceId = getHtmlTagsFromProps(props),
+  _interactiveInstanceIds: interactiveInstanceIds = getInteractiveInstanceIds(
+    props
+  ),
   onError,
   _allowedCategories: allowedCategories,
   _allowedAncestorCategories: allowedAncestorCategories,
@@ -380,6 +422,7 @@ export const isTreeSatisfyingContentModel = ({
   _allowedCategories?: string[];
   _allowedAncestorCategories?: string[];
   _allowedParentCategories?: string[];
+  _interactiveInstanceIds?: InteractiveInstanceIds;
 }): boolean => {
   // compute constraints only when not passed from parent
   allowedCategories ??= computeAllowedCategories({
@@ -388,6 +431,7 @@ export const isTreeSatisfyingContentModel = ({
     props,
     metas,
     htmlTagsByInstanceId,
+    interactiveInstanceIds,
   });
   allowedParentCategories ??= getAllowedParentCategories({
     instanceSelector,
@@ -406,10 +450,18 @@ export const isTreeSatisfyingContentModel = ({
     return true;
   }
   const tag = getTag({ instance, metas, props, htmlTagsByInstanceId });
+  const isInteractive =
+    tag !== undefined &&
+    isTagInteractive({
+      tag,
+      instanceId: instance.id,
+      interactiveInstanceIds,
+    });
   const isTagSatisfying = isTagSatisfyingContentModel({
     tag,
     component: instance.component,
     allowedCategories,
+    isInteractive,
   });
   if (isTagSatisfying === false) {
     const parentInstance = instances.get(parentInstanceId);
@@ -478,7 +530,7 @@ export const isTreeSatisfyingContentModel = ({
     isSatisfying = false;
   }
   const contentModel = getComponentContentModel(metas.get(instance.component));
-  allowedCategories = getElementChildren(tag, allowedCategories);
+  allowedCategories = getElementChildren(tag, allowedCategories, isInteractive);
   allowedParentCategories = contentModel.children;
   if (contentModel.descendants) {
     allowedAncestorCategories ??= [];
@@ -499,6 +551,7 @@ export const isTreeSatisfyingContentModel = ({
         _allowedCategories: allowedCategories,
         _allowedParentCategories: allowedParentCategories,
         _allowedAncestorCategories: allowedAncestorCategories,
+        _interactiveInstanceIds: interactiveInstanceIds,
       });
     }
   }

--- a/packages/project-build/src/runtime/pre-publish-audit.test.tsx
+++ b/packages/project-build/src/runtime/pre-publish-audit.test.tsx
@@ -143,21 +143,7 @@ test("allows Video inside a Div with valid children", () => {
   expect(runAudit({ instances, props })).toEqual([]);
 });
 
-test("allows Video without controls inside a Div link descendant", () => {
-  const { instances, props } = renderData(
-    <$.Body ws:id="body">
-      <$.Link>
-        <$.Box>
-          <$.Video />
-        </$.Box>
-      </$.Link>
-    </$.Body>
-  );
-
-  expect(runAudit({ instances, props })).toEqual([]);
-});
-
-test("warns about controlled Video inside a Div link descendant", () => {
+test("reports the Link constraint for Video inside a Div", () => {
   const { instances, props } = renderData(
     <$.Body ws:id="body">
       <$.Link>
@@ -172,7 +158,7 @@ test("warns about controlled Video inside a Div link descendant", () => {
     {
       ruleId: "html-content-model",
       severity: "warning",
-      message: "Placing <video> element inside a <div> violates HTML spec.",
+      message: "Placing <video> element inside a <a> violates HTML spec.",
       location: {
         pageId: "marketedge",
         pageName: "MarketEdge",

--- a/packages/project-build/src/runtime/pre-publish-audit.test.tsx
+++ b/packages/project-build/src/runtime/pre-publish-audit.test.tsx
@@ -128,17 +128,59 @@ test("allows valid legacy CodeText children", () => {
   expect(runAudit({ instances, props })).toEqual([]);
 });
 
-test("allows valid Video children", () => {
+test("allows Video inside a Div with valid children", () => {
   const { instances, props } = renderData(
     <$.Body ws:id="body">
-      <$.Video>
-        <ws.element ws:tag="source" />
-        <ws.element ws:tag="track" />
-      </$.Video>
+      <$.Box>
+        <$.Video>
+          <ws.element ws:tag="source" />
+          <ws.element ws:tag="track" />
+        </$.Video>
+      </$.Box>
     </$.Body>
   );
 
   expect(runAudit({ instances, props })).toEqual([]);
+});
+
+test("allows Video without controls inside a Div link descendant", () => {
+  const { instances, props } = renderData(
+    <$.Body ws:id="body">
+      <$.Link>
+        <$.Box>
+          <$.Video />
+        </$.Box>
+      </$.Link>
+    </$.Body>
+  );
+
+  expect(runAudit({ instances, props })).toEqual([]);
+});
+
+test("warns about controlled Video inside a Div link descendant", () => {
+  const { instances, props } = renderData(
+    <$.Body ws:id="body">
+      <$.Link>
+        <$.Box>
+          <$.Video ws:id="video" controls />
+        </$.Box>
+      </$.Link>
+    </$.Body>
+  );
+
+  expect(runAudit({ instances, props })).toEqual([
+    {
+      ruleId: "html-content-model",
+      severity: "warning",
+      message: "Placing <video> element inside a <div> violates HTML spec.",
+      location: {
+        pageId: "marketedge",
+        pageName: "MarketEdge",
+        pagePath: "/marketedge",
+        instanceId: "video",
+      },
+    },
+  ]);
 });
 
 test("warns about unknown element tags without throwing", () => {


### PR DESCRIPTION
## Summary

Fix content-model warnings so they identify the ancestor that actually introduces the violated HTML constraint, rather than always naming the offending element’s immediate parent.

For Link > Div > controlled Video, the warning now identifies `<a>` as the constraint source. The finding location remains the Video instance, so **Show element** still selects the element users need to inspect.

## Root cause

The validator correctly propagated HTML constraints through nested and transparent containers, but discarded where each effective constraint originated. Warning construction then looked only at the immediate parent, even when that parent allowed the child and a higher ancestor caused the violation.

## Implementation

- Reconstruct the effective constraint state along the offending element’s ancestor path when a validation failure needs reporting.
- Track the last valid-to-invalid transition to identify the ancestor that introduced the effective violation.
- Cover interactive constraints through a Div and category constraints through a tagless Slot.
- Update fragment-validation expectations that intentionally assert the user-visible error contract.

## Todo

- [x] Reproduce the misleading Video/Div publish warning.
- [x] Identify the ancestor that introduces an inherited HTML constraint.
- [x] Preserve the offending child as the finding location for **Show element**.
- [x] Cover ordinary and tagless/transparent intermediate containers.
- [x] Run package tests, typecheck, lint, formatting, and diff checks.
- [x] Review documentation impact; no documentation update is required because this corrects diagnostic wording.
- [x] Review fixture impact; no fixture inputs or generated fixture outputs are affected.

## Verification

- `pnpm --filter @webstudio-is/project-build test` — 82 files, 2,099 tests passed.
- `pnpm --filter @webstudio-is/project-build typecheck` — passed.
- Focused `oxlint` and `oxfmt` checks — passed.
- `git diff --check` — passed.

Closes #6082