### PR TITLE
fix: Forward fragment token conflict resolution

### DIFF
--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -2,7 +2,10 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, expect, test, vi } from "vitest";
-import { getInputJsonSchemaMetadata } from "@webstudio-is/sdk";
+import {
+  getInputJsonSchemaMetadata,
+  getInputJsonSchemaProperties,
+} from "@webstudio-is/sdk";
 import {
   createProjectSessionMcpCore,
   getDetailedProjectSessionMcpInputSchema,
@@ -81,6 +84,44 @@ const tempDirs: string[] = [];
 type CommandBuilder = (yargs: unknown) => unknown;
 type CommandCall = [readonly string[], string, CommandBuilder, unknown];
 
+const normalizeMcpJsonValueSchemas = (value: unknown): unknown => {
+  if (Array.isArray(value)) {
+    return value.map(normalizeMcpJsonValueSchemas);
+  }
+  if (value === null || typeof value !== "object") {
+    return value;
+  }
+  const object = value as Record<string, unknown>;
+  if (
+    Object.keys(object).length === 1 &&
+    Array.isArray(object.anyOf) &&
+    JSON.stringify(object.anyOf) ===
+      JSON.stringify([
+        { type: "string" },
+        { type: "number" },
+        { type: "boolean" },
+        { type: "null" },
+        { type: "array", items: {} },
+        { type: "object" },
+      ])
+  ) {
+    return {};
+  }
+  const omitSyntheticTupleItems =
+    Array.isArray(object.prefixItems) &&
+    object.items !== null &&
+    typeof object.items === "object" &&
+    Object.keys(object.items).length === 0;
+  return Object.fromEntries(
+    Object.entries(object)
+      .filter(([key]) => omitSyntheticTupleItems === false || key !== "items")
+      .map(([key, nestedValue]) => [
+        key,
+        normalizeMcpJsonValueSchemas(nestedValue),
+      ])
+  );
+};
+
 test("keeps every MCP API tool aligned with its public API contract", () => {
   const toolsByName = new Map(
     listProjectSessionMcpTools(publicApiOperations).map((tool) => [
@@ -117,6 +158,22 @@ test("keeps every MCP API tool aligned with its public API contract", () => {
     expect(new Set(semanticFields), operation.command).toEqual(
       new Set(operation.inputFields)
     );
+
+    const apiProperties = getInputJsonSchemaProperties(operation.inputSchema);
+    const mcpProperties = getInputJsonSchemaProperties(schema);
+    for (const field of operation.inputFields) {
+      const isRepresentationOverride =
+        (operation.command === "insert-fragment" &&
+          ["parentInstanceId", "fragment"].includes(field)) ||
+        (operation.command === "insert-collection" && field === "itemFragment");
+      if (isRepresentationOverride) {
+        continue;
+      }
+      expect(
+        normalizeMcpJsonValueSchemas(mcpProperties?.[field]),
+        `${operation.command}.${field}`
+      ).toEqual(apiProperties?.[field]);
+    }
 
     const requiredFields = [...operation.requiredInputFields];
     if (

--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -2,8 +2,11 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, expect, test, vi } from "vitest";
+import { getInputJsonSchemaMetadata } from "@webstudio-is/sdk";
 import {
   createProjectSessionMcpCore,
+  getDetailedProjectSessionMcpInputSchema,
+  hiddenMcpOperationCommands,
   listProjectSessionMcpTools,
 } from "@webstudio-is/project-build/mcp";
 import { publicApiOperations } from "@webstudio-is/protocol";
@@ -77,6 +80,57 @@ test("classifies structured MCP tool failures for nonzero CLI exit", () => {
 const tempDirs: string[] = [];
 type CommandBuilder = (yargs: unknown) => unknown;
 type CommandCall = [readonly string[], string, CommandBuilder, unknown];
+
+test("keeps every MCP API tool aligned with its public API contract", () => {
+  const toolsByName = new Map(
+    listProjectSessionMcpTools(publicApiOperations).map((tool) => [
+      tool.name,
+      tool,
+    ])
+  );
+
+  for (const operation of publicApiOperations) {
+    if (hiddenMcpOperationCommands.has(operation.command)) {
+      expect(toolsByName.has(operation.command), operation.command).toBe(false);
+      continue;
+    }
+
+    const tool = toolsByName.get(operation.command);
+    expect(tool, operation.command).toBeDefined();
+    if (tool === undefined) {
+      continue;
+    }
+
+    const schema = getDetailedProjectSessionMcpInputSchema(tool);
+    const transportFields = [
+      ...(operation.method === "mutation" && operation.localCapable
+        ? ["dryRun"]
+        : []),
+      ...(operation.requiresConfirm && operation.localCapable
+        ? ["confirmDestructive", "confirmationToken"]
+        : []),
+    ];
+    const schemaMetadata = getInputJsonSchemaMetadata(schema);
+    const semanticFields = schemaMetadata.inputFields.filter(
+      (field) => transportFields.includes(field) === false
+    );
+    expect(new Set(semanticFields), operation.command).toEqual(
+      new Set(operation.inputFields)
+    );
+
+    const requiredFields = [...operation.requiredInputFields];
+    if (
+      operation.command === "insert-fragment" &&
+      requiredFields.includes("parentInstanceId") === false
+    ) {
+      requiredFields.push("parentInstanceId");
+    }
+    expect(
+      new Set(schemaMetadata.requiredInputFields),
+      operation.command
+    ).toEqual(new Set(requiredFields));
+  }
+});
 
 afterEach(async () => {
   vi.restoreAllMocks();

--- a/packages/cli/src/commands/schema.test.ts
+++ b/packages/cli/src/commands/schema.test.ts
@@ -245,6 +245,7 @@ test("prints full mcp tool input schemas when requested", () => {
   expect(Object.keys(insertFragmentTool.inputSchema.properties)).toEqual([
     "parentInstanceId",
     "fragment",
+    "conflictResolution",
     "mode",
     "insertIndex",
     "dryRun",

--- a/packages/cli/src/commands/schema.test.ts
+++ b/packages/cli/src/commands/schema.test.ts
@@ -246,6 +246,7 @@ test("prints full mcp tool input schemas when requested", () => {
     "parentInstanceId",
     "fragment",
     "conflictResolution",
+    "contentMode",
     "mode",
     "insertIndex",
     "dryRun",

--- a/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
+++ b/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
@@ -39616,8 +39616,12 @@ export const runtimeOperationContractData = [
                 conflictResolution: {
                   type: "string",
                   enum: ["ours", "theirs", "merge"],
+                  description:
+                    'How to resolve incoming design tokens that share a name with an existing token. "ours" keeps the existing token styles and id, "theirs" uses incoming styles, and "merge" combines both.',
                 },
                 contentMode: {
+                  description:
+                    "Apply content-mode copy restrictions to props and styles while reusing existing tokens and breakpoints.",
                   type: "boolean",
                 },
                 mode: {
@@ -54817,8 +54821,12 @@ export const runtimeOperationContractData = [
         conflictResolution: {
           type: "string",
           enum: ["ours", "theirs", "merge"],
+          description:
+            'How to resolve incoming design tokens that share a name with an existing token. "ours" keeps the existing token styles and id, "theirs" uses incoming styles, and "merge" combines both.',
         },
         contentMode: {
+          description:
+            "Apply content-mode copy restrictions to props and styles while reusing existing tokens and breakpoints.",
           type: "boolean",
         },
         mode: {

--- a/packages/project-build/src/mcp.test.ts
+++ b/packages/project-build/src/mcp.test.ts
@@ -323,6 +323,7 @@ const publicMcpOperations: readonly PublicMcpOperation[] = [
       z.object({
         parentInstanceId: z.string(),
         fragment: z.unknown(),
+        conflictResolution: z.enum(["ours", "theirs", "merge"]).optional(),
         mode: z.enum(["append", "prepend", "replace"]).optional(),
         insertIndex: z.number().optional(),
       })
@@ -1034,6 +1035,7 @@ describe("project session mcp adapter", () => {
     ).toEqual([
       "parentInstanceId",
       "fragment",
+      "conflictResolution",
       "mode",
       "insertIndex",
       "dryRun",
@@ -2412,12 +2414,22 @@ describe("project session mcp adapter", () => {
       executeOperation,
     });
 
+    expect(
+      adapter.listTools().find(({ name }) => name === "insert-fragment")
+        ?.inputSchema.properties?.conflictResolution
+    ).toEqual({
+      type: "string",
+      enum: ["ours", "theirs", "merge"],
+      description: expect.any(String),
+    });
+
     await adapter.callTool({
       name: "insert-fragment",
       input: {
         parentInstanceId: "body",
         fragment:
           '<ws.element ws:tag="section"><ws.element ws:tag="h2">Title</ws.element></ws.element>',
+        conflictResolution: "ours",
       },
     });
 
@@ -2432,6 +2444,7 @@ describe("project session mcp adapter", () => {
             expect.objectContaining({ component: "ws:element" }),
           ]),
         }),
+        conflictResolution: "ours",
         mode: undefined,
         insertIndex: undefined,
       },
@@ -2465,12 +2478,23 @@ describe("project session mcp adapter", () => {
     expect(adapter.listTools().map(({ name }) => name)).toContain(
       "insert-fragment-verified"
     );
+    expect(
+      adapter
+        .listTools()
+        .find(({ name }) => name === "insert-fragment-verified")?.inputSchema
+        .properties?.conflictResolution
+    ).toEqual({
+      type: "string",
+      enum: ["ours", "theirs", "merge"],
+      description: expect.any(String),
+    });
     const result = await adapter.callTool({
       name: "insert-fragment-verified",
       input: {
         parentInstanceId: "root-id",
         pagePath: "/account",
         fragment: '<ws.element ws:tag="section" />',
+        conflictResolution: "merge",
       },
     });
 
@@ -2478,6 +2502,7 @@ describe("project session mcp adapter", () => {
       1,
       expect.objectContaining({
         command: "insert-fragment",
+        input: expect.objectContaining({ conflictResolution: "merge" }),
         dryRun: false,
       })
     );

--- a/packages/project-build/src/mcp.test.ts
+++ b/packages/project-build/src/mcp.test.ts
@@ -30,6 +30,7 @@ import {
   type ProjectSessionScreenshotInput,
 } from "./mcp";
 import { getComponentTemplates } from "./runtime/component-templates";
+import { insertFragmentInput } from "./runtime/components";
 import { createEmptyWebstudioFragment } from "./runtime/component-template";
 import {
   projectSessionBusyMessage,
@@ -320,15 +321,7 @@ const publicMcpOperations: readonly PublicMcpOperation[] = [
     method: "mutation",
     permit: "build",
     description: "Insert fragment",
-    inputSchema: getTestInputSchema(
-      z.object({
-        parentInstanceId: z.string(),
-        fragment: z.unknown(),
-        conflictResolution: z.enum(["ours", "theirs", "merge"]).optional(),
-        mode: z.enum(["append", "prepend", "replace"]).optional(),
-        insertIndex: z.number().optional(),
-      })
-    ),
+    inputSchema: getTestInputSchema(insertFragmentInput),
     readNamespaces: ["pages", "instances"],
     writeNamespaces: ["instances", "props", "styles"],
     invalidatesNamespaces: ["instances", "props", "styles"],
@@ -1027,6 +1020,18 @@ describe("project session mcp adapter", () => {
     const insertFragmentTool = tools.find(
       (tool) => tool.name === "insert-fragment"
     );
+    const runtimeInsertFragmentProperties = Object.keys(
+      getInputSchemaMetadata(insertFragmentInput).inputJsonSchema.properties ??
+        {}
+    );
+    expect(
+      Object.keys(
+        insertFragmentTool === undefined
+          ? {}
+          : (getDetailedProjectSessionMcpInputSchema(insertFragmentTool)
+              .properties ?? {})
+      ).filter((property) => property !== "dryRun")
+    ).toEqual(runtimeInsertFragmentProperties);
     expect(insertFragmentTool?.inputSchema.required).toEqual([
       "parentInstanceId",
       "fragment",
@@ -1037,6 +1042,7 @@ describe("project session mcp adapter", () => {
       "parentInstanceId",
       "fragment",
       "conflictResolution",
+      "contentMode",
       "mode",
       "insertIndex",
       "dryRun",
@@ -2436,6 +2442,7 @@ describe("project session mcp adapter", () => {
         fragment:
           '<ws.element ws:tag="section"><ws.element ws:tag="h2">Title</ws.element></ws.element>',
         conflictResolution: "ours",
+        contentMode: true,
       },
     });
 
@@ -2451,6 +2458,7 @@ describe("project session mcp adapter", () => {
           ]),
         }),
         conflictResolution: "ours",
+        contentMode: true,
         mode: undefined,
         insertIndex: undefined,
       },

--- a/packages/project-build/src/mcp.test.ts
+++ b/packages/project-build/src/mcp.test.ts
@@ -21,6 +21,7 @@ import {
   createProjectSessionMcpCore,
   createProjectSessionMcpServer,
   createMcpStdioTransport,
+  getDetailedProjectSessionMcpInputSchema,
   hiddenMcpOperationCommands,
   listProjectSessionMcpResources,
   listProjectSessionMcpTools,
@@ -1042,15 +1043,20 @@ describe("project session mcp adapter", () => {
     ]);
     const fragmentSchema = insertFragmentTool?.inputSchema.properties?.fragment;
     expect(fragmentSchema).toEqual(expect.objectContaining({ type: "string" }));
+    const detailedFragmentSchema =
+      insertFragmentTool === undefined
+        ? undefined
+        : getDetailedProjectSessionMcpInputSchema(insertFragmentTool).properties
+            ?.fragment;
     expect(
       tools.find((tool) => tool.name === "insert-fragment-verified")
         ?.inputSchema.required
     ).toEqual(["parentInstanceId", "fragment", "pagePath"]);
     const jsxDescription =
-      typeof fragmentSchema === "object" &&
-      "description" in fragmentSchema &&
-      typeof fragmentSchema.description === "string"
-        ? fragmentSchema.description
+      typeof detailedFragmentSchema === "object" &&
+      "description" in detailedFragmentSchema &&
+      typeof detailedFragmentSchema.description === "string"
+        ? detailedFragmentSchema.description
         : undefined;
     expect(jsxDescription).toContain("not React aliases className or htmlFor");
     expect(jsxDescription).toContain("Use ws:style");

--- a/packages/project-build/src/mcp.test.ts
+++ b/packages/project-build/src/mcp.test.ts
@@ -2614,6 +2614,8 @@ describe("project session mcp adapter", () => {
         data: { type: "expression", value: "Posts.data.items" },
         itemFragment:
           '<ws.element ws:tag="article"><ws.element ws:tag="h2">{expression`collectionItem.title`}</ws.element></ws.element>',
+        mode: "prepend",
+        insertIndex: 2,
       },
     });
 
@@ -2631,8 +2633,8 @@ describe("project session mcp adapter", () => {
             expect.objectContaining({ component: "ws:element", tag: "h2" }),
           ]),
         }),
-        mode: undefined,
-        insertIndex: undefined,
+        mode: "prepend",
+        insertIndex: 2,
       },
       dryRun: false,
     });

--- a/packages/project-build/src/mcp.ts
+++ b/packages/project-build/src/mcp.ts
@@ -510,6 +510,12 @@ const insertFragmentMcpInputSchema = {
       type: "string",
       description: webstudioJsxFragmentInputDescription,
     },
+    conflictResolution: {
+      type: "string",
+      enum: ["ours", "theirs", "merge"],
+      description:
+        'How to resolve incoming design tokens that share a name with an existing token. "ours" keeps the existing token styles and id, "theirs" uses incoming styles, and "merge" combines both.',
+    },
     mode: {
       type: "string",
       enum: ["append", "prepend", "replace"],
@@ -3879,6 +3885,17 @@ const getInsertFragmentInput = async (input: unknown) => {
     );
   }
   const fragment = await parseWebstudioJsxFragment(input.fragment);
+  const conflictResolution = input.conflictResolution;
+  if (
+    conflictResolution !== undefined &&
+    conflictResolution !== "ours" &&
+    conflictResolution !== "theirs" &&
+    conflictResolution !== "merge"
+  ) {
+    throw new Error(
+      'insert-fragment conflictResolution must be "ours", "theirs", or "merge".'
+    );
+  }
   const mode = input.mode;
   if (
     mode !== undefined &&
@@ -3897,6 +3914,7 @@ const getInsertFragmentInput = async (input: unknown) => {
   return {
     parentInstanceId: input.parentInstanceId,
     fragment,
+    conflictResolution,
     mode,
     insertIndex,
   };

--- a/packages/project-build/src/mcp.ts
+++ b/packages/project-build/src/mcp.ts
@@ -75,6 +75,7 @@ import {
 } from "./runtime/component-templates";
 import {
   getTemplateRequiredStructure,
+  insertFragmentInput,
   parseComponentEdge,
 } from "./runtime/components";
 import { getInputSchemaMetadata } from "./contracts/input-schema";
@@ -496,55 +497,6 @@ const workflowNextInputSchema = {
   required: [],
 } as const satisfies ProjectSessionMcpInputSchema;
 
-const insertFragmentMcpInputSchema = {
-  ...emptyInputSchema,
-  description:
-    "Insert a Webstudio fragment from a Webstudio JSX string. The CLI converts JSX into structured Webstudio data before mutation.",
-  additionalProperties: false,
-  properties: {
-    parentInstanceId: {
-      type: "string",
-      description: "Parent instance id where the fragment is inserted.",
-    },
-    fragment: {
-      type: "string",
-      description: webstudioJsxFragmentInputDescription,
-    },
-    conflictResolution: {
-      type: "string",
-      enum: ["ours", "theirs", "merge"],
-      description:
-        'How to resolve incoming design tokens that share a name with an existing token. "ours" keeps the existing token styles and id, "theirs" uses incoming styles, and "merge" combines both.',
-    },
-    mode: {
-      type: "string",
-      enum: ["append", "prepend", "replace"],
-      description:
-        "Append, prepend, or replace parent children before inserting the fragment.",
-    },
-    insertIndex: {
-      type: "number",
-      description: "Zero-based child index for insertion.",
-    },
-  },
-  required: ["parentInstanceId", "fragment"],
-} as const satisfies ProjectSessionMcpInputSchema;
-
-const insertFragmentVerifiedMcpInputSchema = {
-  ...insertFragmentMcpInputSchema,
-  description:
-    "Insert a Webstudio fragment and immediately verify its persisted bindings in one call.",
-  properties: {
-    ...insertFragmentMcpInputSchema.properties,
-    pagePath: {
-      type: "string",
-      description:
-        "Concrete page path used for post-commit binding verification, for example /account.",
-    },
-  },
-  required: ["parentInstanceId", "fragment", "pagePath"],
-} as const satisfies ProjectSessionMcpInputSchema;
-
 const insertCollectionMcpInput = insertCollectionInput
   .omit({ itemFragment: true })
   .extend({
@@ -775,6 +727,35 @@ const getZodObjectSchema = (schema: z.ZodTypeAny) => {
 
 const getZodMcpInputSchema = (schema: z.ZodTypeAny) =>
   getHandshakeInputSchema(getZodObjectSchema(schema)).inputSchema;
+
+const insertFragmentMcpInput = z
+  .object({
+    ...insertFragmentInput.shape,
+    parentInstanceId: insertFragmentInput.shape.parentInstanceId
+      .unwrap()
+      .describe("Parent instance id where the fragment is inserted."),
+    fragment: z.string().describe(webstudioJsxFragmentInputDescription),
+  })
+  .describe(
+    "Insert a Webstudio fragment from a Webstudio JSX string. The CLI converts JSX into structured Webstudio data before mutation."
+  );
+
+const insertFragmentMcpInputSchema = getZodObjectSchema(insertFragmentMcpInput);
+
+const insertFragmentVerifiedMcpInputSchema = {
+  ...insertFragmentMcpInputSchema,
+  description:
+    "Insert a Webstudio fragment and immediately verify its persisted bindings in one call.",
+  properties: {
+    ...insertFragmentMcpInputSchema.properties,
+    pagePath: {
+      type: "string",
+      description:
+        "Concrete page path used for post-commit binding verification, for example /account.",
+    },
+  },
+  required: ["parentInstanceId", "fragment", "pagePath"],
+} as const satisfies ProjectSessionMcpInputSchema;
 
 const insertCollectionMcpInputSchema = getOperationInputSchema({
   inputSchema: getInputSchemaMetadata(insertCollectionMcpInput).inputJsonSchema,
@@ -3885,40 +3866,12 @@ const getInsertFragmentInput = async (input: unknown) => {
       'insert-fragment requires fragment as a Webstudio JSX string, for example {"fragment":"<ws.element ws:tag=\'section\' />"}.'
     );
   }
-  const fragment = await parseWebstudioJsxFragment(input.fragment);
-  const conflictResolution = input.conflictResolution;
-  if (
-    conflictResolution !== undefined &&
-    conflictResolution !== "ours" &&
-    conflictResolution !== "theirs" &&
-    conflictResolution !== "merge"
-  ) {
-    throw new Error(
-      'insert-fragment conflictResolution must be "ours", "theirs", or "merge".'
-    );
-  }
-  const mode = input.mode;
-  if (
-    mode !== undefined &&
-    mode !== "append" &&
-    mode !== "prepend" &&
-    mode !== "replace"
-  ) {
-    throw new Error(
-      'insert-fragment mode must be "append", "prepend", or "replace".'
-    );
-  }
-  const insertIndex = input.insertIndex;
-  if (insertIndex !== undefined && typeof insertIndex !== "number") {
-    throw new Error("insert-fragment insertIndex must be a number.");
-  }
-  return {
-    parentInstanceId: input.parentInstanceId,
-    fragment,
-    conflictResolution,
-    mode,
-    insertIndex,
-  };
+  const { fragment: fragmentSource, ...runtimeInput } =
+    insertFragmentMcpInput.parse(input);
+  return insertFragmentInput.parse({
+    ...runtimeInput,
+    fragment: await parseWebstudioJsxFragment(fragmentSource),
+  });
 };
 
 const getInsertCollectionInput = async (input: unknown) => {

--- a/packages/project-build/src/mcp.ts
+++ b/packages/project-build/src/mcp.ts
@@ -3413,11 +3413,12 @@ export const hiddenMcpOperationCommands = new Set<string>([
   "copy-page",
 ]);
 
-const compactMcpOperationCommands = new Set([
-  "create-assets-resource",
-  "update-assets-resource",
-  "validate-asset-query",
-  "preview-asset-query",
+const mcpOperationSchemaInlineSizes = new Map<string, number>([
+  ["insert-fragment", 1_000],
+  ["create-assets-resource", 2_500],
+  ["update-assets-resource", 2_500],
+  ["validate-asset-query", 2_500],
+  ["preview-asset-query", 2_500],
 ]);
 
 const detailedMcpInputSchemas = new WeakMap<
@@ -3455,7 +3456,7 @@ export const listProjectSessionMcpTools = (
       });
       const { inputSchema, detailedInputSchema } = getHandshakeInputSchema(
         operationInputSchema,
-        compactMcpOperationCommands.has(operation.command) ? 2_500 : undefined
+        mcpOperationSchemaInlineSizes.get(operation.command)
       );
       const tool = createProjectSessionMcpTool({
         name: operation.command,

--- a/packages/project-build/src/runtime/components.test.ts
+++ b/packages/project-build/src/runtime/components.test.ts
@@ -1100,6 +1100,17 @@ test("honors fragment token conflict resolution", async () => {
   ).filter((styleSource) => styleSource.type === "token");
   expect(addedTokenSources).toEqual([]);
   expect(
+    getAddedValues<{ instanceId: string; values: string[] }>(
+      mutation,
+      "styleSourceSelections"
+    )
+  ).toEqual([
+    {
+      instanceId: "generated-1",
+      values: [existingFragment.styleSources[0]?.id],
+    },
+  ]);
+  expect(
     getAddedValues<{ property: string; value: unknown }>(mutation, "styles")
   ).not.toContainEqual(
     expect.objectContaining({

--- a/packages/project-build/src/runtime/components.ts
+++ b/packages/project-build/src/runtime/components.ts
@@ -67,7 +67,11 @@ import {
 } from "./matcher";
 import { z } from "zod";
 
-const conflictResolutionInput = z.enum(["ours", "theirs", "merge"]);
+const conflictResolutionInput = z
+  .enum(["ours", "theirs", "merge"])
+  .describe(
+    'How to resolve incoming design tokens that share a name with an existing token. "ours" keeps the existing token styles and id, "theirs" uses incoming styles, and "merge" combines both.'
+  );
 
 export const insertComponentInput = z.object({
   parentInstanceId: z.string(),
@@ -90,7 +94,12 @@ export const insertFragmentInput = z
       "Structured Webstudio fragment produced by Webstudio JSX/template helpers. Runtime remaps fragment ids to generated project ids."
     ),
     conflictResolution: conflictResolutionInput.optional(),
-    contentMode: z.boolean().optional(),
+    contentMode: z
+      .boolean()
+      .optional()
+      .describe(
+        "Apply content-mode copy restrictions to props and styles while reusing existing tokens and breakpoints."
+      ),
     mode: instanceInsertModeInput.optional(),
     insertIndex: insertIndexInput.optional(),
   })


### PR DESCRIPTION
## Summary

- expose `conflictResolution` on both JSX fragment MCP tools
- derive the JSX-facing fragment contract from the Builder runtime contract instead of maintaining a second handwritten field list
- preserve `conflictResolution`, `contentMode`, insertion mode, and insertion index through JSX normalization
- verify all 151 MCP-exposed public APIs stay aligned with the generated public API catalog
- keep the normal MCP handshake below its size budget while retaining the complete schema in focused discovery
- cover direct and verified fragment insertion, shared-contract parity, and reuse of the existing token id

## Implementation

The runtime remains the canonical semantic contract for fragment insertion. The MCP adapter now inherits its fields and validation from `insertFragmentInput`, overriding only the transport-specific differences: MCP accepts `fragment` as a Webstudio JSX string and requires `parentInstanceId`. After converting JSX to structured Webstudio data, the adapter validates the result with the same runtime schema used by Builder operations.

This removes the duplicated conflict-resolution, content-mode, insertion-mode, and insertion-index definitions. It also restores `contentMode` to the MCP schema, where the previous handwritten contract had omitted it. Builder performance is unchanged because JSX parsing exists only on the MCP boundary; Builder continues to pass structured fragments directly to the runtime.

A catalog-wide audit confirmed that the other public API tools already derive their schemas from the generated protocol catalog. There are 152 public APIs: 151 are exposed through MCP and `copy-page` is intentionally hidden because its hydrated `Map` input is not serializable. The only schema adapters are `insert-fragment` and `insert-collection`, where MCP accepts JSX instead of structured fragment data. A permanent test now compares complete semantic field schemas and required fields for every exposed API, including types, enums, constraints, descriptions, branched schemas, and focused schemas that were compacted during the handshake. The collection adapter test also covers all optional insertion controls.

The runtime already resolves colliding token names and reuses the target token id when `conflictResolution` is supplied. The complete `insert-fragment` input remains available through focused schema discovery, while its normal handshake representation is compacted to keep the complete tool handshake below the existing 200 KB limit.

No migrations or persistence-format changes are required. Existing calls that omit the optional fields keep their current behavior.

## Checklist

- [x] Add `conflictResolution` to `insert-fragment`
- [x] Inherit the option in `insert-fragment-verified`
- [x] Derive shared MCP fields and validation from the runtime fragment contract
- [x] Keep JSX parsing and required-parent validation at the MCP boundary
- [x] Validate converted JSX with the runtime schema
- [x] Restore `contentMode` to the MCP contract
- [x] Audit all 152 public APIs for duplicate MCP contracts
- [x] Add catalog-wide complete-schema parity coverage for all 151 MCP-exposed APIs
- [x] Cover all `insert-collection` insertion controls through the JSX adapter
- [x] Demonstrate the new contract and forwarding tests fail when behavior is disabled and pass when restored
- [x] Keep the MCP handshake within its existing size budget
- [x] Verify `ours` attaches the existing token id without adding a duplicate token
- [x] Regenerate and verify runtime API contracts
- [x] Run the full fixture sync/build; no fixture changes were produced
- [x] Review generated MCP documentation; no documentation output changed
- [x] Review documentation impact; no user-facing documentation update is required
- [ ] Run agent evaluations (not run because they require separate explicit approval)

## Verification

- `pnpm --filter @webstudio-is/project-build test` — 2,089 tests passed
- `pnpm --filter webstudio test` — 971 tests passed
- `pnpm --filter @webstudio-is/project-build typecheck`
- `pnpm --filter webstudio typecheck`
- `pnpm exec oxlint packages/cli/src/commands/mcp.test.ts packages/project-build/src/mcp.test.ts`
- `pnpm exec oxfmt --check packages/cli/src/commands/mcp.test.ts packages/project-build/src/mcp.test.ts`
- `pnpm check:generated-api`
- `pnpm check:generated-docs`
- `pnpm fixtures`

Closes #6121
Ref #5928