### PR TITLE
fix: Improve MCP preview verification reliability

### DIFF
--- a/packages/cli/src/commands/mcp-preview.test.ts
+++ b/packages/cli/src/commands/mcp-preview.test.ts
@@ -400,6 +400,7 @@ test("passes explicit preview source to preview preparation", async () => {
     {
       preserveGeneratedProject: false,
       prepareForIncrementalGeneration: true,
+      reportProgress: expect.any(Function),
     }
   );
   expect(prepareSessionDataFile).toHaveBeenCalledOnce();

--- a/packages/cli/src/commands/mcp-preview.ts
+++ b/packages/cli/src/commands/mcp-preview.ts
@@ -255,9 +255,11 @@ const prepareDefaultPreviewProject = (
   {
     preserveGeneratedProject = false,
     prepareForIncrementalGeneration = false,
+    reportProgress,
   }: {
     preserveGeneratedProject?: boolean;
     prepareForIncrementalGeneration?: boolean;
+    reportProgress?: (message: string) => void;
   } = {}
 ) =>
   preparePreviewProject({
@@ -271,6 +273,7 @@ const prepareDefaultPreviewProject = (
     prepareSessionDataFile,
     preserveGeneratedProject,
     prepareForIncrementalGeneration,
+    reportProgress,
   });
 
 export const createMcpPreviewHandlers = ({
@@ -430,6 +433,12 @@ export const createMcpPreviewHandlers = ({
         {
           preserveGeneratedProject: canReusePreview && mode === "iterative",
           prepareForIncrementalGeneration: mode === "iterative",
+          ...(progress === undefined
+            ? {}
+            : {
+                reportProgress: (message: string) =>
+                  progress.report(`tool screenshot ${message}`),
+              }),
         }
       );
       const projectVersion = getProjectVersion();
@@ -525,6 +534,12 @@ export const createMcpPreviewHandlers = ({
           {
             preserveGeneratedProject: canReusePreview && mode === "iterative",
             prepareForIncrementalGeneration: mode === "iterative",
+            ...(progress === undefined
+              ? {}
+              : {
+                  reportProgress: (message: string) =>
+                    progress.report(`tool preview.start ${message}`),
+                }),
           }
         );
         const projectVersion = getProjectVersion();

--- a/packages/cli/src/commands/mcp-preview.ts
+++ b/packages/cli/src/commands/mcp-preview.ts
@@ -69,6 +69,17 @@ type McpToolProgress = {
   report: (message: string) => void;
 };
 
+const getPreparationProgress = (
+  progress: McpToolProgress | undefined,
+  tool: "screenshot" | "preview.start"
+) =>
+  progress === undefined
+    ? {}
+    : {
+        reportProgress: (message: string) =>
+          progress.report(`tool ${tool} ${message}`),
+      };
+
 export const createPreviewFreshness = () => {
   let revision = 0;
   let freshRevision = -1;
@@ -433,12 +444,7 @@ export const createMcpPreviewHandlers = ({
         {
           preserveGeneratedProject: canReusePreview && mode === "iterative",
           prepareForIncrementalGeneration: mode === "iterative",
-          ...(progress === undefined
-            ? {}
-            : {
-                reportProgress: (message: string) =>
-                  progress.report(`tool screenshot ${message}`),
-              }),
+          ...getPreparationProgress(progress, "screenshot"),
         }
       );
       const projectVersion = getProjectVersion();
@@ -534,12 +540,7 @@ export const createMcpPreviewHandlers = ({
           {
             preserveGeneratedProject: canReusePreview && mode === "iterative",
             prepareForIncrementalGeneration: mode === "iterative",
-            ...(progress === undefined
-              ? {}
-              : {
-                  reportProgress: (message: string) =>
-                    progress.report(`tool preview.start ${message}`),
-                }),
+            ...getPreparationProgress(progress, "preview.start"),
           }
         );
         const projectVersion = getProjectVersion();

--- a/packages/cli/src/commands/preview.test.ts
+++ b/packages/cli/src/commands/preview.test.ts
@@ -544,38 +544,6 @@ test("uses npm-cli from an npx launcher and forwards a writable npm cache", asyn
   );
 });
 
-test("reports generated preview preparation phases", async () => {
-  const previousDirectory = cwd();
-  const projectDir = join(tmpdir(), `webstudio-preview-test-${randomUUID()}`);
-  const progress: string[] = [];
-
-  await mkdir(join(projectDir, ".webstudio"), { recursive: true });
-  await writeFile(join(projectDir, ".webstudio", "data.json"), "{}");
-  chdir(projectDir);
-  try {
-    await preparePreviewProject({
-      assets: true,
-      template: [],
-      generate: true,
-      source: "session",
-      prepareSessionDataFile: vi.fn(async () => undefined),
-      prebuildProject: vi.fn(async () => undefined),
-      ensureDependencies: vi.fn(async () => undefined),
-      reportProgress: (message) => progress.push(message),
-    });
-  } finally {
-    chdir(previousDirectory);
-    await rm(projectDir, { recursive: true, force: true });
-  }
-
-  expect(progress).toEqual([
-    "materializing session project data",
-    "generating preview files",
-    "checking or installing generated preview dependencies (2 minute timeout)",
-    "generated preview project is ready",
-  ]);
-});
-
 test("reports an actionable error when generated dependencies cannot install", async () => {
   const access = vi.fn(async () => {
     throw Object.assign(new Error("missing"), { code: "ENOENT" });
@@ -647,6 +615,7 @@ test("materializes session data before previewing from session source", async ()
   const previousDirectory = cwd();
   const projectDir = join(tmpdir(), `webstudio-preview-test-${randomUUID()}`);
   let expectedPreviewProjectDir = "";
+  const progress: string[] = [];
   const prepareSessionDataFile = vi.fn(async () => {
     await mkdir(join(projectDir, ".webstudio"), { recursive: true });
     await writeFile(join(projectDir, ".webstudio", "data.json"), "{}");
@@ -669,6 +638,7 @@ test("materializes session data before previewing from session source", async ()
         prepareSessionDataFile,
         prebuildProject,
         ensureDependencies: vi.fn(async () => undefined),
+        reportProgress: (message) => progress.push(message),
       })
     ).resolves.toEqual({
       cwd: expectedPreviewProjectDir,
@@ -686,6 +656,12 @@ test("materializes session data before previewing from session source", async ()
     previewIdentity: true,
     sourceAssetsDirectory: join(expectedPreviewProjectDir, "..", "assets"),
   });
+  expect(progress).toEqual([
+    "materializing session project data",
+    "generating preview files",
+    "checking or installing generated preview dependencies (2 minute timeout)",
+    "generated preview project is ready",
+  ]);
 });
 
 test("refreshes an iterative generated project without replacing its directory", async () => {

--- a/packages/cli/src/commands/preview.test.ts
+++ b/packages/cli/src/commands/preview.test.ts
@@ -455,7 +455,10 @@ test("installs isolated generated dependencies when the cli does not ship them",
   expect(execFile).toHaveBeenCalledWith(
     "npm",
     expect.arrayContaining(["install", "--legacy-peer-deps"]),
-    expect.objectContaining({ cwd: "/tmp/project/.webstudio/preview" })
+    expect.objectContaining({
+      cwd: "/tmp/project/.webstudio/preview",
+      timeout: 120_000,
+    })
   );
   expect(writeFile).toHaveBeenCalledWith(
     "/tmp/project/.webstudio/preview/node_modules/.webstudio-preview-dependencies",
@@ -533,8 +536,44 @@ test("uses npm-cli from an npx launcher and forwards a writable npm cache", asyn
       "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js",
       "install",
     ]),
-    { cwd: "C:/project/.webstudio/preview", env }
+    {
+      cwd: "C:/project/.webstudio/preview",
+      env,
+      timeout: 120_000,
+    }
   );
+});
+
+test("reports generated preview preparation phases", async () => {
+  const previousDirectory = cwd();
+  const projectDir = join(tmpdir(), `webstudio-preview-test-${randomUUID()}`);
+  const progress: string[] = [];
+
+  await mkdir(join(projectDir, ".webstudio"), { recursive: true });
+  await writeFile(join(projectDir, ".webstudio", "data.json"), "{}");
+  chdir(projectDir);
+  try {
+    await preparePreviewProject({
+      assets: true,
+      template: [],
+      generate: true,
+      source: "session",
+      prepareSessionDataFile: vi.fn(async () => undefined),
+      prebuildProject: vi.fn(async () => undefined),
+      ensureDependencies: vi.fn(async () => undefined),
+      reportProgress: (message) => progress.push(message),
+    });
+  } finally {
+    chdir(previousDirectory);
+    await rm(projectDir, { recursive: true, force: true });
+  }
+
+  expect(progress).toEqual([
+    "materializing session project data",
+    "generating preview files",
+    "checking or installing generated preview dependencies (2 minute timeout)",
+    "generated preview project is ready",
+  ]);
 });
 
 test("reports an actionable error when generated dependencies cannot install", async () => {

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -536,6 +536,13 @@ export const preparePreviewProject = async ({
   if (generate === false) {
     return { cwd: projectDir };
   }
+  const prepareDependencies = async () => {
+    reportProgress?.(
+      `checking or installing generated preview dependencies (${previewDependencyInstallTimeout / 60_000} minute timeout)`
+    );
+    await ensureDependencies(previewProjectDir);
+    reportProgress?.("generated preview project is ready");
+  };
 
   const buildCacheKey = await getBuildCacheKey({
     projectDir,
@@ -553,42 +560,32 @@ export const preparePreviewProject = async ({
       "utf8"
     ).catch(() => undefined);
     if (cachedBuildKey === buildCacheKey && canReuseCachedProject) {
-      reportProgress?.(
-        `checking or installing generated preview dependencies (${previewDependencyInstallTimeout / 60_000} minute timeout)`
-      );
-      await ensureDependencies(previewProjectDir);
-      reportProgress?.("generated preview project is ready");
+      await prepareDependencies();
       return { cwd: previewProjectDir, buildCacheKey, buildRequired: false };
     }
   }
 
-  if (generate) {
-    await runExclusive(async () => {
-      const reuseGeneratedProject =
-        preserveGeneratedProject && hasIncrementalInputs;
-      await preparePreviewDirectory(projectDir, reuseGeneratedProject);
-      await runInDirectory(previewProjectDir, async () => {
-        reportProgress?.("generating preview files");
-        await prebuildProject({
-          assets,
-          template: getPreviewTemplates(template),
-          previewIdentity: true,
-          sourceAssetsDirectory: join(projectDir, LOCAL_ASSETS_DIR),
-          ...(silent ? { silent: true } : {}),
-          ...(includeDraftPages ? { includeDraftPages: true } : {}),
-          ...(reuseGeneratedProject ? { incremental: true } : {}),
-          ...(prepareForIncrementalGeneration
-            ? { preserveRouteTemplates: true }
-            : {}),
-        });
+  await runExclusive(async () => {
+    const reuseGeneratedProject =
+      preserveGeneratedProject && hasIncrementalInputs;
+    await preparePreviewDirectory(projectDir, reuseGeneratedProject);
+    await runInDirectory(previewProjectDir, async () => {
+      reportProgress?.("generating preview files");
+      await prebuildProject({
+        assets,
+        template: getPreviewTemplates(template),
+        previewIdentity: true,
+        sourceAssetsDirectory: join(projectDir, LOCAL_ASSETS_DIR),
+        ...(silent ? { silent: true } : {}),
+        ...(includeDraftPages ? { includeDraftPages: true } : {}),
+        ...(reuseGeneratedProject ? { incremental: true } : {}),
+        ...(prepareForIncrementalGeneration
+          ? { preserveRouteTemplates: true }
+          : {}),
       });
-      reportProgress?.(
-        `checking or installing generated preview dependencies (${previewDependencyInstallTimeout / 60_000} minute timeout)`
-      );
-      await ensureDependencies(previewProjectDir);
-      reportProgress?.("generated preview project is ready");
     });
-  }
+    await prepareDependencies();
+  });
 
   return {
     cwd: previewProjectDir,

--- a/packages/cli/src/commands/preview.ts
+++ b/packages/cli/src/commands/preview.ts
@@ -158,12 +158,17 @@ const cliNodeModulesCandidates = getNodeModulesSearchPaths(import.meta.url);
 const execFileAsync = promisify(execFile);
 const dependencyMarker = ".webstudio-preview-dependencies";
 const developmentCliVersion = "0.0.0-webstudio-version";
+const previewDependencyInstallTimeout = 2 * 60_000;
 type PreviewDependencyOperations = {
   access: (path: string) => Promise<void>;
   execFile: (
     file: string,
     args: string[],
-    options: { cwd: string; env: NodeJS.ProcessEnv }
+    options: {
+      cwd: string;
+      env: NodeJS.ProcessEnv;
+      timeout: number;
+    }
   ) => Promise<unknown>;
   lstat: (path: string) => Promise<{ isSymbolicLink: () => boolean }>;
   readFile: (path: string, encoding: "utf8") => Promise<string>;
@@ -300,6 +305,7 @@ export const ensurePreviewDependencies = async (
     await operations.execFile(invocation.command, invocation.args, {
       cwd: previewProjectDir,
       env: operations.env,
+      timeout: previewDependencyInstallTimeout,
     });
   } catch (error) {
     throw new Error(
@@ -465,6 +471,7 @@ export const preparePreviewProject = async ({
   includeDraftPages = false,
   preserveGeneratedProject = false,
   prepareForIncrementalGeneration = false,
+  reportProgress,
   prepareSessionDataFile = async () => {
     const connection = await resolveApiConnection();
     const session = createCliProjectSession({ connection });
@@ -490,6 +497,7 @@ export const preparePreviewProject = async ({
   includeDraftPages?: boolean;
   preserveGeneratedProject?: boolean;
   prepareForIncrementalGeneration?: boolean;
+  reportProgress?: (message: string) => void;
   prepareSessionDataFile?: () => Promise<void>;
 }): Promise<{
   cwd: string;
@@ -498,6 +506,7 @@ export const preparePreviewProject = async ({
 }> => {
   const projectDir = cwd();
   if (source === "session") {
+    reportProgress?.("materializing session project data");
     await prepareSessionDataFile();
   }
   try {
@@ -544,7 +553,11 @@ export const preparePreviewProject = async ({
       "utf8"
     ).catch(() => undefined);
     if (cachedBuildKey === buildCacheKey && canReuseCachedProject) {
+      reportProgress?.(
+        `checking or installing generated preview dependencies (${previewDependencyInstallTimeout / 60_000} minute timeout)`
+      );
       await ensureDependencies(previewProjectDir);
+      reportProgress?.("generated preview project is ready");
       return { cwd: previewProjectDir, buildCacheKey, buildRequired: false };
     }
   }
@@ -555,6 +568,7 @@ export const preparePreviewProject = async ({
         preserveGeneratedProject && hasIncrementalInputs;
       await preparePreviewDirectory(projectDir, reuseGeneratedProject);
       await runInDirectory(previewProjectDir, async () => {
+        reportProgress?.("generating preview files");
         await prebuildProject({
           assets,
           template: getPreviewTemplates(template),
@@ -568,7 +582,11 @@ export const preparePreviewProject = async ({
             : {}),
         });
       });
+      reportProgress?.(
+        `checking or installing generated preview dependencies (${previewDependencyInstallTimeout / 60_000} minute timeout)`
+      );
       await ensureDependencies(previewProjectDir);
+      reportProgress?.("generated preview project is ready");
     });
   }
 

--- a/packages/cli/src/prebuild.test.ts
+++ b/packages/cli/src/prebuild.test.ts
@@ -1374,6 +1374,50 @@ describe("prebuild", () => {
     await expectGeneratedRedirectFallback("app/routes/$.tsx");
   });
 
+  test("preserves an authored catch-all page when redirects are configured", async () => {
+    await writeSiteData(
+      createSiteData({
+        pages: [
+          {
+            id: "home",
+            name: "Home",
+            title: "Home",
+            path: "",
+            rootInstanceId: "root",
+            meta: {},
+          },
+          {
+            id: "not-found",
+            name: "Not found",
+            title: "Not found",
+            path: "/*",
+            rootInstanceId: "root",
+            meta: { status: "404" },
+          },
+        ],
+      })
+    );
+
+    await prebuild({
+      assets: false,
+      template: ["react-router"],
+      preserveRouteTemplates: true,
+    });
+    await prebuild({
+      assets: false,
+      template: ["react-router"],
+      incremental: true,
+    });
+
+    const route = await readFile("app/routes/$.tsx", "utf8");
+    expect(route).toContain("../__generated__/$");
+    expect(route).toContain("../__generated__/$.server");
+    expect(route).not.toContain('new Response("Not Found"');
+    await expect(
+      readFile("app/__generated__/$.server.tsx", "utf8")
+    ).resolves.toContain("status: 404");
+  });
+
   test("ignores the catch-all fallback when generating an SSG site", async () => {
     await writeSiteData(
       createSiteData({

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -1500,9 +1500,14 @@ export const prebuild = async (options: {
     generateRedirectsModule(pages.redirects)
   );
 
-  if (pages.redirects !== undefined && pages.redirects.length > 0) {
+  const redirectFallbackPath = join(routesDir, "$.tsx");
+  if (
+    pages.redirects !== undefined &&
+    pages.redirects.length > 0 &&
+    generatedFiles.has(normalize(redirectFallbackPath)) === false
+  ) {
     await writeGeneratedFile(
-      join(routesDir, "$.tsx"),
+      redirectFallbackPath,
       generateRedirectFallbackRoute(
         options.template.includes("react-router") ? "react-router" : "remix"
       )

--- a/packages/cli/src/screenshot.test.ts
+++ b/packages/cli/src/screenshot.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test, vi } from "vitest";
 import { constants } from "node:fs";
+import { Buffer } from "node:buffer";
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -33,7 +34,7 @@ const createDependencies = (
     kill: vi.fn(),
     once: vi.fn(),
   })),
-  readFile: vi.fn(),
+  readFile: vi.fn(async () => Buffer.from("image")) as never,
   writeFile: vi.fn(),
   mkdtemp: vi.fn(
     async () => "/tmp/webstudio-browser"
@@ -465,6 +466,37 @@ describe("captureScreenshot", () => {
     expect(mkdir).toHaveBeenCalledWith(expect.stringContaining("nested"), {
       recursive: true,
     });
+  });
+
+  test("rejects an empty screenshot artifact", async () => {
+    const dependencies = createDependencies({
+      which: vi.fn(async (command) =>
+        command === "chromium" ? "/usr/bin/chromium" : undefined
+      ),
+      readFile: vi.fn(async () => Buffer.alloc(0)) as never,
+      captureBrowserScreenshot: vi.fn(async () => ({
+        viewportWidth: 1440,
+        viewportHeight: 900,
+        contentWidth: 1440,
+        contentHeight: 900,
+        horizontalOverflow: false,
+        images: [],
+        resources: [],
+      })),
+    });
+
+    await expect(
+      captureScreenshot(
+        {
+          url: "https://example.com",
+          output: "empty.png",
+          width: 1440,
+          height: 900,
+          browser: "auto",
+        },
+        dependencies
+      )
+    ).rejects.toThrow("Screenshot artifact is empty");
   });
 });
 

--- a/packages/cli/src/screenshot.test.ts
+++ b/packages/cli/src/screenshot.test.ts
@@ -44,6 +44,7 @@ const createDependencies = (
   createWebSocket: vi.fn(),
   captureBrowserScreenshot: vi.fn(async () => undefined),
   installCommand: vi.fn(async () => undefined),
+  readArtifactByte: vi.fn(async () => 1),
   getuid: vi.fn(() => 1000),
   now: vi.fn(() => 123),
   ...overrides,
@@ -473,7 +474,7 @@ describe("captureScreenshot", () => {
       which: vi.fn(async (command) =>
         command === "chromium" ? "/usr/bin/chromium" : undefined
       ),
-      readFile: vi.fn(async () => Buffer.alloc(0)) as never,
+      readArtifactByte: vi.fn(async () => 0),
       captureBrowserScreenshot: vi.fn(async () => ({
         viewportWidth: 1440,
         viewportHeight: 900,

--- a/packages/cli/src/screenshot.ts
+++ b/packages/cli/src/screenshot.ts
@@ -1,6 +1,5 @@
 import { constants } from "node:fs";
-import { Buffer } from "node:buffer";
-import { access, mkdir, readdir } from "node:fs/promises";
+import { access, mkdir, open, readdir } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { spawn } from "node:child_process";
@@ -65,6 +64,7 @@ export type ScreenshotDependencies = {
       options: BrowserScreenshotOptions
     ) => Promise<BrowserScreenshotLayout | undefined>;
     installCommand: (file: string, args: readonly string[]) => Promise<void>;
+    readArtifactByte: (path: string) => Promise<number>;
     getuid: () => number | undefined;
     now: () => number;
   };
@@ -97,6 +97,15 @@ export const defaultScreenshotDependencies: ScreenshotDependencies = {
         reject(new Error(`${file} ${args.join(" ")} exited with code ${code}`));
       });
     });
+  },
+  async readArtifactByte(path) {
+    const file = await open(path, "r");
+    try {
+      const { bytesRead } = await file.read(new Uint8Array(1), 0, 1, 0);
+      return bytesRead;
+    } finally {
+      await file.close();
+    }
   },
   getuid: () => process.getuid?.(),
   now: () => Date.now(),
@@ -627,16 +636,16 @@ const validateScreenshotArtifact = async (
   output: string,
   dependencies: ScreenshotDependencies
 ) => {
-  let artifact: Buffer;
+  let bytesRead: number;
   try {
-    artifact = await dependencies.readFile(output);
+    bytesRead = await dependencies.readArtifactByte(output);
   } catch (cause) {
     throw Object.assign(
       new Error(`Screenshot artifact is unreadable: ${output}`),
       { code: "SCREENSHOT_ARTIFACT_UNREADABLE", cause }
     );
   }
-  if (artifact.byteLength === 0) {
+  if (bytesRead === 0) {
     throw Object.assign(new Error(`Screenshot artifact is empty: ${output}`), {
       code: "SCREENSHOT_ARTIFACT_EMPTY",
     });

--- a/packages/cli/src/screenshot.ts
+++ b/packages/cli/src/screenshot.ts
@@ -1,4 +1,5 @@
 import { constants } from "node:fs";
+import { Buffer } from "node:buffer";
 import { access, mkdir, readdir } from "node:fs/promises";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
@@ -622,6 +623,26 @@ const getBrowserScreenshotOptions = (
   scale: options.scale,
 });
 
+const validateScreenshotArtifact = async (
+  output: string,
+  dependencies: ScreenshotDependencies
+) => {
+  let artifact: Buffer;
+  try {
+    artifact = await dependencies.readFile(output);
+  } catch (cause) {
+    throw Object.assign(
+      new Error(`Screenshot artifact is unreadable: ${output}`),
+      { code: "SCREENSHOT_ARTIFACT_UNREADABLE", cause }
+    );
+  }
+  if (artifact.byteLength === 0) {
+    throw Object.assign(new Error(`Screenshot artifact is empty: ${output}`), {
+      code: "SCREENSHOT_ARTIFACT_EMPTY",
+    });
+  }
+};
+
 const captureResolvedScreenshot = async (
   options: CaptureScreenshotOptions,
   browser: BrowserCandidate,
@@ -650,6 +671,7 @@ const captureResolvedScreenshot = async (
             browserScreenshotOptions,
             dependencies
           );
+  await validateScreenshotArtifact(output, dependencies);
   return {
     output,
     browser,
@@ -780,6 +802,11 @@ export const createScreenshotCaptureSession = (
       );
       const layouts = await activeBrowserSession.capturePage(
         captures.map((capture) => capture.browserOptions)
+      );
+      await Promise.all(
+        captures.map(({ output }) =>
+          validateScreenshotArtifact(output, dependencies)
+        )
       );
       return captures.map(({ options, output }, index) => {
         const layout = layouts[index];


### PR DESCRIPTION
## Summary

Fix the third MCP reliability batch across generated catch-all routes, rendered screenshot evidence, and preview startup diagnostics.

## Root causes

- Incremental prebuild rewrote an authored `/*` route with the redirect-only fallback at `routes/$.tsx`.
- Screenshot capture trusted the browser writer result without verifying that the output artifact was readable and non-empty.
- Generated preview dependency installation had no timeout, and preparation exposed only one broad progress phase.

## Implementation

- [x] Preserve authored catch-all HTML routes during full and incremental React Router generation while retaining the redirect fallback when no catch-all page exists.
- [x] Probe every single and responsive screenshot artifact before returning success; reject missing, unreadable, or zero-byte output with stable error codes.
- [x] Bound generated preview dependency installation to two minutes.
- [x] Report session materialization, route generation, dependency preparation, and completion phases through MCP progress output.
- [x] Deduplicate preview dependency preparation and MCP progress wiring, flatten generation control flow, and consolidate overlapping test setup.
- [x] Add regression coverage and demonstrate each new test failing before its implementation and passing afterward.
- [x] Review documentation impact: no documentation update is required because the existing preview and audit workflow is unchanged; this PR makes its generated output and failure behavior reliable.
- [x] Review fixture impact and run the full fixture pipeline; no fixture diff was produced.
- [ ] Agent evaluations — not run because repository policy requires separate explicit approval.

## Verification

- `pnpm --filter webstudio test` — 60 files, 974 tests passed.
- `pnpm --filter webstudio typecheck`
- `pnpm lint`
- `pnpm check:package-boundaries`
- `pnpm check:generated-api`
- `pnpm check:generated-docs`
- `pnpm fixtures`

Closes #6081
Closes #6080
Closes #6078
