### PR TITLE
fix: Preserve variable font styles

### DIFF
--- a/docs/university/how-tos/how-to-use-custom-fonts.md
+++ b/docs/university/how-tos/how-to-use-custom-fonts.md
@@ -72,7 +72,8 @@ When uploading custom fonts, these formats are supported:
 
 - **Use WOFF2 format** when possible for smallest file size
 - **Limit font variations** — only upload weights you actually use
-- **Consider variable fonts** — one file contains multiple weights
+- **Upload upright and italic files together** when a family provides separate files. Webstudio reads each file's style metadata so the browser can select the correct face.
+- **Consider variable fonts** — one file can contain multiple weights and may also contain italic or slant variations
 
 ---
 

--- a/fixtures/react-router-cloudflare/.webstudio/data.json
+++ b/fixtures/react-router-cloudflare/.webstudio/data.json
@@ -1,5 +1,5 @@
 {
-  "bundleVersion": "bundle-oez66b",
+  "bundleVersion": "bundle-1pgeukw",
   "build": {
     "id": "f565d527-32e7-4731-bc71-aca9e9574587",
     "projectId": "d845c167-ea07-4875-b08d-83e97c09dcce",

--- a/fixtures/react-router-docker/.webstudio/data.json
+++ b/fixtures/react-router-docker/.webstudio/data.json
@@ -1,5 +1,5 @@
 {
-  "bundleVersion": "bundle-oez66b",
+  "bundleVersion": "bundle-1pgeukw",
   "build": {
     "id": "f565d527-32e7-4731-bc71-aca9e9574587",
     "projectId": "d845c167-ea07-4875-b08d-83e97c09dcce",

--- a/fixtures/react-router-netlify/.webstudio/data.json
+++ b/fixtures/react-router-netlify/.webstudio/data.json
@@ -1,5 +1,5 @@
 {
-  "bundleVersion": "bundle-oez66b",
+  "bundleVersion": "bundle-1pgeukw",
   "build": {
     "id": "f565d527-32e7-4731-bc71-aca9e9574587",
     "projectId": "d845c167-ea07-4875-b08d-83e97c09dcce",

--- a/fixtures/react-router-vercel/.webstudio/data.json
+++ b/fixtures/react-router-vercel/.webstudio/data.json
@@ -1,5 +1,5 @@
 {
-  "bundleVersion": "bundle-oez66b",
+  "bundleVersion": "bundle-1pgeukw",
   "build": {
     "id": "f565d527-32e7-4731-bc71-aca9e9574587",
     "projectId": "d845c167-ea07-4875-b08d-83e97c09dcce",

--- a/fixtures/ssg-cloudflare-pages/.webstudio/data.json
+++ b/fixtures/ssg-cloudflare-pages/.webstudio/data.json
@@ -1,5 +1,5 @@
 {
-  "bundleVersion": "bundle-oez66b",
+  "bundleVersion": "bundle-1pgeukw",
   "build": {
     "id": "a2e8de30-03d5-4514-a3a6-406b3266a3af",
     "projectId": "d845c167-ea07-4875-b08d-83e97c09dcce",

--- a/fixtures/ssg-netlify-by-project-id/.webstudio/data.json
+++ b/fixtures/ssg-netlify-by-project-id/.webstudio/data.json
@@ -1,5 +1,5 @@
 {
-  "bundleVersion": "bundle-oez66b",
+  "bundleVersion": "bundle-1pgeukw",
   "build": {
     "id": "8f0fdff2-e76b-4f86-9203-ea7df5f1143c",
     "projectId": "8a7358b1-7de3-459d-b7b1-56dddfb6ce1e",

--- a/fixtures/webstudio-cloudflare-template/.webstudio/data.json
+++ b/fixtures/webstudio-cloudflare-template/.webstudio/data.json
@@ -1,5 +1,5 @@
 {
-  "bundleVersion": "bundle-oez66b",
+  "bundleVersion": "bundle-1pgeukw",
   "build": {
     "id": "a2e8de30-03d5-4514-a3a6-406b3266a3af",
     "projectId": "d845c167-ea07-4875-b08d-83e97c09dcce",

--- a/fixtures/webstudio-features/.webstudio/data.json
+++ b/fixtures/webstudio-features/.webstudio/data.json
@@ -1,5 +1,5 @@
 {
-  "bundleVersion": "bundle-oez66b",
+  "bundleVersion": "bundle-1pgeukw",
   "build": {
     "id": "1b66ee06-8ea5-4420-9a0e-e0d3a67aca32",
     "projectId": "cddc1d44-af37-4cb6-a430-d300cf6f932d",

--- a/packages/asset-uploader/src/utils/font-data.test.ts
+++ b/packages/asset-uploader/src/utils/font-data.test.ts
@@ -1,7 +1,10 @@
 import { describe, test, expect } from "vitest";
-import { parseSubfamily, __testing__ } from "./font-data";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { getFontData, parseSubfamily, __testing__ } from "./font-data";
 
-const { getFontFamily, normalizeFamily } = __testing__;
+const { detectFontStyle, getFontFamily, normalizeFamily } = __testing__;
+const require = createRequire(import.meta.url);
 
 describe("font-data", () => {
   describe("parseSubfamily()", () => {
@@ -111,6 +114,59 @@ describe("font-data", () => {
         `"Roboto Bold"`
       );
       expect(normalizeFamily("", "", "font.woff")).toBe(`font`);
+    });
+  });
+
+  test("detects style from authoritative font metadata", () => {
+    expect(
+      detectFontStyle(
+        {
+          "OS/2": { fsSelection: { italic: true, oblique: false } },
+          italicAngle: 0,
+        },
+        "normal"
+      )
+    ).toBe("italic");
+    expect(
+      detectFontStyle(
+        {
+          "OS/2": { fsSelection: { italic: false, oblique: true } },
+          italicAngle: 0,
+        },
+        "normal"
+      )
+    ).toBe("oblique");
+    expect(
+      detectFontStyle(
+        {
+          "OS/2": { fsSelection: { italic: false, oblique: false } },
+          italicAngle: -12,
+        },
+        "normal"
+      )
+    ).toBe("italic");
+  });
+
+  test("detects separate upright and italic variable font files", () => {
+    const readInter = (style: "normal" | "italic") => {
+      const name = `inter-latin-wght-${style}.woff2`;
+      return getFontData(
+        readFileSync(
+          require.resolve(`@fontsource-variable/inter/files/${name}`)
+        ),
+        name
+      );
+    };
+
+    expect(readInter("normal")).toMatchObject({
+      family: "Inter",
+      style: "normal",
+      variationAxes: { wght: { min: 100, default: 400, max: 900 } },
+    });
+    expect(readInter("italic")).toMatchObject({
+      family: "Inter",
+      style: "italic",
+      variationAxes: { wght: { min: 100, default: 400, max: 900 } },
     });
   });
 

--- a/packages/asset-uploader/src/utils/font-data.ts
+++ b/packages/asset-uploader/src/utils/font-data.ts
@@ -91,9 +91,37 @@ type FontDataStatic = {
 type FontDataVariable = {
   format: FontFormat;
   family: string;
+  style: FontStyle;
   variationAxes: VariationAxes;
 };
 type FontData = FontDataStatic | FontDataVariable;
+
+type FontStyleSource = {
+  "OS/2"?: {
+    fsSelection?: {
+      italic?: boolean;
+      oblique?: boolean;
+    };
+  };
+  italicAngle?: number;
+};
+
+const detectFontStyle = (
+  font: FontStyleSource,
+  fallback: FontStyle
+): FontStyle => {
+  const selection = font["OS/2"]?.fsSelection;
+  if (selection?.italic === true) {
+    return "italic";
+  }
+  if (selection?.oblique === true) {
+    return "oblique";
+  }
+  if (font.italicAngle !== undefined && font.italicAngle !== 0) {
+    return "italic";
+  }
+  return fallback;
+};
 
 export const getFontData = (data: Uint8Array, fileName: string): FontData => {
   const font = createFontKit(data as Buffer);
@@ -107,12 +135,18 @@ export const getFontData = (data: Uint8Array, fileName: string): FontData => {
     font.getName("fontSubfamily", defaultLanguage) ??
     "";
   const family = normalizeFamily(originalFamily, subfamily, fileName);
+  const parsedSubfamily = parseSubfamily(
+    subfamily,
+    font["OS/2"]?.usWeightClass
+  );
+  const style = detectFontStyle(font, parsedSubfamily.style);
   const isVariable = Object.keys(font.variationAxes).length !== 0;
 
   if (isVariable) {
     return {
       format,
       family,
+      style,
       variationAxes: font.variationAxes,
     };
   }
@@ -120,7 +154,8 @@ export const getFontData = (data: Uint8Array, fileName: string): FontData => {
   return {
     format,
     family,
-    ...parseSubfamily(subfamily, font["OS/2"]?.usWeightClass),
+    style,
+    weight: parsedSubfamily.weight,
   };
 };
 
@@ -131,4 +166,5 @@ export const __testing__: {
     fileName: string
   ) => string;
   getFontFamily: typeof getFontFamily;
-} = { normalizeFamily, getFontFamily };
+  detectFontStyle: typeof detectFontStyle;
+} = { normalizeFamily, getFontFamily, detectFontStyle };

--- a/packages/asset-uploader/src/utils/get-asset-data.test.ts
+++ b/packages/asset-uploader/src/utils/get-asset-data.test.ts
@@ -58,7 +58,11 @@ describe("asset data overrides", () => {
         {
           size: 100,
           format: "woff2",
-          meta: { family: "Detected Family", variationAxes },
+          meta: {
+            family: "Detected Family",
+            style: "italic",
+            variationAxes,
+          },
         },
         {
           format: "woff2",
@@ -72,7 +76,11 @@ describe("asset data overrides", () => {
     ).toEqual({
       size: 100,
       format: "woff2",
-      meta: { family: "Configured Family", variationAxes },
+      meta: {
+        family: "Configured Family",
+        style: "normal",
+        variationAxes,
+      },
     });
   });
 

--- a/packages/cli/evaluations/high-impact/validate.ts
+++ b/packages/cli/evaluations/high-impact/validate.ts
@@ -522,8 +522,8 @@ const validateFontAssets = (
       fontAssets.every(
         (asset) =>
           asset.meta.family === fontAssetFixtureMeta.family &&
-          "style" in asset.meta &&
           asset.meta.style === fontAssetFixtureMeta.style &&
+          "weight" in asset.meta &&
           asset.meta.weight === fontAssetFixtureMeta.weight
       ),
     "Uploaded font metadata did not persist as Rajdhani normal 600."

--- a/packages/fonts/src/get-font-faces.test.ts
+++ b/packages/fonts/src/get-font-faces.test.ts
@@ -202,6 +202,7 @@ describe("getFontFaces()", () => {
         format: "ttf",
         meta: {
           family: "Inter",
+          style: "normal",
           variationAxes: {
             wght: { name: "wght", min: 100, default: 400, max: 1000 },
             wdth: { name: "wdth", min: 25, default: 100, max: 151 },
@@ -232,7 +233,79 @@ describe("getFontFaces()", () => {
     "fontWeight": "100 1000",
     "src": "url("/fonts/inter.ttf") format("truetype")",
   },
+  {
+    "fontDisplay": "swap",
+    "fontFamily": "Inter",
+    "fontStretch": "25% 151%",
+    "fontStyle": "oblique",
+    "fontWeight": "100 1000",
+    "src": "url("/fonts/inter.ttf") format("truetype")",
+  },
 ]
 `);
+  });
+
+  test("keeps separate upright and italic variable font files", () => {
+    const variationAxes = {
+      wght: { name: "Weight", min: 100, default: 400, max: 900 },
+      wdth: { name: "Width", min: 75, default: 100, max: 100 },
+    };
+    const assets: Array<PartialFontAsset> = [
+      {
+        format: "woff2",
+        meta: { family: "Example", style: "normal", variationAxes },
+        name: "example-normal.woff2",
+      },
+      {
+        format: "woff2",
+        meta: { family: "Example", style: "italic", variationAxes },
+        name: "example-italic.woff2",
+      },
+    ];
+
+    expect(getFontFaces(assets, { assetBaseUrl: "/fonts/" })).toEqual([
+      {
+        fontDisplay: "swap",
+        fontFamily: "Example",
+        fontStretch: "75% 100%",
+        fontStyle: "normal",
+        fontWeight: "100 900",
+        src: 'url("/fonts/example-normal.woff2") format("woff2")',
+      },
+      {
+        fontDisplay: "swap",
+        fontFamily: "Example",
+        fontStretch: "75% 100%",
+        fontStyle: "italic",
+        fontWeight: "100 900",
+        src: 'url("/fonts/example-italic.woff2") format("woff2")',
+      },
+    ]);
+  });
+
+  test("registers variable ital and slant axes for matching styles", () => {
+    const faces = getFontFaces(
+      [
+        {
+          format: "woff2",
+          meta: {
+            family: "Flexible",
+            style: "normal",
+            variationAxes: {
+              ital: { name: "Italic", min: 0, default: 0, max: 1 },
+              slnt: { name: "Slant", min: -12, default: 0, max: 0 },
+            },
+          },
+          name: "flexible.woff2",
+        },
+      ],
+      { assetBaseUrl: "/fonts/" }
+    );
+
+    expect(faces.map(({ fontStyle }) => fontStyle)).toEqual([
+      "normal",
+      "italic",
+      "oblique",
+    ]);
   });
 });

--- a/packages/fonts/src/get-font-faces.ts
+++ b/packages/fonts/src/get-font-faces.ts
@@ -1,5 +1,5 @@
-import { FONT_FORMATS } from "./constants";
-import type { FontMeta, FontFormat, FontMetaStatic } from "./schema";
+import { FONT_FORMATS, type FontStyle } from "./constants";
+import type { FontMeta, FontFormat } from "./schema";
 
 export type PartialFontAsset = {
   format: FontFormat;
@@ -11,7 +11,7 @@ export type FontFace = {
   fontFamily: string;
   fontDisplay: "swap" | "auto" | "block" | "fallback" | "optional";
   src: string;
-  fontStyle?: FontMetaStatic["style"];
+  fontStyle?: FontStyle;
   fontWeight?: number | string;
   fontStretch?: string;
 };
@@ -30,13 +30,14 @@ const getFontFormat = (asset: PartialFontAsset): string => {
 const formatFace = (
   asset: PartialFontAsset,
   format: string,
-  url: string
+  url: string,
+  style: FontStyle
 ): FontFace => {
   if ("variationAxes" in asset.meta) {
     const { wght, wdth } = asset.meta?.variationAxes ?? {};
     return {
       fontFamily: asset.meta.family,
-      fontStyle: "normal",
+      fontStyle: style,
       fontDisplay: "swap",
       src: `url(${sanitizeCssUrl(url)}) format("${format}")`,
       fontStretch: wdth ? `${wdth.min}% ${wdth.max}%` : undefined,
@@ -45,18 +46,40 @@ const formatFace = (
   }
   return {
     fontFamily: asset.meta.family,
-    fontStyle: asset.meta.style,
+    fontStyle: style,
     fontWeight: asset.meta.weight,
     fontDisplay: "swap",
     src: `url(${sanitizeCssUrl(url)}) format("${format}")`,
   };
 };
 
-const getKey = (asset: PartialFontAsset) => {
+const getKey = (asset: PartialFontAsset, style: FontStyle) => {
   if ("variationAxes" in asset.meta) {
-    return asset.meta.family + Object.values(asset.meta.variationAxes).join("");
+    const { wght, wdth } = asset.meta.variationAxes;
+    return JSON.stringify([asset.meta.family, style, wght, wdth]);
   }
-  return asset.meta.family + asset.meta.style + asset.meta.weight;
+  return JSON.stringify([asset.meta.family, style, asset.meta.weight]);
+};
+
+const getStyles = (meta: FontMeta): FontStyle[] => {
+  const styles = new Set<FontStyle>([meta.style]);
+  if ("variationAxes" in meta) {
+    const { ital, slnt } = meta.variationAxes;
+    if (ital !== undefined && ital.min <= 0 && ital.max >= 1) {
+      styles.add("normal");
+      styles.add("italic");
+    }
+    if (
+      slnt !== undefined &&
+      slnt.min < slnt.max &&
+      slnt.min <= 0 &&
+      slnt.max >= 0
+    ) {
+      styles.add("normal");
+      styles.add("oblique");
+    }
+  }
+  return Array.from(styles);
 };
 
 export const getFontFaces = (
@@ -68,33 +91,44 @@ export const getFontFaces = (
   const { assetBaseUrl } = options;
   const faces = new Map<
     string,
-    Map<string, { asset: PartialFontAsset; format: string; url: string }>
+    Map<
+      string,
+      {
+        asset: PartialFontAsset;
+        format: string;
+        style: FontStyle;
+        url: string;
+      }
+    >
   >();
-  const seenUrls = new Set<string>();
+  const seenSources = new Set<string>();
   for (const asset of assets) {
     const url = `${assetBaseUrl}${asset.name}`;
-    const assetKey = getKey(asset);
-    if (seenUrls.has(url)) {
-      continue;
+    for (const style of getStyles(asset.meta)) {
+      const sourceKey = JSON.stringify([url, style]);
+      if (seenSources.has(sourceKey)) {
+        continue;
+      }
+      seenSources.add(sourceKey);
+      const assetKey = getKey(asset, style);
+      const format = getFontFormat(asset);
+      const sources = faces.get(assetKey) ?? new Map();
+      const existing = sources.get(format);
+      if (existing === undefined || url < existing.url) {
+        sources.set(format, { asset, format, style, url });
+      }
+      faces.set(assetKey, sources);
     }
-    seenUrls.add(url);
-    const format = getFontFormat(asset);
-    const sources = faces.get(assetKey) ?? new Map();
-    const existing = sources.get(format);
-    if (existing === undefined || url < existing.url) {
-      sources.set(format, { asset, format, url });
-    }
-    faces.set(assetKey, sources);
   }
   return Array.from(faces.values(), (sources) => {
-    const [{ asset, format, url }, ...fallbacks] = Array.from(
+    const [{ asset, format, style, url }, ...fallbacks] = Array.from(
       sources.values()
     ).sort(
       (left, right) =>
         fontFormatOrder.indexOf(left.format) -
         fontFormatOrder.indexOf(right.format)
     );
-    const face = formatFace(asset, format, url);
+    const face = formatFace(asset, format, url, style);
     face.src += fallbacks
       .map(
         ({ format: fallbackFormat, url: fallbackUrl }) =>

--- a/packages/fonts/src/get-font-faces.ts
+++ b/packages/fonts/src/get-font-faces.ts
@@ -27,29 +27,31 @@ const getFontFormat = (asset: PartialFontAsset): string => {
     : (FONT_FORMATS.get(asset.format) ?? asset.format);
 };
 
-const formatFace = (
-  asset: PartialFontAsset,
-  format: string,
-  url: string,
-  style: FontStyle
-): FontFace => {
+type FontSource = {
+  asset: PartialFontAsset;
+  format: string;
+  style: FontStyle;
+  url: string;
+};
+
+const formatFace = ({ asset, format, style, url }: FontSource): FontFace => {
+  const face = {
+    fontFamily: asset.meta.family,
+    fontStyle: style,
+    fontDisplay: "swap" as const,
+    src: `url(${sanitizeCssUrl(url)}) format("${format}")`,
+  };
   if ("variationAxes" in asset.meta) {
-    const { wght, wdth } = asset.meta?.variationAxes ?? {};
+    const { wght, wdth } = asset.meta.variationAxes;
     return {
-      fontFamily: asset.meta.family,
-      fontStyle: style,
-      fontDisplay: "swap",
-      src: `url(${sanitizeCssUrl(url)}) format("${format}")`,
+      ...face,
       fontStretch: wdth ? `${wdth.min}% ${wdth.max}%` : undefined,
       fontWeight: wght ? `${wght.min} ${wght.max}` : undefined,
     };
   }
   return {
-    fontFamily: asset.meta.family,
-    fontStyle: style,
+    ...face,
     fontWeight: asset.meta.weight,
-    fontDisplay: "swap",
-    src: `url(${sanitizeCssUrl(url)}) format("${format}")`,
   };
 };
 
@@ -89,18 +91,7 @@ export const getFontFaces = (
   }
 ): Array<FontFace> => {
   const { assetBaseUrl } = options;
-  const faces = new Map<
-    string,
-    Map<
-      string,
-      {
-        asset: PartialFontAsset;
-        format: string;
-        style: FontStyle;
-        url: string;
-      }
-    >
-  >();
+  const faces = new Map<string, Map<string, FontSource>>();
   const seenSources = new Set<string>();
   for (const asset of assets) {
     const url = `${assetBaseUrl}${asset.name}`;
@@ -121,14 +112,12 @@ export const getFontFaces = (
     }
   }
   return Array.from(faces.values(), (sources) => {
-    const [{ asset, format, style, url }, ...fallbacks] = Array.from(
-      sources.values()
-    ).sort(
+    const [source, ...fallbacks] = Array.from(sources.values()).sort(
       (left, right) =>
         fontFormatOrder.indexOf(left.format) -
         fontFormatOrder.indexOf(right.format)
     );
-    const face = formatFace(asset, format, url, style);
+    const face = formatFace(source);
     face.src += fallbacks
       .map(
         ({ format: fallbackFormat, url: fallbackUrl }) =>

--- a/packages/fonts/src/schema.test.ts
+++ b/packages/fonts/src/schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { fontMeta, mergeFontMeta } from "./schema";
+import { fontMeta, fontMetaUpdate, mergeFontMeta } from "./schema";
 
 test("accepts custom variation axes", () => {
   const meta = {
@@ -10,20 +10,47 @@ test("accepts custom variation axes", () => {
     },
   };
 
-  expect(fontMeta.parse(meta)).toEqual(meta);
+  expect(fontMeta.parse(meta)).toEqual({ ...meta, style: "normal" });
 });
 
 describe("mergeFontMeta", () => {
+  test("defaults legacy variable fonts to normal style", () => {
+    expect(fontMeta.parse({ family: "Inter", variationAxes: {} })).toEqual({
+      family: "Inter",
+      style: "normal",
+      variationAxes: {},
+    });
+  });
+
+  test("round-trips and updates variable font metadata", () => {
+    const variationAxes = {
+      wght: { name: "Weight", min: 100, default: 400, max: 900 },
+    };
+    const meta = { family: "Inter", style: "italic" as const, variationAxes };
+    expect(fontMetaUpdate.parse(meta)).toEqual(meta);
+    expect(
+      mergeFontMeta(
+        { family: "Inter", style: "normal", variationAxes },
+        { style: "italic" }
+      )
+    ).toEqual(meta);
+    expect(mergeFontMeta(meta, { variationAxes })).toEqual(meta);
+  });
+
   test("keeps the detected font shape", () => {
     const variationAxes = {
       wght: { name: "Weight", min: 100, default: 400, max: 900 },
     };
     expect(
       mergeFontMeta(
-        { family: "Detected Family", variationAxes },
+        { family: "Detected Family", style: "normal", variationAxes },
         { family: "Configured Family", style: "normal", weight: 400 }
       )
-    ).toEqual({ family: "Configured Family", variationAxes });
+    ).toEqual({
+      family: "Configured Family",
+      style: "normal",
+      variationAxes,
+    });
     expect(
       mergeFontMeta(
         { family: "Detected Family", style: "normal", weight: 400 },
@@ -41,6 +68,7 @@ describe("mergeFontMeta", () => {
       mergeFontMeta(
         {
           family: "Detected Family",
+          style: "normal",
           variationAxes: {
             wght: { name: "Weight", min: 100, default: 400, max: 900 },
           },

--- a/packages/fonts/src/schema.ts
+++ b/packages/fonts/src/schema.ts
@@ -66,9 +66,8 @@ export const mergeFontMeta = (
   if (result.success === false) {
     return;
   }
-  const { family } = result.data;
+  const { family, style } = result.data;
   if ("variationAxes" in current) {
-    const style = "style" in result.data ? result.data.style : undefined;
     const variationAxes =
       "variationAxes" in result.data ? result.data.variationAxes : undefined;
     return {
@@ -78,7 +77,6 @@ export const mergeFontMeta = (
       ...(variationAxes === undefined ? {} : { variationAxes }),
     };
   }
-  const style = "style" in result.data ? result.data.style : undefined;
   const weight = "weight" in result.data ? result.data.weight : undefined;
   return {
     ...current,

--- a/packages/fonts/src/schema.ts
+++ b/packages/fonts/src/schema.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import { FONT_STYLES } from "./constants";
 
+const fontStyle = z.enum(FONT_STYLES);
+
 export const fontFormat = z.union([
   z.literal("ttf"),
   z.literal("woff"),
@@ -29,7 +31,7 @@ export type VariationAxes = z.infer<typeof variationAxes>;
 
 export const fontMetaStatic = z.object({
   family: z.string(),
-  style: z.enum(FONT_STYLES),
+  style: fontStyle,
   weight: z.number(),
 });
 
@@ -37,6 +39,7 @@ export type FontMetaStatic = z.infer<typeof fontMetaStatic>;
 
 export const fontMetaVariable = z.object({
   family: z.string(),
+  style: fontStyle.default("normal"),
   variationAxes: variationAxes,
 });
 
@@ -44,7 +47,13 @@ export const fontMeta = z.union([fontMetaStatic, fontMetaVariable]);
 
 export const fontMetaUpdate = z.union([
   fontMetaStatic.partial().strict(),
-  fontMetaVariable.partial().strict(),
+  z
+    .object({
+      family: fontMetaVariable.shape.family.optional(),
+      style: fontStyle.optional(),
+      variationAxes: fontMetaVariable.shape.variationAxes.optional(),
+    })
+    .strict(),
 ]);
 
 export type FontMeta = z.infer<typeof fontMeta>;
@@ -59,11 +68,13 @@ export const mergeFontMeta = (
   }
   const { family } = result.data;
   if ("variationAxes" in current) {
+    const style = "style" in result.data ? result.data.style : undefined;
     const variationAxes =
       "variationAxes" in result.data ? result.data.variationAxes : undefined;
     return {
       ...current,
       ...(family === undefined ? {} : { family }),
+      ...(style === undefined ? {} : { style }),
       ...(variationAxes === undefined ? {} : { variationAxes }),
     };
   }

--- a/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
+++ b/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
@@ -3741,6 +3741,11 @@ export const runtimeOperationContractData = [
                                       family: {
                                         type: "string",
                                       },
+                                      style: {
+                                        default: "normal",
+                                        type: "string",
+                                        enum: ["normal", "italic", "oblique"],
+                                      },
                                       variationAxes: {
                                         type: "object",
                                         propertyNames: {
@@ -6857,6 +6862,11 @@ export const runtimeOperationContractData = [
                                     properties: {
                                       family: {
                                         type: "string",
+                                      },
+                                      style: {
+                                        default: "normal",
+                                        type: "string",
+                                        enum: ["normal", "italic", "oblique"],
                                       },
                                       variationAxes: {
                                         type: "object",
@@ -9986,6 +9996,11 @@ export const runtimeOperationContractData = [
                                       family: {
                                         type: "string",
                                       },
+                                      style: {
+                                        default: "normal",
+                                        type: "string",
+                                        enum: ["normal", "italic", "oblique"],
+                                      },
                                       variationAxes: {
                                         type: "object",
                                         propertyNames: {
@@ -13102,6 +13117,11 @@ export const runtimeOperationContractData = [
                                     properties: {
                                       family: {
                                         type: "string",
+                                      },
+                                      style: {
+                                        default: "normal",
+                                        type: "string",
+                                        enum: ["normal", "italic", "oblique"],
                                       },
                                       variationAxes: {
                                         type: "object",
@@ -18929,6 +18949,15 @@ export const runtimeOperationContractData = [
                                             family: {
                                               type: "string",
                                             },
+                                            style: {
+                                              default: "normal",
+                                              type: "string",
+                                              enum: [
+                                                "normal",
+                                                "italic",
+                                                "oblique",
+                                              ],
+                                            },
                                             variationAxes: {
                                               type: "object",
                                               propertyNames: {
@@ -22249,6 +22278,15 @@ export const runtimeOperationContractData = [
                                           properties: {
                                             family: {
                                               type: "string",
+                                            },
+                                            style: {
+                                              default: "normal",
+                                              type: "string",
+                                              enum: [
+                                                "normal",
+                                                "italic",
+                                                "oblique",
+                                              ],
                                             },
                                             variationAxes: {
                                               type: "object",
@@ -36615,6 +36653,11 @@ export const runtimeOperationContractData = [
                                       family: {
                                         type: "string",
                                       },
+                                      style: {
+                                        default: "normal",
+                                        type: "string",
+                                        enum: ["normal", "italic", "oblique"],
+                                      },
                                       variationAxes: {
                                         type: "object",
                                         propertyNames: {
@@ -39810,6 +39853,11 @@ export const runtimeOperationContractData = [
                                     properties: {
                                       family: {
                                         type: "string",
+                                      },
+                                      style: {
+                                        default: "normal",
+                                        type: "string",
+                                        enum: ["normal", "italic", "oblique"],
                                       },
                                       variationAxes: {
                                         type: "object",
@@ -46119,6 +46167,11 @@ export const runtimeOperationContractData = [
                               family: {
                                 type: "string",
                               },
+                              style: {
+                                default: "normal",
+                                type: "string",
+                                enum: ["normal", "italic", "oblique"],
+                              },
                               variationAxes: {
                                 type: "object",
                                 propertyNames: {
@@ -51924,6 +51977,11 @@ export const runtimeOperationContractData = [
                             properties: {
                               family: {
                                 type: "string",
+                              },
+                              style: {
+                                default: "normal",
+                                type: "string",
+                                enum: ["normal", "italic", "oblique"],
                               },
                               variationAxes: {
                                 type: "object",
@@ -70656,6 +70714,10 @@ export const runtimeOperationContractData = [
                         family: {
                           type: "string",
                         },
+                        style: {
+                          type: "string",
+                          enum: ["normal", "italic", "oblique"],
+                        },
                         variationAxes: {
                           type: "object",
                           propertyNames: {
@@ -70710,7 +70772,7 @@ export const runtimeOperationContractData = [
                 },
               ],
               description:
-                "Type-specific metadata: family/style/weight or variationAxes for fonts, width/height for images, and no fields for generic files.",
+                "Type-specific metadata: family and style plus weight for static fonts or variationAxes for variable fonts, width/height for images, and no fields for generic files.",
             },
           },
           required: [],
@@ -70905,6 +70967,11 @@ export const runtimeOperationContractData = [
                       properties: {
                         family: {
                           type: "string",
+                        },
+                        style: {
+                          default: "normal",
+                          type: "string",
+                          enum: ["normal", "italic", "oblique"],
                         },
                         variationAxes: {
                           type: "object",

--- a/packages/project-build/src/runtime/assets.test.ts
+++ b/packages/project-build/src/runtime/assets.test.ts
@@ -1154,6 +1154,23 @@ describe("updateAsset", () => {
       values: { meta: { family: "Rajdhani Display", weight: 600 } },
     });
 
+    const variationAxes = {
+      wght: { name: "Weight", min: 100, default: 400, max: 900 },
+    };
+    expect(
+      assetUpdateInput.parse({
+        assetId: "variable-font-1",
+        values: {
+          meta: { family: "Inter", style: "italic", variationAxes },
+        },
+      })
+    ).toEqual({
+      assetId: "variable-font-1",
+      values: {
+        meta: { family: "Inter", style: "italic", variationAxes },
+      },
+    });
+
     expect(
       assetUpdateInput.parse({
         assetId: "image-1",

--- a/packages/project-build/src/runtime/assets.ts
+++ b/packages/project-build/src/runtime/assets.ts
@@ -105,7 +105,7 @@ export const assetUpdateInput = z.object({
       folderId: z.union([z.string().min(1), z.null()]).optional(),
       meta: assetMetaUpdate
         .describe(
-          "Type-specific metadata: family/style/weight or variationAxes for fonts, width/height for images, and no fields for generic files."
+          "Type-specific metadata: family and style plus weight for static fonts or variationAxes for variable fonts, width/height for images, and no fields for generic files."
         )
         .optional(),
     })

--- a/packages/sdk/src/assets.test.ts
+++ b/packages/sdk/src/assets.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from "vitest";
+import { fontMeta } from "@webstudio-is/fonts";
 import {
   ALLOWED_FILE_TYPES,
   getMimeTypeByExtension,
@@ -1027,10 +1028,10 @@ describe("allowed-file-types", () => {
       format: "woff2" as const,
       description: null,
       createdAt: "2024-01-01",
-      meta: {
+      meta: fontMeta.parse({
         family: "Inter",
         variationAxes: {},
-      },
+      }),
     };
 
     const mockGenericAsset = {
@@ -1064,7 +1065,7 @@ describe("allowed-file-types", () => {
       });
     });
 
-    test("converts variable font asset without style/weight", () => {
+    test("defaults variable font style and omits weight", () => {
       const result = toRuntimeAsset(
         mockVariableFontAsset,
         "https://example.com"
@@ -1072,6 +1073,7 @@ describe("allowed-file-types", () => {
       expect(result).toEqual({
         url: "/cgi/asset/variable-font.woff2?format=raw",
         family: "Inter",
+        style: "normal",
       });
     });
 

--- a/packages/sdk/src/assets.ts
+++ b/packages/sdk/src/assets.ts
@@ -586,10 +586,10 @@ const extractFontMetadata = (asset: Asset): RuntimeMetadata => {
   }
   const metadata: Omit<RuntimeAsset, "url"> = {
     family: asset.meta.family,
+    style: asset.meta.style,
   };
-  // Static fonts have style and weight, variable fonts have variationAxes
-  if ("style" in asset.meta) {
-    metadata.style = asset.meta.style;
+  // Static fonts have weight, variable fonts have variationAxes
+  if ("weight" in asset.meta) {
     metadata.weight = asset.meta.weight;
   }
   return metadata;

--- a/packages/sdk/src/css.test.tsx
+++ b/packages/sdk/src/css.test.tsx
@@ -2,6 +2,7 @@ import { expect, test } from "vitest";
 import { $, ws, css, renderData, createProxy } from "@webstudio-is/template";
 import { generateCss, type CssConfig } from "./css";
 import type { Breakpoint } from "./schema/breakpoints";
+import type { Asset } from "./schema/assets";
 import { rootComponent } from "./core-metas";
 
 const toMap = <T extends { id: string }>(list: T[]) =>
@@ -18,6 +19,45 @@ const generateAllCss = (config: Omit<CssConfig, "atomic">) => {
   });
   return { cssText, atomicCssText, classes, atomicClasses };
 };
+
+test("generates distinct upright and italic variable font faces", () => {
+  const variableFontAsset = (style: "normal" | "italic"): Asset => ({
+    id: style,
+    projectId: "project",
+    name: `family-${style}.woff2`,
+    type: "font",
+    size: 1,
+    format: "woff2",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    description: null,
+    meta: {
+      family: "Family",
+      style,
+      variationAxes: {
+        wght: { name: "Weight", min: 100, default: 400, max: 900 },
+      },
+    },
+  });
+  const assets = toMap([
+    variableFontAsset("normal"),
+    variableFontAsset("italic"),
+  ]);
+  const { cssText } = generateCss({
+    ...renderData(<$.Body />),
+    assets,
+    atomic: false,
+    componentMetas: new Map(),
+    assetBaseUrl: "/assets/",
+  });
+
+  expect(cssText).toBe(`@font-face {
+  font-family: Family; font-style: normal; font-weight: 100 900; font-display: swap; src: url("/assets/family-normal.woff2") format("woff2");
+}
+@font-face {
+  font-family: Family; font-style: italic; font-weight: 100 900; font-display: swap; src: url("/assets/family-italic.woff2") format("woff2");
+}
+`);
+});
 
 test("generate css for one instance with two tokens", () => {
   const { cssText, atomicCssText, atomicClasses } = generateAllCss({


### PR DESCRIPTION
## Summary

Preserve font style metadata for variable fonts so upright and italic files from the same family produce distinct `@font-face` rules. Variable fonts with an `ital` or `slnt` axis are also registered for the matching CSS styles.

## Technical choices

- Detect `normal`, `italic`, and `oblique` from the font binary, preferring OS/2 `fsSelection`, then `post.italicAngle`, then the existing subfamily parser.
- Add `style` to variable-font metadata while defaulting legacy stored records to `normal`.
- Keep update metadata partial and strict, but accept and persist `style` and `variationAxes` together so a `get-asset` result can be written back.
- Group generated font faces by family, style, and browser-selectable variable descriptors so separate upright and italic files cannot overwrite each other.
- Regenerate the runtime operation contracts from the updated schema.

## Checklist

- [x] Add regressions using real upright and italic Inter variable-font binaries.
- [x] Cover style detection, metadata compatibility, updates, and generated font-face selection.
- [x] Verify the final stylesheet contains distinct upright and italic `@font-face` rules.
- [x] Verify the public asset update contract accepts a complete variable-font metadata object.
- [x] Review documentation impact and update the custom-font guide.
- [x] Regenerate and verify runtime API contracts.

## Verification

- `@webstudio-is/fonts`: 14 tests and typecheck passed.
- `@webstudio-is/asset-uploader`: 198 tests and typecheck passed.
- `@webstudio-is/sdk`: 514 tests and typecheck passed.
- `@webstudio-is/project-build`: 2,094 tests and typecheck passed.
- CLI: 980 tests and typecheck passed.
- Builder typecheck passed.
- `pnpm lint`, `pnpm check:package-boundaries`, `pnpm check:generated-api`, and `pnpm check:generated-docs` passed.
- Regression tests were demonstrated failing against the previous behavior and passing with the fix.
- Fixture builds regenerated successfully with no diff. Full remote fixture sync was attempted, but the deployed API rejected the source CLI contract as incompatible.
- Agent evaluations were not run because they require separate explicit approval.

Closes #6150