### PR TITLE
fix: Resolve published asset paths in structured content

### DIFF
--- a/docs/university/foundations/assets.md
+++ b/docs/university/foundations/assets.md
@@ -83,10 +83,16 @@ background image, social image, download link, or another URL property. The
 same resolution works for nested properties and values in arrays. JSON files
 can use relative paths in the same way.
 
+Imported content can also use published asset paths such as
+`./assets/hero.png` or `/assets/hero.png`. Webstudio matches the final file name
+across project Asset folders, so the document and referenced asset do not need
+to share the same folder hierarchy. The file name must identify exactly one
+project asset.
+
 Query strings and fragments are preserved, so values such as
 `./images/hero.png?width=1200#cover` remain usable. Webstudio resolves a value
-only when it uniquely matches a project asset. Absolute URLs, root-relative
-URLs, missing paths, and ambiguous paths remain unchanged.
+only when it uniquely matches a project asset. External URLs, other
+root-relative URLs, missing paths, and ambiguous paths remain unchanged.
 
 ## Organizing assets with folders
 

--- a/packages/content-engine/src/asset-path-resolution.ts
+++ b/packages/content-engine/src/asset-path-resolution.ts
@@ -1,0 +1,116 @@
+import { encodeAssetPathSegment } from "./asset-path";
+
+export const createUniqueAssetIdsByPath = (
+  assets: Iterable<{ id: string; path: string }>
+) => {
+  const ambiguousPaths = new Set<string>();
+  const assetIdsByPath = new Map<string, string>();
+  for (const { id, path } of assets) {
+    if (assetIdsByPath.has(path)) {
+      ambiguousPaths.add(path);
+      assetIdsByPath.delete(path);
+      continue;
+    }
+    if (ambiguousPaths.has(path) === false) {
+      assetIdsByPath.set(path, id);
+    }
+  }
+  return assetIdsByPath;
+};
+
+const getRelativeAssetPath = ({
+  sourcePath,
+  url,
+  allowRootRelative = false,
+}: {
+  sourcePath: string;
+  url: string;
+  allowRootRelative?: boolean;
+}) => {
+  if (
+    url.length === 0 ||
+    url.startsWith("#") ||
+    url.startsWith("?") ||
+    (allowRootRelative === false && url.startsWith("/"))
+  ) {
+    return;
+  }
+  const origin = "https://content.webstudio.invalid";
+  let tokenPrefix = "__webstudio_asset_source_";
+  while (sourcePath.includes(tokenPrefix) || url.includes(tokenPrefix)) {
+    tokenPrefix = `_${tokenPrefix}`;
+  }
+  const sourceSegments = sourcePath.split("/");
+  const sourceSegmentByToken = new Map(
+    sourceSegments.map((segment, index) => [
+      `${tokenPrefix}${index}__`,
+      segment,
+    ])
+  );
+  const sourceUrl = Array.from(sourceSegmentByToken.keys()).join("/");
+  let parsed: URL;
+  try {
+    parsed = new URL(url, new URL(sourceUrl, `${origin}/`));
+  } catch {
+    return;
+  }
+  if (parsed.origin !== origin) {
+    return;
+  }
+  const segments: string[] = [];
+  for (const encodedSegment of parsed.pathname.slice(1).split("/")) {
+    let segment: string;
+    try {
+      segment = decodeURIComponent(encodedSegment);
+    } catch {
+      return;
+    }
+    if (segment === "") {
+      continue;
+    }
+    const sourceSegment = sourceSegmentByToken.get(segment);
+    if (sourceSegment !== undefined) {
+      segments.push(sourceSegment);
+      continue;
+    }
+    if (segment.includes("/")) {
+      return;
+    }
+    segments.push(encodeAssetPathSegment(segment));
+  }
+  return segments.join("/");
+};
+
+const getPublishedAssetName = (url: string) => {
+  const path = getRelativeAssetPath({
+    sourcePath: "document",
+    url,
+    allowRootRelative: true,
+  });
+  const segments = path?.split("/");
+  if (segments?.length !== 2 || segments[0] !== "assets") {
+    return;
+  }
+  return segments[1];
+};
+
+export const createAssetIdResolver = (
+  assetIdsByPath: ReadonlyMap<string, string>,
+  sourcePath: string
+) => {
+  const assetIds = new Set(assetIdsByPath.values());
+  const assetIdsByName = createUniqueAssetIdsByPath(
+    Array.from(assetIdsByPath, ([path, id]) => ({
+      id,
+      path: path.slice(path.lastIndexOf("/") + 1),
+    }))
+  );
+  return (url: string) => {
+    const path = getRelativeAssetPath({ sourcePath, url });
+    return (
+      (path === undefined ? undefined : assetIdsByPath.get(path)) ??
+      assetIdsByName.get(getPublishedAssetName(url) ?? "") ??
+      (assetIds.has(url) ? url : undefined)
+    );
+  };
+};

