### PR TITLE
fix: Keep Assets routes out of the static sitemap

### DIFF
--- a/packages/cli/src/prebuild.test.ts
+++ b/packages/cli/src/prebuild.test.ts
@@ -2131,12 +2131,13 @@ sitemap.map((page) => page.path);`
     await expect(
       readFile("pages/blog/@slug/+onBeforePrerenderStart.ts", "utf8")
     ).resolves.not.toContain("/blog/draft-post");
-    await expect(
-      readFile("app/__generated__/$resources.sitemap.xml.ts", "utf8")
-    ).resolves.toContain('"path": "/blog/hello-world"');
-    await expect(
-      readFile("app/__generated__/$resources.sitemap.xml.ts", "utf8")
-    ).resolves.not.toContain('"path": "/blog/draft-post"');
+    const sitemap = await readFile(
+      "app/__generated__/$resources.sitemap.xml.ts",
+      "utf8"
+    );
+    expect(sitemap).toContain('"path": "/"');
+    expect(sitemap).not.toContain('"path": "/blog/hello-world"');
+    expect(sitemap).not.toContain('"path": "/blog/draft-post"');
     await symlink(join(originalCwd, "node_modules"), "node_modules", "dir");
     await runGeneratedCommand("vite", ["build"]);
     await runGeneratedCommand("vike", ["prerender"]);

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -31,7 +31,6 @@ import {
   generateResources,
   generatePageMeta,
   getStaticSiteMapXml,
-  isPageEligibleForSitemap,
   replaceFormActionsWithResources,
   isCoreComponent,
   coreMetas,
@@ -935,8 +934,6 @@ export const prebuild = async (options: {
   const generatedPages = options.includeDraftPages
     ? getAllPages(pages)
     : publishablePages;
-  const publishablePageIds = new Set(publishablePages.map((page) => page.id));
-  const assetSitemapPaths = new Set<string>();
   await writeWsAuthResources(
     generatedDir,
     pages,
@@ -1365,11 +1362,6 @@ export const prebuild = async (options: {
       index: siteData.assetIndex,
       requireCompleteEnumeration: options.template.includes("ssg"),
     });
-    if (publishablePageIds.has(page.id) && isPageEligibleForSitemap(page)) {
-      for (const path of prerenderPaths) {
-        assetSitemapPaths.add(path);
-      }
-    }
     for (const { file, template } of getTemplates({
       pagePath,
       prerenderPaths,
@@ -1429,17 +1421,6 @@ export const prebuild = async (options: {
   }
 
   const sitemap = getStaticSiteMapXml(pages, siteData.build.updatedAt);
-  const sitemapPaths = new Set(sitemap.map(({ path }) => path));
-  for (const path of [...assetSitemapPaths].sort()) {
-    if (sitemapPaths.has(path)) {
-      continue;
-    }
-    sitemapPaths.add(path);
-    sitemap.push({
-      path,
-      lastModified: siteData.build.updatedAt.split("T")[0],
-    });
-  }
   await writeGeneratedFile(
     join(generatedDir, "$resources.sitemap.xml.ts"),
     `


### PR DESCRIPTION
## Summary

- keep Assets-backed dynamic path discovery and SSG prerendering unchanged
- stop merging Assets-derived paths into `$resources.sitemap.xml`
- keep eligible static pages in the generated sitemap
- update the existing Assets prerender integration test to cover static sitemap behavior

## Why

The CLI used one Assets query result for both route generation and sitemap indexing. Renderability and indexability are separate concerns, and automatic insertion could duplicate entries from a custom `/sitemap.xml` page. The Builder already exposes only static sitemap data, so generated production output should match it.

## Compatibility and release note

Assets-backed dynamic routes are no longer added automatically to the static sitemap. Existing projects that relied on that behavior need to add those routes explicitly to a custom `/sitemap.xml` page with an Assets resource and Collection. This `fix:` PR is included in the repository's generated release notes under **Fixes**.

## Technical choices

- Removed only the Assets-derived sitemap collection and merge.
- Left `getAssetResourcePrerenderPaths()`, query evaluation, route generation, prerendering, and draft filtering unchanged.
- Continued using `getStaticSiteMapXml()` as the sole source of generated sitemap entries.

## Verification

- Regression demonstration before the implementation change: the updated targeted test failed because `/blog/hello-world` was present in `$resources.sitemap.xml.ts`.
- After the implementation change, the targeted integration test passed and successfully built/prerendered `/blog/hello-world`.
- `pnpm --filter webstudio test -- src/prebuild.test.ts` — 58 tests passed.
- `pnpm --filter webstudio typecheck` — passed.
- `pnpm exec oxfmt --check packages/cli/src/prebuild.ts packages/cli/src/prebuild.test.ts` — passed.
- `pnpm exec oxlint --deny-warnings packages/cli/src/prebuild.ts packages/cli/src/prebuild.test.ts` — passed.
- Agent evaluations were not run, per request.
- Fixture regeneration was not needed because no fixture inputs or outputs changed.

## Todo

- [x] Invert the existing Assets prerender sitemap assertion.
- [x] Demonstrate that the regression test fails with the old behavior.
- [x] Remove Assets-derived sitemap collection and merging.
- [x] Confirm dynamic Assets routes still build and prerender.
- [x] Confirm drafts stay excluded and eligible static pages stay included.
- [x] Review documentation impact.
- [x] Review the authoritative `docs/` content: the Content Engine guide already directs users to build and draft-filter a custom sitemap for dynamic Assets entries, and the XML Node guide documents combining it with the static Sitemap resource; no docs change is required.
- [x] Document the compatibility change for generated release notes.

Closes #6157