### PR TITLE
fix: Allow folder index page paths

### DIFF
--- a/packages/project/src/db/build-patch.test.ts
+++ b/packages/project/src/db/build-patch.test.ts
@@ -395,6 +395,103 @@ describe("patchBuild", () => {
     ).toBe("/company");
   });
 
+  test("persists folder index paths for page updates and duplicates", async () => {
+    const buildWithFolder = {
+      ...buildRow,
+      pages: JSON.stringify({
+        meta: {},
+        homePage: {
+          id: "page-1",
+          name: "Home",
+          path: "",
+          title: "Home",
+          meta: {},
+          rootInstanceId: "body-1",
+        },
+        pages: [
+          {
+            id: "page-2",
+            name: "Landing",
+            path: "/landing",
+            title: "Landing",
+            meta: {},
+            rootInstanceId: "body-2",
+          },
+        ],
+        folders: [
+          {
+            id: "root",
+            name: "Root",
+            slug: "",
+            children: ["page-1", "folder-1"],
+          },
+          {
+            id: "folder-1",
+            name: "Folder",
+            slug: "folder",
+            children: ["page-2"],
+          },
+        ],
+      }),
+    };
+
+    const updated = await createBuildPatchUpdate({
+      build: buildWithFolder,
+      clientVersion: 3,
+      transactions: [
+        transaction({
+          payload: [
+            {
+              namespace: "pages",
+              patches: [
+                {
+                  op: "replace",
+                  path: ["pages", "page-2", "path"],
+                  value: "",
+                },
+              ],
+            },
+          ],
+        }),
+      ],
+    });
+    expect(updated.status).toBe("ok");
+
+    const duplicated = await createBuildPatchUpdate({
+      build: buildWithFolder,
+      clientVersion: 3,
+      transactions: [
+        transaction({
+          payload: [
+            {
+              namespace: "pages",
+              patches: [
+                {
+                  op: "add",
+                  path: ["pages", "page-copy"],
+                  value: {
+                    id: "page-copy",
+                    name: "Copy",
+                    path: "",
+                    title: "Copy",
+                    meta: {},
+                    rootInstanceId: "body-copy",
+                  },
+                },
+                {
+                  op: "add",
+                  path: ["folders", "folder-1", "children", 1],
+                  value: "page-copy",
+                },
+              ],
+            },
+          ],
+        }),
+      ],
+    });
+    expect(duplicated.status).toBe("ok");
+  });
+
   test("applies data source variable additions", async () => {
     const result = await createBuildPatchUpdate({
       build: buildRow,

--- a/packages/sdk/src/schema/pages.test.ts
+++ b/packages/sdk/src/schema/pages.test.ts
@@ -154,6 +154,40 @@ test("validates non-home page path is not empty", () => {
   ]);
 });
 
+test("allows an empty local path for a folder index page", () => {
+  expect(
+    pages.safeParse({
+      ...validPages,
+      pages: new Map(validPages.pages).set("folder-index", {
+        id: "folder-index",
+        name: "Folder index",
+        path: "",
+        title: `"Folder index"`,
+        meta: {},
+        rootInstanceId: "folderIndexRoot",
+      }),
+      folders: new Map([
+        [
+          "root",
+          {
+            ...validPages.folders.get("root")!,
+            children: ["home", "folder"],
+          },
+        ],
+        [
+          "folder",
+          {
+            id: "folder",
+            name: "Folder",
+            slug: "folder",
+            children: ["folder-index"],
+          },
+        ],
+      ]),
+    }).success
+  ).toBe(true);
+});
+
 test("supports text document type", () => {
   expect(documentTypes).toContain("text");
   expect(

--- a/packages/sdk/src/schema/pages.ts
+++ b/packages/sdk/src/schema/pages.ts
@@ -287,6 +287,17 @@ export const pages = z
   .superRefine((pages, context) => {
     const homePage = pages.pages.get(pages.homePageId);
     const rootFolder = pages.folders.get(pages.rootFolderId);
+    const folderIndexPageIds = new Set<Page["id"]>();
+    for (const [folderId, folder] of pages.folders) {
+      if (folderId === pages.rootFolderId) {
+        continue;
+      }
+      for (const childId of folder.children) {
+        if (pages.pages.has(childId)) {
+          folderIndexPageIds.add(childId);
+        }
+      }
+    }
     if (homePage === undefined) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
@@ -316,7 +327,11 @@ export const pages = z
           message: "Page id must match its record key",
         });
       }
-      if (pageId !== pages.homePageId && page.path === "") {
+      if (
+        pageId !== pages.homePageId &&
+        page.path === "" &&
+        folderIndexPageIds.has(pageId) === false
+      ) {
         context.addIssue({
           code: z.ZodIssueCode.custom,
           path: ["pages", pageId, "path"],


### PR DESCRIPTION
## Summary

Fix the dry-run/commit mismatch for folder index pages. Page mutations could plan an empty local path inside a folder, but persistence rejected the same page because the shared Pages schema treated every non-home empty path as invalid.

## Technical choices

- Derive valid folder-index page IDs from non-root folder children in the shared SDK schema.
- Continue rejecting empty paths for non-home pages at the root.
- Keep the existing home-page and root-folder invariants unchanged.
- Cover both an existing page update and the transaction shape used when duplicating a folder index page.

The other reports from this batch were verified against current main and closed against their existing fixes: browser process failures are covered by #6135, and fragment conflict options are covered by #6122.

## Checklist

- [x] Reproduce the persistence failure
- [x] Add regressions that fail before the schema fix and pass after it
- [x] Allow empty local paths only for pages parented by non-root folders
- [x] Verify update and duplicate persistence paths
- [x] Run the fixture sync/build pipeline and inspect generated output
- [x] Review documentation impact — no documentation change is needed because this restores the existing folder-index behavior
- [x] Review the final diff for duplicated logic, edge cases, and unrelated changes

## Verification

- `pnpm --filter @webstudio-is/sdk test` — 513 tests passed
- SDK typecheck passed
- `pnpm --filter @webstudio-is/project test` — 85 tests passed
- Project typecheck passed
- `pnpm --filter @webstudio-is/project-build test` — 2,094 tests passed
- Project-build typecheck passed
- `pnpm --filter ./packages/cli test` — 980 tests passed
- CLI typecheck passed
- `pnpm lint`
- `pnpm check:generated-api`
- `pnpm fixtures` — completed with no tracked fixture changes
- Real local Chrome and auto-browser screenshot reproductions passed, including parallel captures

Agent evaluations were not run because they require separate explicit approval.

Closes #6142