### PR TITLE
fix: Make Content Block template JSX insertable

### DIFF
--- a/packages/project-build/package.json
+++ b/packages/project-build/package.json
@@ -89,6 +89,7 @@
     "acorn-jsx": "^5.3.2",
     "allof-merge": "^0.6.8",
     "bcp-47": "^2.1.0",
+    "change-case": "^5.4.4",
     "css-tree": "^3.1.0",
     "esbuild": "^0.25.3",
     "fast-deep-equal": "^3.1.3",

--- a/packages/project-build/src/mcp.test.ts
+++ b/packages/project-build/src/mcp.test.ts
@@ -5254,6 +5254,10 @@ describe("project session mcp adapter", () => {
       name: "components.get",
       input: { component: "ws:collection" },
     });
+    const blockTemplateDetails = await adapter.callTool({
+      name: "components.get",
+      input: { component: "ws:block-template" },
+    });
     const italicDetails = await adapter.callTool({
       name: "components.get",
       input: { component: "Italic" },
@@ -5738,6 +5742,7 @@ describe("project session mcp adapter", () => {
     expect(collectionDetails.structuredContent.data).toEqual(
       expect.objectContaining({
         component: "ws:collection",
+        jsxElement: "<ws.collection />",
         description: expect.stringContaining("array or object"),
         collectionUsage: expect.stringMatching(
           /insert-collection.*private item\/itemKey parameters.*atomically/
@@ -5748,6 +5753,13 @@ describe("project session mcp adapter", () => {
           item: expect.objectContaining({ type: "string" }),
           itemKey: expect.objectContaining({ type: "string" }),
         }),
+      })
+    );
+    expect(blockTemplateDetails.structuredContent.data).toEqual(
+      expect.objectContaining({
+        component: "ws:block-template",
+        jsxElement: "<ws.blockTemplate />",
+        standaloneInsertable: false,
       })
     );
     expect(selectTemplateDetails.structuredContent.data).toEqual(

--- a/packages/project-build/src/mcp.ts
+++ b/packages/project-build/src/mcp.ts
@@ -66,7 +66,12 @@ import {
   ListToolsRequestSchema,
   ReadResourceRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
-import { componentMetas } from "@webstudio-is/sdk-components-registry/metas";
+import {
+  animationComponentNamespace,
+  componentMetas,
+  radixComponentNamespace,
+} from "@webstudio-is/sdk-components-registry/metas";
+import { camelCase } from "change-case";
 import { readProjectBuildDoc } from "./docs";
 import type { ComponentTemplateRegistry } from "./runtime/component-template";
 import {
@@ -88,10 +93,7 @@ import {
   type ComponentRegistryItem,
 } from "./runtime/component-catalog";
 import { parseWebstudioJsxFragment } from "./runtime/jsx";
-import {
-  getWebstudioJsxComponentName,
-  webstudioJsxFragmentInputDescription,
-} from "./runtime/jsx/bindings";
+import { webstudioJsxFragmentInputDescription } from "./runtime/jsx/bindings";
 import {
   formatValidationErrorMessage,
   getValidationIssues,
@@ -4596,10 +4598,16 @@ const getComponentSummaryEntry = ({
   }
   const [parsedNamespace, exportName] = parseComponentName(component);
   const namespace = parsedNamespace ?? "global";
-  const jsxComponentName = getWebstudioJsxComponentName({
-    namespace: parsedNamespace,
-    exportName,
-  });
+  const jsxNamespace =
+    parsedNamespace === radixComponentNamespace
+      ? "radix"
+      : parsedNamespace === animationComponentNamespace
+        ? "animation"
+        : parsedNamespace === "ws"
+          ? "ws"
+          : "$";
+  const jsxExportName =
+    parsedNamespace === "ws" ? camelCase(exportName) : exportName;
   const template = templateMeta?.template;
   const hasTemplate = template !== undefined;
   const instancesById = new Map(
@@ -4643,7 +4651,7 @@ const getComponentSummaryEntry = ({
     component,
     exportName,
     namespace,
-    jsxElement: `<${jsxComponentName} />`,
+    jsxElement: `<${jsxNamespace}.${jsxExportName} />`,
     label: meta.label,
     category: visibleCategory,
     contentCategory: meta.contentModel?.category,

--- a/packages/project-build/src/mcp.ts
+++ b/packages/project-build/src/mcp.ts
@@ -88,7 +88,10 @@ import {
   type ComponentRegistryItem,
 } from "./runtime/component-catalog";
 import { parseWebstudioJsxFragment } from "./runtime/jsx";
-import { webstudioJsxFragmentInputDescription } from "./runtime/jsx/bindings";
+import {
+  getWebstudioJsxComponentName,
+  webstudioJsxFragmentInputDescription,
+} from "./runtime/jsx/bindings";
 import {
   formatValidationErrorMessage,
   getValidationIssues,
@@ -4593,12 +4596,10 @@ const getComponentSummaryEntry = ({
   }
   const [parsedNamespace, exportName] = parseComponentName(component);
   const namespace = parsedNamespace ?? "global";
-  const jsxNamespace =
-    parsedNamespace === "@webstudio-is/sdk-components-react-radix"
-      ? "radix"
-      : parsedNamespace === "@webstudio-is/sdk-components-animation"
-        ? "animation"
-        : "$";
+  const jsxComponentName = getWebstudioJsxComponentName({
+    namespace: parsedNamespace,
+    exportName,
+  });
   const template = templateMeta?.template;
   const hasTemplate = template !== undefined;
   const instancesById = new Map(
@@ -4642,7 +4643,7 @@ const getComponentSummaryEntry = ({
     component,
     exportName,
     namespace,
-    jsxElement: `<${jsxNamespace}.${exportName} />`,
+    jsxElement: `<${jsxComponentName} />`,
     label: meta.label,
     category: visibleCategory,
     contentCategory: meta.contentModel?.category,

--- a/packages/project-build/src/runtime/components.test.ts
+++ b/packages/project-build/src/runtime/components.test.ts
@@ -1402,6 +1402,38 @@ test("inserts authored template part structure from webstudio jsx fragments", as
   ]);
 });
 
+test("inserts authored Content Block template structure from webstudio jsx fragments", async () => {
+  const parent = createParent();
+  const fragment = await parseWebstudioJsxFragment(
+    `<ws.block><ws.blockTemplate><ws.element ws:tag="section"><ws.element ws:tag="h2">Title</ws.element></ws.element></ws.blockTemplate></ws.block>`
+  );
+
+  const mutation = insertFragment(
+    createState(parent),
+    {
+      parentInstanceId: parent.id,
+      fragment,
+    },
+    {
+      createId: createIdFactory(),
+      projectId: "project-id",
+    }
+  );
+
+  const instances = getAddedValues<Instance>(mutation, "instances");
+  expect(instances).toEqual([
+    expect.objectContaining({ component: "ws:block" }),
+    expect.objectContaining({ component: "ws:block-template" }),
+    expect.objectContaining({ component: elementComponent, tag: "section" }),
+    expect.objectContaining({ component: elementComponent, tag: "h2" }),
+  ]);
+  const [block, blockTemplate, section, heading] = instances;
+  expect(block.children).toEqual([{ type: "id", value: blockTemplate.id }]);
+  expect(blockTemplate.children).toEqual([{ type: "id", value: section.id }]);
+  expect(section.children).toEqual([{ type: "id", value: heading.id }]);
+  expect(heading.children).toEqual([{ type: "text", value: "Title" }]);
+});
+
 test("supports react style props in webstudio jsx fragments", async () => {
   const fragment = await parseWebstudioJsxFragment(
     `<$.Box style={{ padding: 24 }}>Hello</$.Box>`

--- a/packages/project-build/src/runtime/jsx/bindings.ts
+++ b/packages/project-build/src/runtime/jsx/bindings.ts
@@ -25,53 +25,11 @@ const css = (strings: TemplateStringsArray, ...values: string[]) => {
   return parseTemplateCss(source);
 };
 
-const wsComponentPropertyAliases = {
-  blockTemplate: "block-template",
-} as const;
-
-const wsBinding = new Proxy(ws, {
-  get: (target, property, receiver) => {
-    if (
-      typeof property === "string" &&
-      Object.hasOwn(wsComponentPropertyAliases, property)
-    ) {
-      return target[
-        wsComponentPropertyAliases[
-          property as keyof typeof wsComponentPropertyAliases
-        ]
-      ];
-    }
-    return Reflect.get(target, property, receiver);
-  },
-});
-
 const componentBindings = {
   $,
-  ws: wsBinding,
+  ws,
   radix: createProxy("@webstudio-is/sdk-components-react-radix:"),
   animation: createProxy("@webstudio-is/sdk-components-animation:"),
-};
-
-export const getWebstudioJsxComponentName = ({
-  namespace,
-  exportName,
-}: {
-  namespace: string | undefined;
-  exportName: string;
-}) => {
-  if (namespace === "@webstudio-is/sdk-components-react-radix") {
-    return `radix.${exportName}`;
-  }
-  if (namespace === "@webstudio-is/sdk-components-animation") {
-    return `animation.${exportName}`;
-  }
-  if (namespace === "ws") {
-    const alias = Object.entries(wsComponentPropertyAliases).find(
-      ([, componentName]) => componentName === exportName
-    )?.[0];
-    return `ws.${alias ?? exportName}`;
-  }
-  return `$.${exportName}`;
 };
 
 const helperBindings = {

--- a/packages/project-build/src/runtime/jsx/bindings.ts
+++ b/packages/project-build/src/runtime/jsx/bindings.ts
@@ -25,11 +25,53 @@ const css = (strings: TemplateStringsArray, ...values: string[]) => {
   return parseTemplateCss(source);
 };
 
+const wsComponentPropertyAliases = {
+  blockTemplate: "block-template",
+} as const;
+
+const wsBinding = new Proxy(ws, {
+  get: (target, property, receiver) => {
+    if (
+      typeof property === "string" &&
+      Object.hasOwn(wsComponentPropertyAliases, property)
+    ) {
+      return target[
+        wsComponentPropertyAliases[
+          property as keyof typeof wsComponentPropertyAliases
+        ]
+      ];
+    }
+    return Reflect.get(target, property, receiver);
+  },
+});
+
 const componentBindings = {
   $,
-  ws,
+  ws: wsBinding,
   radix: createProxy("@webstudio-is/sdk-components-react-radix:"),
   animation: createProxy("@webstudio-is/sdk-components-animation:"),
+};
+
+export const getWebstudioJsxComponentName = ({
+  namespace,
+  exportName,
+}: {
+  namespace: string | undefined;
+  exportName: string;
+}) => {
+  if (namespace === "@webstudio-is/sdk-components-react-radix") {
+    return `radix.${exportName}`;
+  }
+  if (namespace === "@webstudio-is/sdk-components-animation") {
+    return `animation.${exportName}`;
+  }
+  if (namespace === "ws") {
+    const alias = Object.entries(wsComponentPropertyAliases).find(
+      ([, componentName]) => componentName === exportName
+    )?.[0];
+    return `ws.${alias ?? exportName}`;
+  }
+  return `$.${exportName}`;
 };
 
 const helperBindings = {

--- a/packages/sdk-components-registry/src/metas.ts
+++ b/packages/sdk-components-registry/src/metas.ts
@@ -14,3 +14,5 @@ for (const library of componentMetaLibraries) {
     componentMetas.set(getComponentName(library, exportName), meta);
   }
 }
+
+export { animationComponentNamespace, radixComponentNamespace } from "./shared";

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -20,6 +20,7 @@
     "@webstudio-is/css-engine": "workspace:*",
     "@webstudio-is/react-sdk": "workspace:*",
     "@webstudio-is/sdk": "workspace:*",
+    "change-case": "^5.4.4",
     "react": "18.3.0-canary-14898b6a9-20240318"
   },
   "devDependencies": {

--- a/packages/template/src/jsx.test.tsx
+++ b/packages/template/src/jsx.test.tsx
@@ -1144,3 +1144,16 @@ test("render ws:element with ws:tag prop", () => {
   ]);
   expect(props).toEqual([]);
 });
+
+test("render camel-cased ws component as canonical kebab-case", () => {
+  const { instances } = renderTemplate(<ws.blockTemplate />);
+
+  expect(instances).toEqual([
+    {
+      type: "instance",
+      id: "0",
+      component: "ws:block-template",
+      children: [],
+    },
+  ]);
+});

--- a/packages/template/src/jsx.ts
+++ b/packages/template/src/jsx.ts
@@ -1,4 +1,5 @@
 import { Fragment, type JSX, type ReactNode } from "react";
+import { kebabCase } from "change-case";
 import { hyphenateProperty } from "@webstudio-is/css-engine";
 import {
   animationAction,
@@ -846,13 +847,16 @@ type Component = { displayName: string } & ((
   props: ComponentProps
 ) => ReactNode);
 
-export const createProxy = (prefix: string): Record<string, Component> => {
+export const createProxy = (
+  prefix: string,
+  transformName: (name: string) => string = (name) => name
+): Record<string, Component> => {
   return new Proxy(
     {},
     {
       get(_target, prop) {
         const component: Component = () => undefined;
-        component.displayName = `${prefix}${prop as string}`;
+        component.displayName = `${prefix}${transformName(String(prop))}`;
         return component;
       },
     }
@@ -861,4 +865,4 @@ export const createProxy = (prefix: string): Record<string, Component> => {
 
 export const $: Record<string, Component> = createProxy("");
 
-export const ws: Record<string, Component> = createProxy("ws:");
+export const ws: Record<string, Component> = createProxy("ws:", kebabCase);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2261,6 +2261,9 @@ importers:
       bcp-47:
         specifier: ^2.1.0
         version: 2.1.0
+      change-case:
+        specifier: ^5.4.4
+        version: 5.4.4
       css-tree:
         specifier: ^3.1.0
         version: 3.1.0
@@ -2996,6 +2999,9 @@ importers:
       '@webstudio-is/sdk':
         specifier: workspace:*
         version: link:../sdk
+      change-case:
+        specifier: ^5.4.4
+        version: 5.4.4
       react:
         specifier: 18.3.0-canary-14898b6a9-20240318
         version: 18.3.0-canary-14898b6a9-20240318


### PR DESCRIPTION
## Summary

Fix MCP component discovery so Content Block template JSX can be passed directly to `insert-fragment`.

The catalog previously advertised `<$.block-template />`. The hyphen is invalid in a JSX member name, and the fallback `$` namespace also did not match the canonical `ws:block-template` component.

## Implementation

- Advertise Webstudio-owned components through the `ws` JSX binding.
- Expose `ws:block-template` as the parser-safe `<ws.blockTemplate />`.
- Resolve that alias back to the unchanged canonical component ID at runtime.
- Keep catalog formatting and runtime resolution on one shared alias contract.
- Add regression coverage for inserting a Content Block, its required template part, nested elements, and authored text.

Existing stored component IDs and Builder behavior remain unchanged.

## Todo

- [x] Advertise parser-compatible Content Block template JSX
- [x] Resolve the JSX alias to `ws:block-template`
- [x] Verify nested authored Content Block insertion
- [x] Verify other `ws:*` discovery entries use the correct namespace
- [x] Review documentation impact — no user-facing documentation changes are required
- [x] Run project-build tests, typecheck, lint, formatting, generated-doc checks, and fixtures
- [ ] Run the complete agent evaluation suite after explicit approval

## Verification

- `pnpm --filter @webstudio-is/project-build test` — 2,090 tests passed
- `pnpm --filter @webstudio-is/project-build typecheck`
- `pnpm lint`
- `pnpm exec oxfmt --check packages/project-build/src/runtime/jsx/bindings.ts packages/project-build/src/mcp.ts packages/project-build/src/runtime/components.test.ts packages/project-build/src/mcp.test.ts`
- `pnpm check:generated-docs`
- `pnpm fixtures` — completed with no fixture diff

Evaluations were not run because repository policy requires separate explicit approval.

Closes #6127