### PR TITLE
fix: Resolve published asset paths in structured content

### DIFF
--- a/docs/university/foundations/assets.md
+++ b/docs/university/foundations/assets.md
@@ -83,10 +83,16 @@ background image, social image, download link, or another URL property. The
 same resolution works for nested properties and values in arrays. JSON files
 can use relative paths in the same way.
 
+Imported content can also use published asset paths such as
+`./assets/hero.png` or `/assets/hero.png`. Webstudio matches the final file name
+across project Asset folders, so the document and referenced asset do not need
+to share the same folder hierarchy. The file name must identify exactly one
+project asset.
+
 Query strings and fragments are preserved, so values such as
 `./images/hero.png?width=1200#cover` remain usable. Webstudio resolves a value
-only when it uniquely matches a project asset. Absolute URLs, root-relative
-URLs, missing paths, and ambiguous paths remain unchanged.
+only when it uniquely matches a project asset. External URLs, other
+root-relative URLs, missing paths, and ambiguous paths remain unchanged.
 
 ## Organizing assets with folders
 

--- a/packages/content-engine/src/asset-value-references.test.ts
+++ b/packages/content-engine/src/asset-value-references.test.ts
@@ -63,6 +63,47 @@ describe("structured asset value references", () => {
     ]);
   });
 
