### PR TITLE
fix: Preserve SSG template file URL

### DIFF
--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -101,6 +101,7 @@ import { createFramework as createRemixFramework } from "./framework-remix";
 import { createFramework as createReactRouterFramework } from "./framework-react-router";
 import { createFramework as createVikeSsgFramework } from "./framework-vike-ssg";
 import { routeTemplatesDirectory } from "./framework";
+import { readSsgAssetResourceFetchTemplate } from "./ssg-asset-resource-fetch-template";
 
 export const generatedFilesManifest = join(
   ".webstudio",
@@ -111,10 +112,6 @@ const contentRuntimeBundleUrl = new URL(
   import.meta.url
 );
 const contentRuntimeFile = "$resources.asset-query-vendor.js";
-const ssgAssetResourceFetchTemplateUrl = new URL(
-  "../templates/ssg/app/asset-resource-fetch.ts",
-  import.meta.url
-);
 const appRoot = "app";
 const generatedDir = join(appRoot, "__generated__");
 const routesDir = join(appRoot, "routes");
@@ -496,7 +493,7 @@ const configureSsgAssetResourceFetch = async ({
   const ssgFetchPath = join(cwd(), "app", "asset-resource-fetch.ts");
   if (existsSync(ssgFetchPath)) {
     const content = enabled
-      ? await readFile(ssgAssetResourceFetchTemplateUrl, "utf8")
+      ? await readSsgAssetResourceFetchTemplate()
       : `export const createSsgAssetResourceFetch = (_options: unknown) =>
   async (_input: RequestInfo | URL, _init?: RequestInit) => undefined;\n`;
     await writeFileIfChanged(ssgFetchPath, content);

--- a/packages/cli/src/ssg-asset-resource-fetch-template.test.ts
+++ b/packages/cli/src/ssg-asset-resource-fetch-template.test.ts
@@ -1,0 +1,70 @@
+import { cp, mkdir, mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { pathToFileURL } from "node:url";
+import { afterEach, expect, test } from "vitest";
+import { build } from "vite";
+
+const packageRoot = join(import.meta.dirname, "..");
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryDirectories
+      .splice(0)
+      .map((directory) => rm(directory, { recursive: true, force: true }))
+  );
+});
+
+test("reads the SSG asset resource fetch template from the bundled CLI package", async () => {
+  const temporaryDirectory = await mkdtemp(
+    join(tmpdir(), "webstudio-ssg-template-")
+  );
+  temporaryDirectories.push(temporaryDirectory);
+  const outputDirectory = join(temporaryDirectory, "package", "lib");
+  const templatePath = join(
+    "templates",
+    "ssg",
+    "app",
+    "asset-resource-fetch.ts"
+  );
+  await mkdir(dirname(join(temporaryDirectory, "package", templatePath)), {
+    recursive: true,
+  });
+  await cp(
+    join(packageRoot, templatePath),
+    join(temporaryDirectory, "package", templatePath)
+  );
+
+  await build({
+    configFile: false,
+    logLevel: "silent",
+    build: {
+      target: "node22",
+      outDir: outputDirectory,
+      emptyOutDir: false,
+      lib: {
+        entry: join(packageRoot, "src", "ssg-asset-resource-fetch-template.ts"),
+        formats: ["es"],
+        fileName: "template-reader",
+      },
+      rollupOptions: {
+        external: ["node:fs/promises"],
+      },
+    },
+  });
+
+  const bundledModule = (await import(
+    `${pathToFileURL(join(outputDirectory, "template-reader.js"))}?test=${crypto.randomUUID()}`
+  )) as {
+    readSsgAssetResourceFetchTemplate: () => Promise<string>;
+  };
+  const expectedTemplate = await readFile(
+    join(packageRoot, templatePath),
+    "utf8"
+  );
+
+  await expect(bundledModule.readSsgAssetResourceFetchTemplate()).resolves.toBe(
+    expectedTemplate
+  );
+});

--- a/packages/cli/src/ssg-asset-resource-fetch-template.ts
+++ b/packages/cli/src/ssg-asset-resource-fetch-template.ts
@@ -1,0 +1,9 @@
+import { readFile } from "node:fs/promises";
+
+const templateUrl = new URL(
+  /* @vite-ignore */ "../templates/ssg/app/asset-resource-fetch.ts",
+  import.meta.url
+);
+
+export const readSsgAssetResourceFetchTemplate = () =>
+  readFile(templateUrl, "utf8");


### PR DESCRIPTION
## What changed

- Read the SSG asset resource fetch template through a package-relative file URL that Vite preserves in the CLI bundle.
- Add a focused bundling regression test that packages the real template reader and verifies it can read the installed template.

## Why

Vite recognized the static `new URL("../templates/ssg/app/asset-resource-fetch.ts", import.meta.url)` expression as an asset import. Because the template is small, Vite inlined it as a `data:video/mp2t` URL. During an SSG export with an Assets query, Node passed that URL to `readFile` and threw `ERR_INVALID_URL_SCHEME`.

The template URL now uses Vite's preserve annotation, matching the CLI's other package-relative runtime files, so the bundled CLI resolves the template from the installed package.

## Impact

SSG exports that use Assets queries can scaffold the generated asset resource fetch module. Projects without Assets queries keep the existing fallback behavior.

## Todo

- [x] Reproduce the invalid URL scheme through a bundled template reader.
- [x] Preserve the package-relative template URL in the production CLI bundle.
- [x] Add and verify regression coverage.
- [x] Run CLI tests, typecheck, lint, and build.
- [x] Review documentation impact; no user-facing documentation changes are needed.
- [x] Review fixture impact; no fixture inputs or generated fixture outputs are affected.

## Verification

- `pnpm --filter webstudio test` — 61 files, 977 tests passed
- `pnpm --filter webstudio typecheck`
- `pnpm lint`
- `pnpm --filter webstudio build`
- Regression test confirmed failing with `ERR_INVALID_URL_SCHEME` before the fix and passing after it.
- Built `lib/cli.js` inspected to confirm the template remains a package-relative URL instead of a `data:` URL.

Closes #6100