### PR TITLE
fix: Reconcile MCP commits and Cloudflare scaffold types

### DIFF
--- a/fixtures/react-router-cloudflare/app/__generated__/$resources.sitemap.xml.ts
+++ b/fixtures/react-router-cloudflare/app/__generated__/$resources.sitemap.xml.ts
@@ -1,5 +1,5 @@
 
-      export const sitemap = [
+      export const sitemap: Array<{ path: string; lastModified: string }> = [
   {
     "path": "/",
     "lastModified": "2025-01-04"

--- a/fixtures/react-router-docker/app/__generated__/$resources.sitemap.xml.ts
+++ b/fixtures/react-router-docker/app/__generated__/$resources.sitemap.xml.ts
@@ -1,5 +1,5 @@
 
-      export const sitemap = [
+      export const sitemap: Array<{ path: string; lastModified: string }> = [
   {
     "path": "/",
     "lastModified": "2025-01-04"

--- a/fixtures/react-router-netlify/app/__generated__/$resources.sitemap.xml.ts
+++ b/fixtures/react-router-netlify/app/__generated__/$resources.sitemap.xml.ts
@@ -1,5 +1,5 @@
 
-      export const sitemap = [
+      export const sitemap: Array<{ path: string; lastModified: string }> = [
   {
     "path": "/",
     "lastModified": "2025-01-04"

--- a/fixtures/react-router-vercel/app/__generated__/$resources.sitemap.xml.ts
+++ b/fixtures/react-router-vercel/app/__generated__/$resources.sitemap.xml.ts
@@ -1,5 +1,5 @@
 
-      export const sitemap = [
+      export const sitemap: Array<{ path: string; lastModified: string }> = [
   {
     "path": "/",
     "lastModified": "2025-01-04"

--- a/fixtures/ssg-cloudflare-pages/app/__generated__/$resources.sitemap.xml.ts
+++ b/fixtures/ssg-cloudflare-pages/app/__generated__/$resources.sitemap.xml.ts
@@ -1,5 +1,5 @@
 
-      export const sitemap = [
+      export const sitemap: Array<{ path: string; lastModified: string }> = [
   {
     "path": "/",
     "lastModified": "2024-07-29"

--- a/fixtures/ssg-netlify-by-project-id/app/__generated__/$resources.sitemap.xml.ts
+++ b/fixtures/ssg-netlify-by-project-id/app/__generated__/$resources.sitemap.xml.ts
@@ -1,5 +1,5 @@
 
-      export const sitemap = [
+      export const sitemap: Array<{ path: string; lastModified: string }> = [
   {
     "path": "/",
     "lastModified": "2026-01-04"

--- a/fixtures/webstudio-cloudflare-template/app/__generated__/$resources.sitemap.xml.ts
+++ b/fixtures/webstudio-cloudflare-template/app/__generated__/$resources.sitemap.xml.ts
@@ -1,5 +1,5 @@
 
-      export const sitemap = [
+      export const sitemap: Array<{ path: string; lastModified: string }> = [
   {
     "path": "/",
     "lastModified": "2024-07-29"

--- a/fixtures/webstudio-features/app/__generated__/$resources.sitemap.xml.ts
+++ b/fixtures/webstudio-features/app/__generated__/$resources.sitemap.xml.ts
@@ -1,5 +1,5 @@
 
-      export const sitemap = [
+      export const sitemap: Array<{ path: string; lastModified: string }> = [
   {
     "path": "/",
     "lastModified": "2026-01-15"

--- a/packages/cli/src/prebuild.test.ts
+++ b/packages/cli/src/prebuild.test.ts
@@ -70,7 +70,7 @@ const elementComponent = "ws:element";
 const slowPrebuildTestTimeout = 15_000;
 
 const runGeneratedCommand = async (
-  command: "react-router" | "vite" | "vike",
+  command: "react-router" | "tsc" | "vite" | "vike",
   args: string[]
 ) => {
   const env = { ...process.env };
@@ -1166,6 +1166,51 @@ describe("prebuild", () => {
       readFile("app/__generated__/$resources.sitemap.xml.ts", "utf8")
     ).resolves.not.toContain('"path": "/draft"');
   });
+
+  test(
+    "types an empty generated sitemap",
+    async () => {
+      await writeSiteData(
+        createSiteData({
+          pages: [
+            {
+              id: "draft",
+              name: "Draft",
+              title: "Draft",
+              path: "/draft",
+              rootInstanceId: "root",
+              meta: {},
+              isDraft: true,
+            },
+          ],
+        })
+      );
+
+      await prebuild({
+        assets: false,
+        template: ["react-router"],
+      });
+      await writeFile(
+        "sitemap-typecheck.ts",
+        `import { sitemap } from "./app/__generated__/$resources.sitemap.xml";
+sitemap.map((page) => page.path);`
+      );
+      await runGeneratedCommand("tsc", [
+        "--ignoreConfig",
+        "--noEmit",
+        "--strict",
+        "--skipLibCheck",
+        "--moduleResolution",
+        "bundler",
+        "--module",
+        "esnext",
+        "--target",
+        "es2022",
+        "sitemap-typecheck.ts",
+      ]);
+    },
+    slowPrebuildTestTimeout
+  );
 
   test("generates draft routes for local verification without publishing them", async () => {
     await writeSiteData(

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -1443,7 +1443,7 @@ export const prebuild = async (options: {
   await writeGeneratedFile(
     join(generatedDir, "$resources.sitemap.xml.ts"),
     `
-      export const sitemap = ${JSON.stringify(sitemap, null, 2)};
+      export const sitemap: Array<{ path: string; lastModified: string }> = ${JSON.stringify(sitemap, null, 2)};
     `
   );
 

--- a/packages/project-build/src/project-session.test.ts
+++ b/packages/project-build/src/project-session.test.ts
@@ -1281,6 +1281,83 @@ describe("project session", () => {
     expect(transport.commits[0]?.[0]?.id).toBe(transport.commits[1]?.[0]?.id);
   });
 
+  test("refreshes without replaying after confirmation fails", async () => {
+    const storage = createStorage(createPersistedSnapshot());
+    const transport = createTransport();
+    let attempts = 0;
+    transport.commitPatch = async () => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw Object.assign(new Error("Build version mismatch"), {
+          code: "CONFLICT",
+        });
+      }
+      throw Object.assign(new Error("Connection reset"), {
+        code: "ECONNRESET",
+      });
+    };
+    const session = createSession({ storage, transport });
+
+    await session.initialize();
+    const result = await session.mutate("pages.update", {
+      pageId: "page-home",
+      values: { name: "Conflict" },
+    });
+
+    expect(result.state.committed).toBe(false);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        code: "CONFLICT",
+        details: expect.objectContaining({
+          confirmationFailure: {
+            code: "ECONNRESET",
+            message: "Connection reset",
+          },
+        }),
+      }),
+      expect.objectContaining({ code: "CONFLICT_REFRESHED" }),
+    ]);
+    expect(transport.loadedNamespaces).toEqual([
+      ["pages", "instances", "dataSources"],
+    ]);
+    expect(attempts).toBe(2);
+  });
+
+  test("clears cached permissions after authorization confirmation failure", async () => {
+    const storage = createStorage(createPersistedSnapshot());
+    const transport = createTransport();
+    let attempts = 0;
+    transport.commitPatch = async (input) => {
+      attempts += 1;
+      if (attempts === 1) {
+        throw Object.assign(new Error("Build version mismatch"), {
+          code: "CONFLICT",
+        });
+      }
+      if (attempts === 2) {
+        throw Object.assign(new Error("Token expired"), {
+          code: "UNAUTHORIZED",
+        });
+      }
+      return { version: input.baseVersion + 1 };
+    };
+    const session = createSession({ storage, transport });
+
+    await session.initialize();
+    await session.mutate(
+      "pages.update",
+      { pageId: "page-home", values: { name: "First" } },
+      { permit: "build" }
+    );
+    await session.mutate(
+      "pages.update",
+      { pageId: "page-home", values: { name: "Second" } },
+      { permit: "build" }
+    );
+
+    expect(transport.permissionReads).toBe(2);
+  });
+
   test("checks and caches permissions for local runtime mutations", async () => {
     const storage = createStorage(createPersistedSnapshot());
     const transport = createTransport();

--- a/packages/project-build/src/project-session.test.ts
+++ b/packages/project-build/src/project-session.test.ts
@@ -1479,6 +1479,52 @@ describe("project session", () => {
     expect(transport.restoreCommits).toHaveLength(1);
   });
 
+  test("confirms an ambiguous restore with the same transaction", async () => {
+    const target = createPersistedSnapshot();
+    const current = structuredClone(target);
+    current.version = 2;
+    current.revision = "rev-2";
+    const currentHome = current.state.pages?.pages.get("page-home");
+    if (currentHome === undefined) {
+      throw new Error("Home page fixture is missing");
+    }
+    currentHome.name = "Edited after restore point";
+    const storage = createStorage(current);
+    const transport = createTransport({
+      projectId: current.projectId,
+      buildId: current.buildId,
+      version: current.version,
+      state: current.state,
+    });
+    let committedTransactionId: string | undefined;
+    transport.commitRestorePoint = async (input) => {
+      transport.commits.push([...input.transactions]);
+      transport.restoreCommits.push([...input.transactions]);
+      const transactionId = input.transactions[0]?.id;
+      if (transactionId === committedTransactionId) {
+        return { version: input.baseVersion + 1 };
+      }
+      committedTransactionId = transactionId;
+      throw Object.assign(new Error("Build version mismatch"), {
+        code: "CONFLICT",
+      });
+    };
+    const session = createSession({ storage, transport });
+
+    await session.initialize();
+    const restored = await session.restoreSnapshot(target);
+
+    expect(restored.state.committed).toBe(true);
+    expect(restored.version).toBe(3);
+    expect(restored.diagnostics).toEqual([
+      expect.objectContaining({ code: "COMMIT_RETRY_CONFIRMED" }),
+    ]);
+    expect(transport.restoreCommits).toHaveLength(2);
+    expect(transport.restoreCommits[0]?.[0]?.id).toBe(
+      transport.restoreCommits[1]?.[0]?.id
+    );
+  });
+
   test("keeps separately persisted assets outside restore points", async () => {
     const current = createPersistedSnapshot();
     current.state.assets = new Map([

--- a/packages/project-build/src/project-session.test.ts
+++ b/packages/project-build/src/project-session.test.ts
@@ -1220,7 +1220,7 @@ describe("project session", () => {
     transport.commitPatch = async (input) => {
       attempts += 1;
       transport.commits.push([...input.transactions]);
-      if (attempts === 1) {
+      if (attempts <= 2) {
         throw Object.assign(new Error("Build version mismatch"), {
           code: "CONFLICT",
         });
@@ -1245,7 +1245,40 @@ describe("project session", () => {
     expect(transport.loadedNamespaces).toEqual([
       ["pages", "instances", "dataSources"],
     ]);
+    expect(transport.commits).toHaveLength(3);
+  });
+
+  test("confirms an ambiguous commit with the same transaction", async () => {
+    const storage = createStorage(createPersistedSnapshot());
+    const transport = createTransport();
+    let committedTransactionId: string | undefined;
+    transport.commitPatch = async (input) => {
+      transport.commits.push([...input.transactions]);
+      const transactionId = input.transactions[0]?.id;
+      if (transactionId === committedTransactionId) {
+        return { version: input.baseVersion + 1 };
+      }
+      committedTransactionId = transactionId;
+      throw Object.assign(new Error("Build version mismatch"), {
+        code: "CONFLICT",
+      });
+    };
+    const session = createSession({ storage, transport });
+
+    await session.initialize();
+    const result = await session.mutate("pages.update", {
+      pageId: "page-home",
+      values: { name: "Home updated" },
+    });
+
+    expect(result.state.committed).toBe(true);
+    expect(result.version).toBe(2);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({ code: "COMMIT_RETRY_CONFIRMED" }),
+    ]);
+    expect(transport.loadedNamespaces).toEqual([]);
     expect(transport.commits).toHaveLength(2);
+    expect(transport.commits[0]?.[0]?.id).toBe(transport.commits[1]?.[0]?.id);
   });
 
   test("checks and caches permissions for local runtime mutations", async () => {

--- a/packages/project-build/src/project-session.ts
+++ b/packages/project-build/src/project-session.ts
@@ -96,6 +96,13 @@ export type ProjectSessionCommitResult = {
   version: number;
 };
 
+type ProjectSessionCommitInput = {
+  projectId: string;
+  buildId: string;
+  baseVersion: number;
+  transactions: readonly BuilderPatchTransaction[];
+};
+
 export type ProjectSessionPermissions = {
   canView: boolean;
   canEdit: boolean;
@@ -119,18 +126,12 @@ export type ProjectSessionTransport = {
     projectId: string;
     namespaces: readonly BuilderNamespace[];
   }) => Promise<ProjectSessionRemoteSnapshot>;
-  commitPatch: (input: {
-    projectId: string;
-    buildId: string;
-    baseVersion: number;
-    transactions: readonly BuilderPatchTransaction[];
-  }) => Promise<ProjectSessionCommitResult>;
-  commitRestorePoint: (input: {
-    projectId: string;
-    buildId: string;
-    baseVersion: number;
-    transactions: readonly BuilderPatchTransaction[];
-  }) => Promise<ProjectSessionCommitResult>;
+  commitPatch: (
+    input: ProjectSessionCommitInput
+  ) => Promise<ProjectSessionCommitResult>;
+  commitRestorePoint: (
+    input: ProjectSessionCommitInput
+  ) => Promise<ProjectSessionCommitResult>;
   executeServerOperation?: <Result>(input: {
     operationId: string;
     input: unknown;
@@ -575,19 +576,64 @@ const errorDiagnostic = (error: unknown): ProjectSessionDiagnostic => {
   };
 };
 
+const getCommitConfirmationFailureCode = (error: unknown) => {
+  if (
+    typeof error !== "object" ||
+    error === null ||
+    !("confirmationFailure" in error)
+  ) {
+    return;
+  }
+  const failure = error.confirmationFailure;
+  if (
+    typeof failure !== "object" ||
+    failure === null ||
+    !("code" in failure) ||
+    typeof failure.code !== "string"
+  ) {
+    return;
+  }
+  return failure.code;
+};
+
+const isAuthorizationErrorCode = (code: string | undefined) =>
+  code === "UNAUTHORIZED" || code === "FORBIDDEN" || code === "PLAN_REQUIRED";
+
 const shouldRefreshPermissionsAfterError = (error: unknown) => {
-  const code = getProjectSessionErrorCode(error);
   return (
-    code === "UNAUTHORIZED" || code === "FORBIDDEN" || code === "PLAN_REQUIRED"
+    isAuthorizationErrorCode(getProjectSessionErrorCode(error)) ||
+    isAuthorizationErrorCode(getCommitConfirmationFailureCode(error))
   );
 };
 
 const isVersionConflictError = (error: unknown) =>
   getProjectSessionErrorCode(error) === "CONFLICT";
 
-type ProjectSessionCommitInput = Parameters<
-  ProjectSessionTransport["commitPatch"]
->[0];
+const createCommitConfirmationConflictError = ({
+  conflictError,
+  confirmationError,
+}: {
+  conflictError: unknown;
+  confirmationError: unknown;
+}) =>
+  Object.assign(
+    new Error(
+      conflictError instanceof Error
+        ? conflictError.message
+        : "Build version conflict",
+      { cause: confirmationError }
+    ),
+    {
+      code: "CONFLICT",
+      confirmationFailure: {
+        code: getProjectSessionErrorCode(confirmationError),
+        message:
+          confirmationError instanceof Error
+            ? confirmationError.message
+            : "Unknown error",
+      },
+    }
+  );
 
 const commitWithConflictConfirmation = async ({
   commit,
@@ -603,14 +649,24 @@ const commitWithConflictConfirmation = async ({
       result: await commit(input),
       confirmedAfterRetry: false,
     };
-  } catch (error) {
-    if (isVersionConflictError(error) === false) {
-      throw error;
+  } catch (conflictError) {
+    if (isVersionConflictError(conflictError) === false) {
+      throw conflictError;
     }
-    return {
-      result: await commit(input),
-      confirmedAfterRetry: true,
-    };
+    try {
+      return {
+        result: await commit(input),
+        confirmedAfterRetry: true,
+      };
+    } catch (confirmationError) {
+      if (isVersionConflictError(confirmationError)) {
+        throw confirmationError;
+      }
+      throw createCommitConfirmationConflictError({
+        conflictError,
+        confirmationError,
+      });
+    }
   }
 };
 
@@ -1230,7 +1286,11 @@ export class ProjectSession {
             message:
               "Remote build changed. Required namespaces were refreshed; rerun the operation against the latest snapshot.",
           });
-          if (contract.retryOnConflict && options.dryRun !== true) {
+          if (
+            contract.retryOnConflict &&
+            options.dryRun !== true &&
+            getCommitConfirmationFailureCode(error) === undefined
+          ) {
             return await this.commitMutation({
               operationId,
               input,

--- a/packages/project-build/src/project-session.ts
+++ b/packages/project-build/src/project-session.ts
@@ -585,6 +585,42 @@ const shouldRefreshPermissionsAfterError = (error: unknown) => {
 const isVersionConflictError = (error: unknown) =>
   getProjectSessionErrorCode(error) === "CONFLICT";
 
+type ProjectSessionCommitInput = Parameters<
+  ProjectSessionTransport["commitPatch"]
+>[0];
+
+const commitWithConflictConfirmation = async ({
+  commit,
+  input,
+}: {
+  commit: (
+    input: ProjectSessionCommitInput
+  ) => Promise<ProjectSessionCommitResult>;
+  input: ProjectSessionCommitInput;
+}) => {
+  try {
+    return {
+      result: await commit(input),
+      confirmedAfterRetry: false,
+    };
+  } catch (error) {
+    if (isVersionConflictError(error) === false) {
+      throw error;
+    }
+    return {
+      result: await commit(input),
+      confirmedAfterRetry: true,
+    };
+  }
+};
+
+const commitRetryConfirmedDiagnostic: ProjectSessionDiagnostic = {
+  level: "info",
+  code: "COMMIT_RETRY_CONFIRMED",
+  message:
+    "The transaction was confirmed committed after retrying the same transaction ID.",
+};
+
 const isProjectSessionBusyError = (error: unknown) =>
   getProjectSessionErrorCode(error) === "PROJECT_SESSION_BUSY";
 
@@ -822,12 +858,19 @@ export class ProjectSession {
           transaction,
         });
       }
-      const commit = await this.#options.transport.commitRestorePoint({
-        projectId: snapshot.projectId,
-        buildId: snapshot.buildId,
-        baseVersion: snapshot.version,
-        transactions: [transaction],
-      });
+      const { result: commit, confirmedAfterRetry } =
+        await commitWithConflictConfirmation({
+          commit: (input) => this.#options.transport.commitRestorePoint(input),
+          input: {
+            projectId: snapshot.projectId,
+            buildId: snapshot.buildId,
+            baseVersion: snapshot.version,
+            transactions: [transaction],
+          },
+        });
+      const diagnostics = confirmedAfterRetry
+        ? [commitRetryConfirmedDiagnostic]
+        : [];
       const applied = applyBuilderPatchTransactions(snapshot.state, [
         transaction,
       ]);
@@ -847,7 +890,7 @@ export class ProjectSession {
       const persisted = await this.#synchronizeAfterCommit({
         snapshot: committedSnapshot,
         namespaces: restorePointNamespaces,
-        diagnostics: [],
+        diagnostics,
       });
       return this.createEnvelope({
         source: "local",
@@ -1297,25 +1340,14 @@ export class ProjectSession {
       baseVersion: snapshot.version,
       transactions: [transaction],
     };
-    let commit: { version: number };
-    let commitDiagnostics = diagnostics;
-    try {
-      commit = await this.#options.transport.commitPatch(commitInput);
-    } catch (error) {
-      if (isVersionConflictError(error) === false) {
-        throw error;
-      }
-      commit = await this.#options.transport.commitPatch(commitInput);
-      commitDiagnostics = [
-        ...diagnostics,
-        {
-          level: "info",
-          code: "COMMIT_RETRY_CONFIRMED",
-          message:
-            "The transaction was confirmed committed after retrying the same transaction ID.",
-        },
-      ];
-    }
+    const { result: commit, confirmedAfterRetry } =
+      await commitWithConflictConfirmation({
+        commit: (input) => this.#options.transport.commitPatch(input),
+        input: commitInput,
+      });
+    const commitDiagnostics = confirmedAfterRetry
+      ? [...diagnostics, commitRetryConfirmedDiagnostic]
+      : diagnostics;
     const applied = applyBuilderPatchTransactions(snapshot.state, [
       transaction,
     ]);

--- a/packages/project-build/src/project-session.ts
+++ b/packages/project-build/src/project-session.ts
@@ -1291,12 +1291,31 @@ export class ProjectSession {
         input
       );
     }
-    const commit = await this.#options.transport.commitPatch({
+    const commitInput = {
       projectId: snapshot.projectId,
       buildId: snapshot.buildId,
       baseVersion: snapshot.version,
       transactions: [transaction],
-    });
+    };
+    let commit: { version: number };
+    let commitDiagnostics = diagnostics;
+    try {
+      commit = await this.#options.transport.commitPatch(commitInput);
+    } catch (error) {
+      if (isVersionConflictError(error) === false) {
+        throw error;
+      }
+      commit = await this.#options.transport.commitPatch(commitInput);
+      commitDiagnostics = [
+        ...diagnostics,
+        {
+          level: "info",
+          code: "COMMIT_RETRY_CONFIRMED",
+          message:
+            "The transaction was confirmed committed after retrying the same transaction ID.",
+        },
+      ];
+    }
     const applied = applyBuilderPatchTransactions(snapshot.state, [
       transaction,
     ]);
@@ -1328,7 +1347,7 @@ export class ProjectSession {
         contract.writeNamespaces,
         mutation.invalidatesNamespaces
       ),
-      diagnostics,
+      diagnostics: commitDiagnostics,
     });
     return this.createEnvelope({
       source: "local",

--- a/packages/wsauth/package.json
+++ b/packages/wsauth/package.json
@@ -31,7 +31,7 @@
     }
   },
   "files": [
-    "lib/*",
+    "lib/**/*",
     "README.md",
     "!*.{test,stories}.*"
   ],

--- a/packages/wsauth/src/package.test.ts
+++ b/packages/wsauth/src/package.test.ts
@@ -1,0 +1,129 @@
+import { execFile } from "node:child_process";
+import { createRequire } from "node:module";
+import { cp, mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { delimiter, dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { afterEach, test } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const require = createRequire(import.meta.url);
+const packageDirectory = fileURLToPath(new URL("..", import.meta.url));
+const workspaceDirectory = fileURLToPath(new URL("../../..", import.meta.url));
+const tsc = join(workspaceDirectory, "node_modules/.bin/tsc");
+const packageBinDirectory = join(workspaceDirectory, "node_modules/.bin");
+let temporaryDirectory: string | undefined;
+
+afterEach(async () => {
+  if (temporaryDirectory !== undefined) {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+    temporaryDirectory = undefined;
+  }
+});
+
+test("publishes type declarations for every public entrypoint", async () => {
+  temporaryDirectory = await mkdtemp(join(tmpdir(), "webstudio-wsauth-pack-"));
+  const packDirectory = join(temporaryDirectory, "pack");
+  const stagingDirectory = join(temporaryDirectory, "staging");
+  const projectDirectory = join(temporaryDirectory, "project");
+  await Promise.all([
+    mkdir(packDirectory, { recursive: true }),
+    mkdir(stagingDirectory, { recursive: true }),
+    mkdir(projectDirectory, { recursive: true }),
+  ]);
+  await Promise.all([
+    ...[
+      "package.json",
+      "README.md",
+      "src",
+      "tsconfig.json",
+      "tsconfig.dts.json",
+    ].map((entry) =>
+      cp(join(packageDirectory, entry), join(stagingDirectory, entry), {
+        recursive: true,
+      })
+    ),
+    ...[
+      ["zod", dirname(require.resolve("zod/package.json"))],
+      ["@types/node", dirname(require.resolve("@types/node/package.json"))],
+      [
+        "@webstudio-is/tsconfig",
+        dirname(require.resolve("@webstudio-is/tsconfig/package.json")),
+      ],
+      ["undici-types", dirname(require.resolve("undici-types/package.json"))],
+    ].map(async ([name, source]) => {
+      const destination = join(stagingDirectory, "node_modules", name);
+      await mkdir(dirname(destination), { recursive: true });
+      await cp(source, destination, { recursive: true });
+    }),
+  ]);
+
+  const env = {
+    ...process.env,
+    PATH: `${packageBinDirectory}${delimiter}${process.env.PATH ?? ""}`,
+  };
+  await execFileAsync("pnpm", ["build"], { cwd: stagingDirectory, env });
+  await execFileAsync("pnpm", ["dts"], { cwd: stagingDirectory, env });
+  const packed = JSON.parse(
+    (
+      await execFileAsync(
+        "npm",
+        ["pack", "--json", "--pack-destination", packDirectory],
+        { cwd: stagingDirectory }
+      )
+    ).stdout
+  ) as Array<{ filename: string }>;
+  const archive = join(packDirectory, packed[0]?.filename ?? "");
+  await writeFile(
+    join(projectDirectory, "package.json"),
+    JSON.stringify({
+      private: true,
+      type: "module",
+      dependencies: {
+        "@webstudio-is/wsauth": `file:${archive}`,
+        zod: `file:${dirname(require.resolve("zod/package.json"))}`,
+      },
+    }),
+    "utf8"
+  );
+  await execFileAsync(
+    "npm",
+    [
+      "install",
+      "--ignore-scripts",
+      "--no-package-lock",
+      "--no-audit",
+      "--no-fund",
+    ],
+    { cwd: projectDirectory }
+  );
+  await writeFile(
+    join(projectDirectory, "index.ts"),
+    `import type { WsAuthResources } from "@webstudio-is/wsauth";
+import type { WsAuthConfig } from "@webstudio-is/wsauth/schema";
+
+const routes: WsAuthResources["routes"] = [];
+const config: WsAuthConfig = { version: 1, routes: {} };
+void [routes, config];
+`,
+    "utf8"
+  );
+
+  await execFileAsync(
+    tsc,
+    [
+      "--ignoreConfig",
+      "--noEmit",
+      "--strict",
+      "--moduleResolution",
+      "bundler",
+      "--module",
+      "esnext",
+      "--target",
+      "es2022",
+      "index.ts",
+    ],
+    { cwd: projectDirectory }
+  );
+}, 30_000);

--- a/packages/wsauth/tsconfig.dts.json
+++ b/packages/wsauth/tsconfig.dts.json
@@ -1,10 +1,9 @@
 {
-  "extends": "@webstudio-is/tsconfig/base.json",
+  "extends": "./tsconfig.json",
   "include": ["src"],
+  "exclude": ["**/*.test.ts"],
   "compilerOptions": {
-    "emitDeclarationOnly": true,
-    "declaration": true,
-    "outDir": "lib/types",
+    "declarationDir": "lib/types",
     "rootDir": "./src"
   }
 }


### PR DESCRIPTION
## Summary

- confirm ambiguous project commits by retrying the exact transaction ID before treating a version conflict as a rejection
- share the confirmation path between normal mutations and restore-point commits
- emit an explicit sitemap entry type so an empty sitemap remains type-safe
- generate and publish TypeScript declarations for `@webstudio-is/wsauth`
- regenerate affected CLI fixtures

## Root cause

The project API already treats the latest transaction ID as idempotent, but ProjectSession interpreted the first `CONFLICT` response as a rejected write. If the original transaction had committed, the subsequent refresh exposed the requested values while the tool still reported failure.

The Cloudflare scaffold had two independent type-contract gaps: an empty generated sitemap inferred `never[]`, and the wsauth declaration build inherited a shared output directory, leaving its published package without the declaration files referenced by its exports.

## Technical choices

- Retry only a version conflict, once, with the same base version and transaction ID. A confirmed retry returns the committed server version; persistent conflicts continue through the existing refresh/retry-safe flow.
- Use the same confirmation helper for regular patch and restore-point transports.
- Keep the generated sitemap module standalone by emitting its concrete entry type inline.
- Make the wsauth declaration config extend its package config and publish nested `lib/types` output.
- Preserve existing API payloads and server idempotency behavior; no migration is required.

## Todo

- [x] Reproduce and cover ambiguous committed mutations
- [x] Reuse conflict confirmation for restore-point commits
- [x] Cover empty sitemap typechecking
- [x] Generate and inspect the wsauth package declarations
- [x] Regenerate affected fixtures
- [x] Verify the Cloudflare fixture typecheck and production build
- [x] Review documentation impact — no user-facing documentation changes are required

## Verification

- `pnpm --filter @webstudio-is/project-build test` — 2,092 tests passed
- `pnpm --filter @webstudio-is/project-build typecheck`
- `pnpm --filter webstudio test` — 972 tests passed
- `pnpm --filter webstudio typecheck`
- `pnpm --filter @webstudio-is/wsauth test`
- `pnpm --filter @webstudio-is/wsauth typecheck`
- `pnpm --filter @webstudio-is/wsauth build && pnpm --filter @webstudio-is/wsauth dts`
- `npm pack --dry-run --json` in `packages/wsauth` — both public declaration entrypoints included
- `pnpm -r fixtures:build`
- `pnpm --filter webstudio-cloudflare-template typecheck`
- `pnpm --filter webstudio-cloudflare-template build`
- focused formatting, lint, and `git diff --check`

Agent evaluations were not run because they require separate explicit approval.

Closes #6129
Closes #6130