+  test("resolves published Asset paths from sibling folders", () => {
+    const properties = {
+      relative: "./assets/inception_TDxBrdPwfoJJe_A-k5jhB.png",
+      rootRelative: "/assets/inception_TDxBrdPwfoJJe_A-k5jhB.png",
+    };
+    const references = discoverAssetValueReferences({
+      properties,
+      sourcePath: "blog/posts/inception.md",
+      assetIdsByPath: new Map([
+        ["blog/images/inception_TDxBrdPwfoJJe_A-k5jhB.png", "inception-image"],
+      ]),
+    });
+
+    expect(references).toEqual([
+      {
+        path: ["properties", "relative"],
+        assetId: "inception-image",
+      },
+      {
+        path: ["properties", "rootRelative"],
+        assetId: "inception-image",
+      },
+    ]);
+    expect(
+      resolveAssetValueReferences({
+        value: { properties },
+        references,
+        assetUrls: {
+          "inception-image":
+            "/cgi/image/inception_TDxBrdPwfoJJe_A-k5jhB.png?format=raw",
+        },
+      })
+    ).toEqual({
+      properties: {
+        relative: "/cgi/image/inception_TDxBrdPwfoJJe_A-k5jhB.png?format=raw",
+        rootRelative:
+          "/cgi/image/inception_TDxBrdPwfoJJe_A-k5jhB.png?format=raw",
+      },
+    });
+  });
+
   test("resolves without mutating source values and merges URL suffixes", () => {
     const value = {
       properties: {

--- a/packages/content-engine/src/markdown-assets.test.ts
+++ b/packages/content-engine/src/markdown-assets.test.ts
@@ -100,6 +100,40 @@ describe("Markdown asset references", () => {
     });
   });
 
+  test("resolves published Asset paths by unique asset name", () => {
+    expect(
+      discoverReferences({
+        sourcePath: "blog/posts/inception.md",
+        markdown: `
+![Relative](./assets/inception_TDxBrdPwfoJJe_A-k5jhB.png)
+![Root relative](/assets/inception_TDxBrdPwfoJJe_A-k5jhB.png)
+        `,
+        assetIdsByPath: new Map([
+          [
+            "blog/images/inception_TDxBrdPwfoJJe_A-k5jhB.png",
+            "inception-image",
+          ],
+        ]),
+      })
+    ).toEqual({
+      "./assets/inception_TDxBrdPwfoJJe_A-k5jhB.png": "inception-image",
+      "/assets/inception_TDxBrdPwfoJJe_A-k5jhB.png": "inception-image",
+    });
+  });
+
+  test("leaves published Asset paths with ambiguous names unresolved", () => {
+    expect(
+      discoverReferences({
+        sourcePath: "blog/posts/article.md",
+        markdown: "![Hero](./assets/hero.png)",
+        assetIdsByPath: new Map([
+          ["blog/images/hero.png", "blog-hero"],
+          ["archive/images/hero.png", "archive-hero"],
+        ]),
+      })
+    ).toEqual({});
+  });
+
   test("preserves encoded dot segments in canonical source folders", () => {
     expect(
       discoverReferences({

--- a/packages/content-engine/src/markdown-assets.ts
+++ b/packages/content-engine/src/markdown-assets.ts
@@ -49,15 +49,17 @@ const getMarkdownUrlTokens = (markdown: string) => {
 const getRelativeAssetPath = ({
   sourcePath,
   url,
+  allowRootRelative = false,
 }: {
   sourcePath: string;
   url: string;
+  allowRootRelative?: boolean;
 }) => {
   if (
     url.length === 0 ||
     url.startsWith("#") ||
     url.startsWith("?") ||
-    url.startsWith("/")
+    (allowRootRelative === false && url.startsWith("/"))
   ) {
     return;
   }
@@ -107,15 +109,35 @@ const getRelativeAssetPath = ({
   return segments.join("/");
 };
 
+const getPublishedAssetName = (url: string) => {
+  const path = getRelativeAssetPath({
+    sourcePath: "document.md",
+    url,
+    allowRootRelative: true,
+  });
+  const segments = path?.split("/");
+  if (segments?.length !== 2 || segments[0] !== "assets") {
+    return;
+  }
+  return segments[1];
+};
+
 export const createAssetIdResolver = (
   assetIdsByPath: ReadonlyMap<string, string>,
   sourcePath: string
 ) => {
   const assetIds = new Set(assetIdsByPath.values());
+  const assetIdsByName = createUniqueAssetIdsByPath(
+    Array.from(assetIdsByPath, ([path, id]) => ({
+      id,
+      path: path.slice(path.lastIndexOf("/") + 1),
+    }))
+  );
   return (url: string) => {
     const path = getRelativeAssetPath({ sourcePath, url });
     return (
       (path === undefined ? undefined : assetIdsByPath.get(path)) ??
+      assetIdsByName.get(getPublishedAssetName(url) ?? "") ??
       (assetIds.has(url) ? url : undefined)
     );
   };


### PR DESCRIPTION
## Summary

Resolve Markdown and frontmatter asset values written as published paths such as `./assets/hero.png` or `/assets/hero.png`, even when the content file and asset live in sibling Asset folders.

This PR supersedes #6016 as the fix for the reported Markdown asset-path problem. #6016 remains closed because its raw-format changes were unrelated.

## Technical approach

- Keep canonical source-relative resolution as the first choice.
- Recognize only the published `assets/<file-name>` path shape as a fallback.
- Match the final canonical asset file name only when it uniquely identifies one project asset.
- Leave external URLs, missing assets, ambiguous names, and unrelated root-relative paths unchanged.
- Reuse the structured-content asset reference pipeline, so Image bindings receive the resolved asset URL without component-specific path manipulation.

## Compatibility

This extends resolution for imported/published Markdown paths without changing ordinary source-relative paths or direct asset ID references. Duplicate final file names intentionally remain unresolved to avoid choosing the wrong asset.

## Checklist

- [x] Add regression coverage for relative and root-relative published asset paths.
- [x] Cover discovery and runtime structured-value resolution.
- [x] Verify ambiguous asset names remain unresolved.
- [x] Run the full content-engine test suite.
- [x] Run content-engine typecheck and targeted lint/format checks.
- [x] Rebuild content runtime and repository fixtures.
- [x] Review documentation impact and update the Assets guide.
- [ ] Confirm CI checks pass.

## Verification

- Regression tests were run before the implementation and failed for the expected unresolved-reference behavior.
- `pnpm --filter @webstudio-is/content-engine test` — 294 tests passed.
- `pnpm --filter @webstudio-is/content-engine typecheck` — passed.
- `pnpm exec oxlint --deny-warnings ...` — passed.
- `pnpm exec oxfmt --check ...` — passed.
- `pnpm --filter webstudio build:content-runtime` — passed.
- `pnpm -r fixtures:build` — passed; no generated fixture diff.
- `git diff --check` — passed.
- Agent evaluations were not run because they require separate explicit approval.

Closes #6093