### PR TITLE
fix: Publish docs independently of release smoke

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,9 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
+    outputs:
+      registry_baseline: ${{ steps.registry-baseline.outputs.value }}
+      version: ${{ steps.version.outputs.value }}
     permissions:
       contents: write
     environment:
@@ -119,15 +122,32 @@ jobs:
           echo "Exact registry artifact webstudio@$VERSION was not observable with integrity metadata." >&2
           exit 1
 
-      - name: Gate exact published CLI against baseline
+  release-smoke:
+    needs: publish
+    timeout-minutes: 20
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    environment:
+      name: development
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }} # tag name
+      - uses: ./.github/actions/submodules-checkout
+        with:
+          submodules-ssh-key: ${{ secrets.PRIVATE_GITHUB_DEPLOY_TOKEN }}
+      - uses: ./.github/actions/ci-setup
+
+      - name: Verify exact published CLI against baseline
         id: registry-smoke
         env:
           DATABASE_URL: postgres://
           AUTH_SECRET: test
           WEBSTUDIO_RELEASE_SMOKE_TOKEN_BUDGET: 6000
-          WEBSTUDIO_RELEASE_SMOKE_CANDIDATE: webstudio@${{ steps.version.outputs.value }}
-          WEBSTUDIO_RELEASE_SMOKE_BASELINE: webstudio@${{ steps.registry-baseline.outputs.value }}
-          WEBSTUDIO_RELEASE_SMOKE_EXPECT_REGISTRY_VERSION: ${{ steps.version.outputs.value }}
+          WEBSTUDIO_RELEASE_SMOKE_CANDIDATE: webstudio@${{ needs.publish.outputs.version }}
+          WEBSTUDIO_RELEASE_SMOKE_BASELINE: webstudio@${{ needs.publish.outputs.registry_baseline }}
+          WEBSTUDIO_RELEASE_SMOKE_EXPECT_REGISTRY_VERSION: ${{ needs.publish.outputs.version }}
           WEBSTUDIO_RELEASE_SMOKE_REPORT: ${{ github.workspace }}/artifacts/cli-release-smoke.json
         run: pnpm --filter webstudio test:release-smoke:registry
 
@@ -135,7 +155,7 @@ jobs:
         if: ${{ always() && (steps.registry-smoke.outcome == 'success' || steps.registry-smoke.outcome == 'failure') }}
         uses: actions/upload-artifact@v4
         with:
-          name: cli-release-smoke-${{ steps.version.outputs.value }}
+          name: cli-release-smoke-${{ needs.publish.outputs.version }}
           path: artifacts/cli-release-smoke.json
           if-no-files-found: error
 

--- a/packages/cli/scripts/release-smoke.ts
+++ b/packages/cli/scripts/release-smoke.ts
@@ -64,10 +64,10 @@ const createdPageInputs = [
 ] as const;
 const additionalPageCount = 1 + createdPageInputs.length;
 const agentSmokeClients = [
-  { connect: "claude", name: "claude-code" },
-  { connect: "codex", name: "codex" },
-  { connect: "cursor", name: "cursor" },
-  { connect: "vscode", name: "vscode" },
+  { connect: "claude", name: "claude-code", print: false },
+  { connect: "codex", name: "codex", print: true },
+  { connect: "cursor", name: "cursor", print: false },
+  { connect: "vscode", name: "vscode", print: false },
 ] as const;
 
 const configuredTokenBudget = Number(
@@ -1337,12 +1337,20 @@ const run = async () => {
       "Verify the share link has API access, then run webstudio sync again.",
       ["sync"]
     );
-    for (const { connect: client } of agentSmokeClients) {
-      await runCliStep(
+    for (const { connect: client, print } of agentSmokeClients) {
+      const connected = await runCliStep(
         `connect ${client}`,
         `Run webstudio connect ${client} again and reload ${client}.`,
-        ["connect", client]
+        ["connect", client, ...(print ? ["--print"] : [])]
       );
+      if (
+        client === "codex" &&
+        connected.stdout.includes("codex mcp add webstudio --") === false
+      ) {
+        throw new Error(
+          "Codex connection smoke did not print its registration command."
+        );
+      }
     }
 
     const builderState = state.createBuilderStateFromBuildData({


### PR DESCRIPTION
## Summary

- finish the `publish` job after npm publication and exact registry-artifact verification
- run packaged CLI verification in a separate `release-smoke` job
- keep `publish-docs` dependent on successful release creation and package publication, but independent of post-publish smoke results
- verify the Codex registration command through `webstudio connect codex --print` in CI instead of requiring an installed Codex client

## Root cause

The release workflow ran post-publish CLI smoke verification inside the `publish` job. GitHub therefore marked package publication as failed whenever the smoke failed, even though npm publication had already completed. Because `publish-docs` declared `needs: [release, publish]`, GitHub skipped documentation publication.

The recurring failure was the smoke invoking `webstudio connect codex` on a runner without the `codex` executable.

## Technical choices and tradeoffs

Package publication remains strict: npm publication and exact registry visibility must both succeed before downstream jobs run. Post-publish smoke verification remains a red, visible release job and still uploads its diagnostic artifact, but it no longer changes the truthful outcome of publication or blocks docs.

The Codex package smoke now validates the generated registration command without mutating a real Codex installation. The command subprocess boundary remains covered by the existing focused connect-command tests.

No migrations or compatibility changes are involved.

## Todo

- [x] Separate post-publish CLI smoke from package publication.
- [x] Keep docs gated on successful release and registry publication.
- [x] Make Codex connection verification deterministic in CI.
- [x] Manually advance the `docs` branch to release 0.290.0.
- [x] Review documentation impact: no product documentation update is required because this changes release automation only.
- [x] Verify formatting, workflow syntax and topology, CLI tests, lint, and typechecking.
- [x] Run the non-model release smoke and record the remaining unrelated failure.

## Verification

- `pnpm exec oxfmt --check .github/workflows/release.yml packages/cli/scripts/release-smoke.ts`
- parsed `.github/workflows/release.yml` with Ruby Psych
- asserted the parsed workflow job graph with the repository's `yaml` dependency
- `pnpm --filter webstudio exec vitest run scripts/release-smoke-registry.test.ts src/commands/connect.test.ts` — 22 tests passed
- `pnpm --filter webstudio typecheck`
- `pnpm exec oxlint packages/cli/scripts/release-smoke.ts`
- `pnpm --filter webstudio test:release-smoke` — the corrected Codex path passed; the smoke later reached `preview.start` and failed on an unrelated current-main fixture error: `Project session is missing preview data: assetFolders`

Fixture review: this change does not modify fixture inputs or generated fixture outputs.

Closes #6119
