### PR TITLE
fix: Explain asset count limits

### DIFF
--- a/apps/builder/app/services/asset-rest.server.test.ts
+++ b/apps/builder/app/services/asset-rest.server.test.ts
@@ -3,6 +3,7 @@ import { TRPCError } from "@trpc/server";
 import {
   AssetRepositoryConflictError,
   AssetRepositoryNotFoundError,
+  AssetUploadCountLimitError,
 } from "@webstudio-is/asset-uploader/server";
 import { assetFolders } from "@webstudio-is/sdk";
 import { assetResourceLimits } from "@webstudio-is/sdk/asset-resource-limits";
@@ -30,6 +31,7 @@ describe("Assets REST responses", () => {
     [new TRPCError({ code: "FORBIDDEN" }), 403],
     [new AssetRepositoryNotFoundError("missing"), 404],
     [new AssetRepositoryConflictError("conflict"), 409],
+    [new AssetUploadCountLimitError(50), 409],
     [new AssetRestRangeError("bad range"), 416],
     [new AssetRestPayloadTooLargeError("too large"), 413],
     [new AssetUploadSizeLimitError("post.md", 10), 413],

--- a/apps/builder/app/services/asset-rest.server.ts
+++ b/apps/builder/app/services/asset-rest.server.ts
@@ -8,6 +8,7 @@ import {
   AssetRepositoryConflictError,
   AssetRepositoryNotFoundError,
   AssetRevisionConflictError,
+  AssetUploadCountLimitError,
   AssetUploadSizeLimitError,
   PostgresAssetRepository,
 } from "@webstudio-is/asset-uploader/server";
@@ -184,7 +185,8 @@ const getAssetRestErrorStatus = (error: unknown) => {
   }
   if (
     error instanceof AssetRepositoryConflictError ||
-    error instanceof AssetRevisionConflictError
+    error instanceof AssetRevisionConflictError ||
+    error instanceof AssetUploadCountLimitError
   ) {
     return 409;
   }

--- a/packages/asset-uploader/src/upload.test.ts
+++ b/packages/asset-uploader/src/upload.test.ts
@@ -7,7 +7,11 @@ import {
   testContext,
 } from "@webstudio-is/postgrest/testing";
 import type { AppContext } from "@webstudio-is/trpc-interface/index.server";
-import { createUploadTicket, uploadFile } from "./upload";
+import {
+  AssetUploadCountLimitError,
+  createUploadTicket,
+  uploadFile,
+} from "./upload";
 import { PostgresAssetRepository } from "./asset-repository";
 
 const server = createTestServer();
@@ -426,7 +430,7 @@ describe("createUploadTicket", () => {
         },
         createContext()
       )
-    ).rejects.toThrow("The maximum number of assets per project is 350.");
+    ).rejects.toBeInstanceOf(AssetUploadCountLimitError);
     expect(insertedAsset).toBe(false);
     expect(restoredFile).toBe(false);
   });
@@ -591,7 +595,7 @@ describe("createUploadTicket", () => {
         createContext(),
         () => "asset-2"
       )
-    ).rejects.toThrow("The maximum number of assets per project is 350.");
+    ).rejects.toBeInstanceOf(AssetUploadCountLimitError);
   });
 
   test("uses project owner's asset limit for shared workspace projects", async () => {

--- a/packages/asset-uploader/src/upload.ts
+++ b/packages/asset-uploader/src/upload.ts
@@ -30,6 +30,14 @@ export type CreateUploadTicketInput = {
   contentHash?: string;
 };
 
+export class AssetUploadCountLimitError extends Error {
+  constructor(maxAssetsPerProject: number) {
+    super(
+      `The maximum number of assets per project is ${maxAssetsPerProject}.`
+    );
+  }
+}
+
 const UPLOADING_STALE_TIMEOUT = 1000 * 60 * 30; // 30 minutes
 const maxCreateUploadTicketAttempts = 3;
 const contentHashUploadPollInterval = 100;
@@ -81,9 +89,7 @@ const assertAssetCapacity = async (projectId: string, context: AppContext) => {
     );
   const count = (assetCount.count ?? 0) + (uploadingCount.count ?? 0);
   if (count >= maxAssetsPerProject) {
-    throw new Error(
-      `The maximum number of assets per project is ${maxAssetsPerProject}.`
-    );
+    throw new AssetUploadCountLimitError(maxAssetsPerProject);
   }
 };
 


### PR DESCRIPTION
## Summary

Return a specific, safe error when a project reaches its plan's asset-count limit instead of reporting an internal Assets API failure.

## Root cause

The uploader enforced `maxAssetsPerProject` by throwing a plain `Error`. The REST boundary correctly treated unknown errors as internal failures, returned HTTP 500, and redacted the useful limit explanation. The Builder then displayed that generic response.

## Technical choices

- Represent the expected quota condition with `AssetUploadCountLimitError`.
- Map that domain error to HTTP 409 while preserving its existing message.
- Keep the generic HTTP 500 response and server logging for unexpected failures.
- Reuse the Builder's existing API-error handling; it already displays the returned `errors` value in the upload toast.

## Checklist

- [x] Reproduce the generic uploader and REST error behavior
- [x] Add regressions and verify they fail before the behavior change
- [x] Throw a typed error when the asset-count limit is reached
- [x] Return the safe limit explanation through the Assets API
- [x] Verify unexpected internal errors remain redacted
- [x] Review documentation impact — no documentation change is needed for this error-message correction
- [x] Review fixture impact — no fixture inputs or generated outputs are affected
- [x] Review the final diff for unrelated changes and duplicated logic

## Verification

- `pnpm --filter @webstudio-is/asset-uploader test` — 196 tests passed
- Asset uploader typecheck passed
- Targeted Builder Assets API and upload client tests — 37 tests passed
- Builder typecheck passed
- `pnpm lint`

Closes #6148