### PR TITLE
fix: Refresh resource diagnostics metadata

### DIFF
--- a/apps/builder/app/builder/features/settings-panel/content-database-diagnostics-view.test.tsx
+++ b/apps/builder/app/builder/features/settings-panel/content-database-diagnostics-view.test.tsx
@@ -132,7 +132,7 @@ test("orders collapsible sections and opens only database sizes by default", () 
   const sectionLabels = [
     "Database and sizes",
     "Timing",
-    "Query work",
+    "Assets batch work",
     "Query database",
     "Published database",
     "Unresolved query result",
@@ -209,7 +209,7 @@ test("orders collapsible sections and opens only database sizes by default", () 
   expect(container.textContent).toContain("Compilation workCompiled");
   expect(container.textContent).toContain("Resolved documents2");
   expect(container.textContent).toContain("Timing");
-  expect(container.textContent).toContain("Query work");
+  expect(container.textContent).toContain("Assets batch work");
   expect(container.textContent).toContain("Database and sizes");
   expect(container.querySelectorAll('svg[tabindex="0"]')).toHaveLength(26);
 });

--- a/apps/builder/app/builder/features/settings-panel/content-database-diagnostics.tsx
+++ b/apps/builder/app/builder/features/settings-panel/content-database-diagnostics.tsx
@@ -18,12 +18,15 @@ import {
 } from "~/builder/shared/collapsible-section";
 import {
   RequestDiagnosticsRow,
-  RequestDiagnosticsSections,
+  RequestDiagnosticsContent,
   RequestDiagnosticsTable,
 } from "./request-inspector";
 
 const runtimeContentNote =
   "Referenced documents fetched from storage at runtime are not included.";
+
+const assetBatchTimingNote =
+  "When one Builder request contains multiple Assets resources, this duration covers their combined batch.";
 
 const assetQueryPhaseRows = [
   [
@@ -203,14 +206,14 @@ const PerformanceSizeRows = ({ value }: { value: ResourcePerformance }) => (
       <RequestDiagnosticsRow
         label="Compiler content read"
         value={prettyBytes(value.assetQuery.compilerContentBytes)}
-        description="Total bytes read from storage while preparing compiler entries."
+        description="Total bytes read from storage while preparing compiler entries for the Assets batch."
       />
     )}
     {value.assetQuery?.documentGraphContentBytes !== undefined && (
       <RequestDiagnosticsRow
         label="Document graph content read"
         value={prettyBytes(value.assetQuery.documentGraphContentBytes)}
-        description="Total bytes read from storage while constructing the document graph."
+        description="Total bytes read from storage while constructing document graphs for the Assets batch."
       />
     )}
   </>
@@ -222,6 +225,9 @@ const getPerformanceSizes = (value?: ResourcePerformance) => ({
   documentGraphContentBytes: value?.assetQuery?.documentGraphContentBytes,
 });
 
+const hasDefinedValue = (value: Record<string, unknown>) =>
+  Object.values(value).some((item) => item !== undefined);
+
 const ResourcePerformanceSections = ({
   value,
   includeSizes = true,
@@ -231,21 +237,7 @@ const ResourcePerformanceSections = ({
   includeSizes?: boolean;
   openFirst?: boolean;
 }) => {
-  const hasTiming =
-    value.loaderDurationMs !== undefined ||
-    value.serverDurationMs !== undefined ||
-    assetQueryPhaseRows.some(
-      ([key]) => value.assetQuery?.phases?.[key] !== undefined
-    );
-  const hasQueryWork =
-    value.assetQuery?.compilationCache !== undefined ||
-    value.assetQuery?.compilerContentFetchCount !== undefined ||
-    value.assetQuery?.documentGraphContentFetchCount !== undefined ||
-    value.assetQuery?.resolvedDocumentCount !== undefined ||
-    value.assetQuery?.documentFetchCount !== undefined;
   const sizes = getPerformanceSizes(value);
-  const hasSizes =
-    includeSizes && Object.values(sizes).some((size) => size !== undefined);
   const timing = {
     builderRoundTripMs: value.loaderDurationMs,
     serverDurationMs: value.serverDurationMs,
@@ -259,6 +251,12 @@ const ResourcePerformanceSections = ({
     resolvedDocumentCount: value.assetQuery?.resolvedDocumentCount,
     documentFetchCount: value.assetQuery?.documentFetchCount,
   };
+  const hasSizes = includeSizes && hasDefinedValue(sizes);
+  const hasTiming =
+    timing.builderRoundTripMs !== undefined ||
+    timing.serverDurationMs !== undefined ||
+    hasDefinedValue(timing.phases ?? {});
+  const hasQueryWork = hasDefinedValue(queryWork);
   return (
     <>
       {hasSizes && (
@@ -299,7 +297,7 @@ const ResourcePerformanceSections = ({
                   key={key}
                   label={label}
                   value={`${durationMs.toFixed(1)} ms`}
-                  description={description}
+                  description={`${description} ${assetBatchTimingNote}`}
                 />
               );
             })}
@@ -308,7 +306,7 @@ const ResourcePerformanceSections = ({
       )}
       {hasQueryWork && (
         <DiagnosticsSection
-          label="Query work"
+          label="Assets batch work"
           data={queryWork}
           isOpen={openFirst && hasSizes === false && hasTiming === false}
         >
@@ -317,35 +315,35 @@ const ResourcePerformanceSections = ({
               <RequestDiagnosticsRow
                 label="Compilation work"
                 value={compilationWorkLabels[value.assetQuery.compilationCache]}
-                description="Whether this Assets request reused an artifact compiled earlier in the same request, joined matching in-progress work, compiled it on a miss, or ran with reuse disabled."
+                description="Whether this Assets batch reused an artifact compiled earlier in the same request, joined matching in-progress work, compiled it on a miss, or ran with reuse disabled."
               />
             )}
             {value.assetQuery?.compilerContentFetchCount !== undefined && (
               <RequestDiagnosticsRow
                 label="Compiler content fetches"
                 value={value.assetQuery.compilerContentFetchCount}
-                description="Number of asset contents read from storage while preparing compiler entries."
+                description="Number of asset contents read from storage while preparing compiler entries for the Assets batch."
               />
             )}
             {value.assetQuery?.documentGraphContentFetchCount !== undefined && (
               <RequestDiagnosticsRow
                 label="Document graph content fetches"
                 value={value.assetQuery.documentGraphContentFetchCount}
-                description="Number of document contents read from storage while constructing the document graph."
+                description="Number of document contents read from storage while constructing document graphs for the Assets batch."
               />
             )}
             {value.assetQuery?.resolvedDocumentCount !== undefined && (
               <RequestDiagnosticsRow
                 label="Resolved documents"
                 value={value.assetQuery.resolvedDocumentCount}
-                description="Number of query result documents passed through document-reference resolution."
+                description="Number of query result documents passed through document-reference resolution across the Assets batch."
               />
             )}
             {value.assetQuery?.documentFetchCount !== undefined && (
               <RequestDiagnosticsRow
                 label="Document fetches"
                 value={value.assetQuery.documentFetchCount}
-                description="Number of referenced documents loaded while resolving the query result, including request-local byte reuse."
+                description="Number of referenced documents loaded while resolving the Assets batch, including request-local byte reuse."
               />
             )}
           </RequestDiagnosticsTable>
@@ -360,9 +358,9 @@ export const ResourcePerformanceDiagnostics = ({
 }: {
   value: ResourcePerformance;
 }) => (
-  <RequestDiagnosticsSections>
+  <RequestDiagnosticsContent padded={false}>
     <ResourcePerformanceSections value={value} />
-  </RequestDiagnosticsSections>
+  </RequestDiagnosticsContent>
 );
 
 export const ContentDatabaseDiagnostics = ({
@@ -388,7 +386,7 @@ export const ContentDatabaseDiagnostics = ({
     database: value.database,
   };
   return (
-    <RequestDiagnosticsSections>
+    <RequestDiagnosticsContent padded={false}>
       <DiagnosticsSection
         label="Database and sizes"
         data={databaseAndSizes}
@@ -479,6 +477,6 @@ export const ContentDatabaseDiagnostics = ({
           <ReadonlyJsonEditor value={value.unresolved} />
         </DiagnosticsSection>
       )}
-    </RequestDiagnosticsSections>
+    </RequestDiagnosticsContent>
   );
 };

--- a/apps/builder/app/builder/features/settings-panel/request-inspector.tsx
+++ b/apps/builder/app/builder/features/settings-panel/request-inspector.tsx
@@ -21,23 +21,19 @@ export const clearSettledDiagnosticsKey = (
 
 export const RequestDiagnosticsContent = ({
   children,
+  padded = true,
 }: {
   children: ReactNode;
+  padded?: boolean;
 }) => (
   <ScrollAreaNative css={{ height: "100%", overflow: "auto" }}>
-    <Flex direction="column" gap={3} css={{ padding: theme.panel.padding }}>
-      {children}
-    </Flex>
-  </ScrollAreaNative>
-);
-
-export const RequestDiagnosticsSections = ({
-  children,
-}: {
-  children: ReactNode;
-}) => (
-  <ScrollAreaNative css={{ height: "100%", overflow: "auto" }}>
-    {children}
+    {padded ? (
+      <Flex direction="column" gap={3} css={{ padding: theme.panel.padding }}>
+        {children}
+      </Flex>
+    ) : (
+      children
+    )}
   </ScrollAreaNative>
 );
 

--- a/apps/builder/app/shared/resource-diagnostics.test.ts
+++ b/apps/builder/app/shared/resource-diagnostics.test.ts
@@ -117,4 +117,31 @@ describe("resource diagnostics", () => {
     expect(separated.result).toEqual({ data: { items: [] } });
     expect(separated.performance).toBeUndefined();
   });
+
+  test("preserves known performance metrics when the server adds fields", () => {
+    const separated = separateResourceDiagnostics({
+      request: assetsRequest,
+      result: {
+        data: { items: [] },
+        __performance__: {
+          serverDurationMs: 125.5,
+          futureMetric: 10,
+          assetQuery: {
+            futureMetric: 20,
+            phases: {
+              buildPlan: 30,
+              futurePhase: 40,
+            },
+          },
+        },
+      },
+    });
+
+    expect(separated.performance).toEqual({
+      serverDurationMs: 125.5,
+      assetQuery: {
+        phases: { buildPlan: 30 },
+      },
+    });
+  });
 });

--- a/apps/builder/app/shared/resource-diagnostics.ts
+++ b/apps/builder/app/shared/resource-diagnostics.ts
@@ -3,14 +3,14 @@ import type { ResourceRequest } from "@webstudio-is/sdk";
 import { isAssetsResourceRequest } from "@webstudio-is/sdk/runtime";
 import { z } from "zod";
 
-export const resourcePerformance = z.strictObject({
+export const resourcePerformance = z.object({
   serverDurationMs: z.number().nonnegative().optional(),
   loaderDurationMs: z.number().nonnegative().optional(),
   responseBytes: z.number().int().nonnegative().optional(),
   assetQuery: z
-    .strictObject({
+    .object({
       phases: z
-        .strictObject({
+        .object({
           authorization: z.number().nonnegative().optional(),
           buildPlan: z.number().nonnegative().optional(),
           repositoryAuthorization: z.number().nonnegative().optional(),

--- a/apps/builder/app/shared/resources.test.ts
+++ b/apps/builder/app/shared/resources.test.ts
@@ -40,10 +40,14 @@ test("removes obsolete queued requests but keeps cached results", () => {
   $resourcesCache.get().set(key, { stale: true });
   expect($hasPendingResources.get()).toBe(true);
 
+  const resourceCacheListener = vi.fn();
+  const unlisten = $resourcesCache.listen(resourceCacheListener);
   queueResources([]);
 
   expect($resourcesCache.get().has(key)).toBe(true);
   expect($hasPendingResources.get()).toBe(false);
+  expect(resourceCacheListener).not.toHaveBeenCalled();
+  unlisten();
 });
 
 test("dispatches resources synchronously", async () => {
@@ -406,7 +410,7 @@ test("drains bounded batches without an additional delay", async () => {
   expect(JSON.parse(String(fetch.mock.calls[1][1]?.body))).toHaveLength(1);
 });
 
-test("loads detailed Assets diagnostics only on demand", async () => {
+test("loads detailed Assets diagnostics and performance only on demand", async () => {
   const request: ResourceRequest = {
     name: "assets",
     method: "post",
@@ -437,8 +441,24 @@ test("loads detailed Assets diagnostics only on demand", async () => {
     unresolved: { items: [], totalCount: 0, hasMore: false },
   };
   const fetch = vi.fn<typeof globalThis.fetch>(async () =>
-    Response.json([[key, { data: {}, __diagnostics__: diagnostics }]])
+    Response.json([
+      [
+        key,
+        {
+          data: {},
+          __diagnostics__: diagnostics,
+          __performance__: {
+            serverDurationMs: 75,
+            assetQuery: {
+              phases: { diagnosticsPreparation: 50 },
+            },
+          },
+        },
+      ],
+    ])
   );
+  const resourceCacheListener = vi.fn();
+  const unlisten = $resourcesCache.listen(resourceCacheListener);
 
   const first = loadResourceDiagnostics(request, fetch);
   const second = loadResourceDiagnostics(request, fetch);
@@ -451,6 +471,15 @@ test("loads detailed Assets diagnostics only on demand", async () => {
   );
   expect(fetch).toHaveBeenCalledOnce();
   expect($resourceDiagnosticsCache.get().get(key)).toEqual(diagnostics);
+  expect($resourcePerformanceCache.get().get(key)).toMatchObject({
+    serverDurationMs: 75,
+    loaderDurationMs: expect.any(Number),
+    assetQuery: {
+      phases: { diagnosticsPreparation: 50 },
+    },
+  });
+  expect(resourceCacheListener).not.toHaveBeenCalled();
+  unlisten();
 });
 
 test("caches performance metrics separately from resource values", async () => {
@@ -502,10 +531,16 @@ test("discards stale diagnostics after invalidation", async () => {
   const firstResponse = new Promise<Response>((resolve) => {
     resolveFirst = resolve;
   });
-  const firstFetch = vi.fn<typeof globalThis.fetch>(() => firstResponse);
+  let firstSignal: AbortSignal | undefined;
+  const firstFetch = vi.fn<typeof globalThis.fetch>((_input, init) => {
+    firstSignal = init?.signal ?? undefined;
+    return firstResponse;
+  });
   const first = loadResourceDiagnostics(request, firstFetch);
+  await Promise.resolve();
 
   queueInvalidatedResource(request);
+  expect(firstSignal?.aborted).toBe(true);
   const freshDiagnostics = {
     scope: "query-preview",
     query: {
@@ -538,6 +573,79 @@ test("discards stale diagnostics after invalidation", async () => {
   await second;
 
   expect($resourceDiagnosticsCache.get().get(key)).toEqual(freshDiagnostics);
+});
+
+test("does not retain a diagnostics request after a synchronous fetch failure", async () => {
+  const request: ResourceRequest = {
+    name: "assets",
+    method: "post",
+    url: "/$resources/assets",
+    searchParams: [],
+    headers: [],
+    body: { query: {} },
+  };
+  const error = vi.spyOn(console, "error").mockImplementation(() => {});
+  const fetch = vi.fn<typeof globalThis.fetch>(() => {
+    throw new Error("failed synchronously");
+  });
+
+  await loadResourceDiagnostics(request, fetch);
+  await loadResourceDiagnostics(request, fetch);
+
+  expect(fetch).toHaveBeenCalledTimes(2);
+  error.mockRestore();
+});
+
+test("discards detailed diagnostics that settle after reset", async () => {
+  const request: ResourceRequest = {
+    name: "assets",
+    method: "post",
+    url: "/$resources/assets",
+    searchParams: [],
+    headers: [],
+    body: { query: {} },
+  };
+  const key = getResourceKey(request);
+  let resolveResponse: (response: Response) => void = () => {};
+  const response = new Promise<Response>((resolve) => {
+    resolveResponse = resolve;
+  });
+  const fetch = vi.fn<typeof globalThis.fetch>(() => response);
+  const pending = loadResourceDiagnostics(request, fetch);
+
+  reset();
+  resolveResponse(
+    Response.json([
+      [
+        key,
+        {
+          data: {},
+          __diagnostics__: {
+            scope: "query-preview",
+            query: {
+              usedBytes: 1,
+              maxBytes: 1,
+              unboundedBytes: 1,
+              includedDocumentCount: 1,
+              omittedDocumentCount: 0,
+              truncated: false,
+            },
+            database: {
+              usedBytes: 1,
+              maxBytes: 1,
+              unboundedBytes: 1,
+              includedDocumentCount: 1,
+              omittedDocumentCount: 0,
+              truncated: false,
+            },
+          },
+        },
+      ],
+    ])
+  );
+  await pending;
+
+  expect($resourceDiagnosticsCache.get().has(key)).toBe(false);
 });
 
 test("keeps loading distinct from a confirmed empty Assets result", async () => {

--- a/apps/builder/app/shared/resources.ts
+++ b/apps/builder/app/shared/resources.ts
@@ -16,6 +16,11 @@ type InFlightResourceBatch = {
   versions: Map<string, number>;
 };
 
+type InFlightResourceDiagnostics = {
+  controller: AbortController;
+  promise: Promise<void>;
+};
+
 export { getResourceKey };
 
 const queue = new Map<string, ResourceRequest>();
@@ -23,7 +28,7 @@ const pending = new Map<string, InFlightResourceBatch>();
 const cache = new Map<string, unknown>();
 const diagnosticsCache = new Map<string, AssetQueryPreviewDiagnostics>();
 const performanceCache = new Map<string, ResourcePerformance>();
-const pendingDiagnostics = new Map<string, Promise<void>>();
+const pendingDiagnostics = new Map<string, InFlightResourceDiagnostics>();
 const knownRequests = new Map<string, ResourceRequest>();
 const resourceVersions = new Map<string, number>();
 const inFlightBatches = new Set<InFlightResourceBatch>();
@@ -32,10 +37,38 @@ export const $resourcesCache = atom(cache);
 export const $resourceDiagnosticsCache = atom(diagnosticsCache);
 export const $resourcePerformanceCache = atom(performanceCache);
 
-const updateCache = () => {
-  $resourcesCache.set(new Map(cache));
+const updateMetadataCache = () => {
   $resourceDiagnosticsCache.set(new Map(diagnosticsCache));
   $resourcePerformanceCache.set(new Map(performanceCache));
+};
+
+const updateCache = () => {
+  $resourcesCache.set(new Map(cache));
+  updateMetadataCache();
+};
+
+const cacheResourceMetadata = ({
+  key,
+  request,
+  result,
+  loaderDurationMs,
+}: {
+  key: string;
+  request: ResourceRequest;
+  result: unknown;
+  loaderDurationMs: number;
+}) => {
+  const separated = separateResourceDiagnostics({ request, result });
+  performanceCache.set(key, {
+    ...separated.performance,
+    loaderDurationMs: Math.max(0, loaderDurationMs),
+  });
+  if (separated.diagnostics === undefined) {
+    diagnosticsCache.delete(key);
+  } else {
+    diagnosticsCache.set(key, separated.diagnostics);
+  }
+  return separated.result;
 };
 
 const $pendingUpdater = atom({});
@@ -94,17 +127,15 @@ const loadResources = async (requestFetch: typeof fetch = fetch) => {
       ) {
         continue;
       }
-      const separated = separateResourceDiagnostics({ request, result });
-      cache.set(key, separated.result);
-      performanceCache.set(key, {
-        ...separated.performance,
-        loaderDurationMs,
-      });
-      if (separated.diagnostics === undefined) {
-        diagnosticsCache.delete(key);
-      } else {
-        diagnosticsCache.set(key, separated.diagnostics);
-      }
+      cache.set(
+        key,
+        cacheResourceMetadata({
+          key,
+          request,
+          result,
+          loaderDurationMs,
+        })
+      );
     }
   } catch {
     if (controller.signal.aborted === false) {
@@ -163,6 +194,7 @@ const preloadResource = (resource: ResourceRequest) => {
 const invalidateRequestState = (key: string) => {
   diagnosticsCache.delete(key);
   performanceCache.delete(key);
+  pendingDiagnostics.get(key)?.controller.abort();
   pendingDiagnostics.delete(key);
   resourceVersions.set(key, (resourceVersions.get(key) ?? 0) + 1);
 };
@@ -182,7 +214,7 @@ const queueResources = (resources: readonly ResourceRequest[]) => {
   }
   abortObsoleteBatches();
   if (diagnosticsChanged) {
-    updateCache();
+    updateMetadataCache();
   }
   if (pendingChanged) {
     updatePending();
@@ -229,44 +261,54 @@ export const loadResourceDiagnostics = (
   const key = getResourceKey(resource);
   const existing = pendingDiagnostics.get(key);
   if (existing !== undefined) {
-    return existing;
+    return existing.promise;
   }
   const version = resourceVersions.get(key) ?? 0;
-  const promise = (async () => {
+  const controller = new AbortController();
+  const promise = Promise.resolve().then(async () => {
     try {
+      if (controller.signal.aborted) {
+        return;
+      }
+      const startedAt = performance.now();
       const response = await requestFetch(
         restResourcesLoader({ diagnostics: true }),
         {
           method: "POST",
           body: JSON.stringify([resource]),
+          signal: controller.signal,
         }
       );
       if (response.ok === false) {
         return;
       }
       const result = new Map<string, unknown>(await response.json()).get(key);
-      const { diagnostics } = separateResourceDiagnostics({
-        request: resource,
-        result,
-      });
-      if ((resourceVersions.get(key) ?? 0) !== version) {
+      const loaderDurationMs = performance.now() - startedAt;
+      if (
+        controller.signal.aborted ||
+        pendingDiagnostics.get(key)?.controller !== controller ||
+        (resourceVersions.get(key) ?? 0) !== version
+      ) {
         return;
       }
-      if (diagnostics === undefined) {
-        diagnosticsCache.delete(key);
-      } else {
-        diagnosticsCache.set(key, diagnostics);
-      }
-      updateCache();
+      cacheResourceMetadata({
+        key,
+        request: resource,
+        result,
+        loaderDurationMs,
+      });
+      updateMetadataCache();
     } catch {
-      console.error("Resource diagnostics request failed");
+      if (controller.signal.aborted === false) {
+        console.error("Resource diagnostics request failed");
+      }
     } finally {
-      if ((resourceVersions.get(key) ?? 0) === version) {
+      if (pendingDiagnostics.get(key)?.controller === controller) {
         pendingDiagnostics.delete(key);
       }
     }
-  })();
-  pendingDiagnostics.set(key, promise);
+  });
+  pendingDiagnostics.set(key, { controller, promise });
   return promise;
 };
 
@@ -320,6 +362,9 @@ const reset = () => {
   cache.clear();
   diagnosticsCache.clear();
   performanceCache.clear();
+  for (const { controller } of pendingDiagnostics.values()) {
+    controller.abort();
+  }
   pendingDiagnostics.clear();
   knownRequests.clear();
   resourceVersions.clear();

--- a/packages/asset-uploader/src/asset-repository.ts
+++ b/packages/asset-uploader/src/asset-repository.ts
@@ -398,6 +398,12 @@ export class PostgresAssetRepository implements AssetRepository {
     await this.assertPermit("view", "view this project assets");
   }
 
+  private async assertCanViewWithPerformance() {
+    await this.measurePerformance("repository-authorization", () =>
+      this.assertCanView()
+    );
+  }
+
   private async assertCanBuild() {
     // Index preparation only reads asset data and produces a derived artifact.
     // Callers that perform an actual build or publish enforce the stronger
@@ -405,9 +411,7 @@ export class PostgresAssetRepository implements AssetRepository {
     if (this.context.authorization?.type === "service") {
       return;
     }
-    await this.measurePerformance("repository-authorization", () =>
-      this.assertCanView()
-    );
+    await this.assertCanViewWithPerformance();
   }
 
   private getWritableStore(): AssetObjectStore {
@@ -1081,9 +1085,7 @@ export class PostgresAssetRepository implements AssetRepository {
     if (requests.length === 0) {
       return [];
     }
-    await this.measurePerformance("repository-authorization", () =>
-      this.assertCanView()
-    );
+    await this.assertCanViewWithPerformance();
     signal?.throwIfAborted();
     const executeIndividually = (request: AssetQueryRequestInput) =>
       this.queryAfterAuthorization(request, {
@@ -1246,9 +1248,7 @@ export class PostgresAssetRepository implements AssetRepository {
     request: AssetQueryRequestInput,
     options: AssetQueryPreviewOptions = {}
   ): Promise<AssetQueryExecutionPreviewResult | AssetQueryResultOnly> {
-    await this.measurePerformance("repository-authorization", () =>
-      this.assertCanView()
-    );
+    await this.assertCanViewWithPerformance();
     return await this.queryAfterAuthorization(request, options);
   }
 


### PR DESCRIPTION
## Summary

Follow up on #6095 so explicit Diagnostics refreshes update both diagnostic and performance metadata, stale refreshes are cancelled during invalidation, and Assets batch measurements are labeled consistently in the Builder.

Ref #6092

## Technical choices

- Cache response diagnostics and performance metadata through one shared path.
- Attach an AbortController to each explicit diagnostics request and reject stale results after invalidation.
- Accept additive performance fields from newer servers.
- Clarify that Assets timings and counters cover the combined batch.
- Reuse the measured view-authorization path across repository entry points.

## Implementation checklist

- [x] Refresh performance metadata with explicit diagnostics.
- [x] Cancel and ignore stale diagnostics requests.
- [x] Keep performance parsing forward-compatible with additive fields.
- [x] Clarify Assets batch labels and descriptions.
- [x] Add regression coverage for refresh, invalidation, and parsing behavior.
- [x] Review documentation impact — authoritative `docs/` does not cover this internal Diagnostics tooling, so no update is required.
- [ ] Run affected Builder and asset-uploader typechecks.
- [ ] Confirm GitHub checks pass.

## Verification

- Builder diagnostics/resource tests: 27 passed.
- Asset repository tests: 39 passed.
- `git diff --check origin/main...HEAD` — passed.