--- a/packages/content-engine/src/asset-value-references.test.ts
+++ b/packages/content-engine/src/asset-value-references.test.ts
@@ -63,6 +63,47 @@ describe("structured asset value references", () => {
     ]);
   });
 
+  test("resolves published Asset paths from sibling folders", () => {
+    const properties = {
+      relative: "./assets/inception_TDxBrdPwfoJJe_A-k5jhB.png",
+      rootRelative: "/assets/inception_TDxBrdPwfoJJe_A-k5jhB.png",
+    };
+    const references = discoverAssetValueReferences({
+      properties,
+      sourcePath: "blog/posts/inception.md",
+      assetIdsByPath: new Map([
+        ["blog/images/inception_TDxBrdPwfoJJe_A-k5jhB.png", "inception-image"],
+      ]),
+    });
+
+    expect(references).toEqual([
+      {
+        path: ["properties", "relative"],
+        assetId: "inception-image",
+      },
+      {
+        path: ["properties", "rootRelative"],
+        assetId: "inception-image",
+      },
+    ]);
+    expect(
+      resolveAssetValueReferences({
+        value: { properties },
+        references,
+        assetUrls: {
+          "inception-image":
+            "/cgi/image/inception_TDxBrdPwfoJJe_A-k5jhB.png?format=raw",
+        },
+      })
+    ).toEqual({
+      properties: {
+        relative: "/cgi/image/inception_TDxBrdPwfoJJe_A-k5jhB.png?format=raw",
+        rootRelative:
+          "/cgi/image/inception_TDxBrdPwfoJJe_A-k5jhB.png?format=raw",
+      },
+    });
+  });
+
   test("resolves without mutating source values and merges URL suffixes", () => {
     const value = {
       properties: {

--- a/packages/content-engine/src/asset-value-references.test.ts
+++ b/packages/content-engine/src/asset-value-references.test.ts
@@ -70,9 +70,12 @@ describe("structured asset value references", () => {
     };
     const references = discoverAssetValueReferences({
       properties,
-      sourcePath: "blog/posts/inception.md",
+      sourcePath: "content/data/inception.json",
       assetIdsByPath: new Map([
-        ["blog/images/inception_TDxBrdPwfoJJe_A-k5jhB.png", "inception-image"],
+        [
+          "content/images/inception_TDxBrdPwfoJJe_A-k5jhB.png",
+          "inception-image",
+        ],
       ]),
     });
 

--- a/packages/content-engine/src/asset-value-references.ts
+++ b/packages/content-engine/src/asset-value-references.ts
@@ -1,4 +1,4 @@
-import { createAssetIdResolver } from "./markdown-assets";
+import { createAssetIdResolver } from "./asset-path-resolution";
 
 export type AssetValueReference = {
   path: Array<string | number>;

--- a/packages/content-engine/src/content-source.test.ts
+++ b/packages/content-engine/src/content-source.test.ts
@@ -522,7 +522,7 @@ describe("content source snapshots", () => {
     });
     const portrait = createFile({
       id: "portrait",
-      path: "team/assets/portrait.png",
+      path: "team/images/portrait.png",
       contentType: "image/png",
     });
     const source: ContentSource = {

--- a/packages/content-engine/src/content-source.ts
+++ b/packages/content-engine/src/content-source.ts
@@ -10,10 +10,8 @@ import {
   type ContentCompilerInput,
 } from "./asset-index";
 import type { ContentArtifactV1 } from "./schema";
-import {
-  createUniqueAssetIdsByPath,
-  discoverMarkdownAssetReferenceRanges,
-} from "./markdown-assets";
+import { discoverMarkdownAssetReferenceRanges } from "./markdown-assets";
+import { createUniqueAssetIdsByPath } from "./asset-path-resolution";
 import type { MarkdownAssetReferences } from "./markdown-references";
 import {
   discoverAssetValueReferences,

--- a/packages/content-engine/src/markdown-assets.test.ts
+++ b/packages/content-engine/src/markdown-assets.test.ts
@@ -100,6 +100,40 @@ describe("Markdown asset references", () => {
     });
   });
 
+  test("resolves published Asset paths by unique asset name", () => {
+    expect(
+      discoverReferences({
+        sourcePath: "blog/posts/inception.md",
+        markdown: `
+![Relative](./assets/inception_TDxBrdPwfoJJe_A-k5jhB.png)
+![Root relative](/assets/inception_TDxBrdPwfoJJe_A-k5jhB.png)
+        `,
+        assetIdsByPath: new Map([
+          [
+            "blog/images/inception_TDxBrdPwfoJJe_A-k5jhB.png",
+            "inception-image",
+          ],
+        ]),
+      })
+    ).toEqual({
+      "./assets/inception_TDxBrdPwfoJJe_A-k5jhB.png": "inception-image",
+      "/assets/inception_TDxBrdPwfoJJe_A-k5jhB.png": "inception-image",
+    });
+  });
+
+  test("leaves published Asset paths with ambiguous names unresolved", () => {
+    expect(
+      discoverReferences({
+        sourcePath: "blog/posts/article.md",
+        markdown: "![Hero](./assets/hero.png)",
+        assetIdsByPath: new Map([
+          ["blog/images/hero.png", "blog-hero"],
+          ["archive/images/hero.png", "archive-hero"],
+        ]),
+      })
+    ).toEqual({});
+  });
+
   test("preserves encoded dot segments in canonical source folders", () => {
     expect(
       discoverReferences({

--- a/packages/content-engine/src/markdown-assets.ts
+++ b/packages/content-engine/src/markdown-assets.ts
@@ -49,15 +49,17 @@ const getMarkdownUrlTokens = (markdown: string) => {
 const getRelativeAssetPath = ({
   sourcePath,
   url,
+  allowRootRelative = false,
 }: {
   sourcePath: string;
   url: string;
+  allowRootRelative?: boolean;
 }) => {
   if (
     url.length === 0 ||
     url.startsWith("#") ||
     url.startsWith("?") ||
-    url.startsWith("/")
+    (allowRootRelative === false && url.startsWith("/"))
   ) {
     return;
   }
@@ -107,15 +109,35 @@ const getRelativeAssetPath = ({
   return segments.join("/");
 };
 
+const getPublishedAssetName = (url: string) => {
+  const path = getRelativeAssetPath({
+    sourcePath: "document.md",
+    url,
+    allowRootRelative: true,
+  });
+  const segments = path?.split("/");
+  if (segments?.length !== 2 || segments[0] !== "assets") {
+    return;
+  }
+  return segments[1];
+};
+
 export const createAssetIdResolver = (
   assetIdsByPath: ReadonlyMap<string, string>,
   sourcePath: string
 ) => {
   const assetIds = new Set(assetIdsByPath.values());
+  const assetIdsByName = createUniqueAssetIdsByPath(
+    Array.from(assetIdsByPath, ([path, id]) => ({
+      id,
+      path: path.slice(path.lastIndexOf("/") + 1),
+    }))
+  );
   return (url: string) => {
     const path = getRelativeAssetPath({ sourcePath, url });
     return (
       (path === undefined ? undefined : assetIdsByPath.get(path)) ??
+      assetIdsByName.get(getPublishedAssetName(url) ?? "") ??
       (assetIds.has(url) ? url : undefined)
     );
   };

--- a/packages/content-engine/src/markdown-assets.ts
+++ b/packages/content-engine/src/markdown-assets.ts
@@ -1,25 +1,11 @@
 import { parse, postprocess, preprocess } from "micromark";
 import { decodeString } from "micromark-util-decode-string";
-import { createCanonicalAssetPath, encodeAssetPathSegment } from "./asset-path";
+import { createCanonicalAssetPath } from "./asset-path";
+import {
+  createAssetIdResolver,
+  createUniqueAssetIdsByPath,
+} from "./asset-path-resolution";
 import type { MarkdownAssetReference } from "./markdown-references";
-
-export const createUniqueAssetIdsByPath = (
-  assets: Iterable<{ id: string; path: string }>
-) => {
-  const ambiguousPaths = new Set<string>();
-  const assetIdsByPath = new Map<string, string>();
-  for (const { id, path } of assets) {
-    if (assetIdsByPath.has(path)) {
-      ambiguousPaths.add(path);
-      assetIdsByPath.delete(path);
-      continue;
-    }
-    if (ambiguousPaths.has(path) === false) {
-      assetIdsByPath.set(path, id);
-    }
-  }
-  return assetIdsByPath;
-};
 
 const getMarkdownUrlTokens = (markdown: string) => {
   const events = postprocess(
@@ -44,103 +30,6 @@ const getMarkdownUrlTokens = (markdown: string) => {
     });
   }
   return tokens;
-};
-
-const getRelativeAssetPath = ({
-  sourcePath,
-  url,
-  allowRootRelative = false,
-}: {
-  sourcePath: string;
-  url: string;
-  allowRootRelative?: boolean;
-}) => {
-  if (
-    url.length === 0 ||
-    url.startsWith("#") ||
-    url.startsWith("?") ||
-    (allowRootRelative === false && url.startsWith("/"))
-  ) {
-    return;
-  }
-  const origin = "https://content.webstudio.invalid";
-  let tokenPrefix = "__webstudio_asset_source_";
-  while (sourcePath.includes(tokenPrefix) || url.includes(tokenPrefix)) {
-    tokenPrefix = `_${tokenPrefix}`;
-  }
-  const sourceSegments = sourcePath.split("/");
-  const sourceSegmentByToken = new Map(
-    sourceSegments.map((segment, index) => [
-      `${tokenPrefix}${index}__`,
-      segment,
-    ])
-  );
-  const sourceUrl = Array.from(sourceSegmentByToken.keys()).join("/");
-  let parsed: URL;
-  try {
-    parsed = new URL(url, new URL(sourceUrl, `${origin}/`));
-  } catch {
-    return;
-  }
-  if (parsed.origin !== origin) {
-    return;
-  }
-  const segments: string[] = [];
-  for (const encodedSegment of parsed.pathname.slice(1).split("/")) {
-    let segment: string;
-    try {
-      segment = decodeURIComponent(encodedSegment);
-    } catch {
-      return;
-    }
-    if (segment === "") {
-      continue;
-    }
-    const sourceSegment = sourceSegmentByToken.get(segment);
-    if (sourceSegment !== undefined) {
-      segments.push(sourceSegment);
-      continue;
-    }
-    if (segment.includes("/")) {
-      return;
-    }
-    segments.push(encodeAssetPathSegment(segment));
-  }
-  return segments.join("/");
-};
-
-const getPublishedAssetName = (url: string) => {
-  const path = getRelativeAssetPath({
-    sourcePath: "document.md",
-    url,
-    allowRootRelative: true,
-  });
-  const segments = path?.split("/");
-  if (segments?.length !== 2 || segments[0] !== "assets") {
-    return;
-  }
-  return segments[1];
-};
-
-export const createAssetIdResolver = (
-  assetIdsByPath: ReadonlyMap<string, string>,
-  sourcePath: string
-) => {
-  const assetIds = new Set(assetIdsByPath.values());
-  const assetIdsByName = createUniqueAssetIdsByPath(
-    Array.from(assetIdsByPath, ([path, id]) => ({
-      id,
-      path: path.slice(path.lastIndexOf("/") + 1),
-    }))
-  );
-  return (url: string) => {
-    const path = getRelativeAssetPath({ sourcePath, url });
-    return (
-      (path === undefined ? undefined : assetIdsByPath.get(path)) ??
-      assetIdsByName.get(getPublishedAssetName(url) ?? "") ??
-      (assetIds.has(url) ? url : undefined)
-    );
-  };
 };
 
 export const discoverMarkdownAssetReferenceRanges = ({


### PR DESCRIPTION
## Summary

Resolve Markdown frontmatter and JSON values written as published paths such as `./assets/hero.png` or `/assets/hero.png`, even when the content document and asset live in sibling Asset folders.

This staging PR replaces #6094 and supersedes #6016. #6016's raw-format changes were unrelated to the reported asset-path problem.

## Technical approach

- Keep format-neutral path indexing and resolution in `asset-path-resolution.ts`.
- Keep `markdown-assets.ts` limited to Markdown destination parsing.
- Normalize both Markdown frontmatter and JSON objects through the shared structured-value reference pipeline.
- Keep canonical source-relative resolution as the first choice.
- Recognize only the published `assets/<file-name>` path shape as a fallback.
- Match the final canonical asset file name only when it uniquely identifies one project asset.
- Leave external URLs, missing assets, ambiguous names, and unrelated root-relative paths unchanged.
- Resolve recorded asset references to runtime URLs when queries render their results.

## Compatibility

This extends resolution for imported/published structured content without changing ordinary source-relative paths or direct asset ID references. Duplicate final file names intentionally remain unresolved to avoid choosing the wrong asset.

## Checklist

- [x] Add regression coverage for relative and root-relative published asset paths.
- [x] Cover discovery and runtime structured-value resolution.
- [x] Add explicit JSON document coverage with the asset in a sibling folder.
- [x] Verify ambiguous asset names remain unresolved.
- [x] Separate format-neutral resolution from Markdown parsing.
- [x] Run the full content-engine test suite.
- [x] Run content-engine typecheck and targeted lint/format checks.
- [x] Rebuild content runtime and repository fixtures.
- [x] Review documentation impact and update the Assets guide.
- [ ] Manually verify the published site from `md-assets.staging`.
- [ ] Confirm CI checks pass.

## Verification

- Regression tests were run with the published-path fallback disabled and failed for both generic structured values and the explicit JSON integration case.
- `pnpm --filter @webstudio-is/content-engine test` — 294 tests passed.
- `pnpm --filter @webstudio-is/content-engine typecheck` — passed.
- `pnpm exec oxlint --deny-warnings ...` — passed.
- `pnpm exec oxfmt --check ...` — passed.
- `pnpm --filter webstudio build:content-runtime` — passed.
- `pnpm -r fixtures:build` — passed; no generated fixture diff.
- `git diff --check` — passed.
- Agent evaluations were not run because they require separate explicit approval.

Closes #6093