### PR TITLE
fix: Improve MCP screenshot and session compatibility

### DIFF
--- a/packages/cli/src/commands/mcp-preview.test.ts
+++ b/packages/cli/src/commands/mcp-preview.test.ts
@@ -70,6 +70,23 @@ test("allocates and reuses a collision-free port for automatic screenshots", asy
   expect(getAvailablePort).toHaveBeenCalledOnce();
 });
 
+test("allocates an available port for a local-source screenshot", async () => {
+  const getAvailablePort = vi.fn(async () => 53124);
+
+  await expect(
+    resolveMcpScreenshotInput(
+      {
+        path: "/account",
+        source: "local",
+        viewport: { width: 1440, height: 900 },
+      },
+      { running: false },
+      { getAvailablePort }
+    )
+  ).resolves.toMatchObject({ source: "local", port: 53124 });
+  expect(getAvailablePort).toHaveBeenCalledWith("127.0.0.1");
+});
+
 test("rejects an occupied explicit screenshot port before preview preparation", async () => {
   const isPortAvailable = vi.fn(async () => false);
 
@@ -1009,6 +1026,64 @@ test("captures one session page across multiple viewports through resize", async
   expect(preview.startAndWait).not.toHaveBeenCalled();
 });
 
+test("prepares one local page for multiple viewport captures", async () => {
+  let running = false;
+  const preview = {
+    status: vi.fn(() => ({
+      url: "http://127.0.0.1:5173/",
+      running,
+      mode: "production" as const,
+    })),
+    startAndWait: vi.fn(async () => {
+      running = true;
+      return {
+        url: "http://127.0.0.1:5173/",
+        running: true,
+        mode: "production" as const,
+      };
+    }),
+    resolveUrl: vi.fn((path: string) => `http://127.0.0.1:5173${path}`),
+  };
+  const capture = createCaptureScreenshotMock([]);
+  const capturePage = vi.fn(
+    async (optionsList) => await Promise.all(optionsList.map(capture))
+  );
+  const createCaptureSession = vi.fn(() => ({
+    capture,
+    capturePage,
+    close: vi.fn(async () => undefined),
+  }));
+  const preparePreview = vi.fn(async () => ({ cwd: "/tmp/local-preview" }));
+  const handlers = createMcpPreviewHandlers({
+    preview,
+    preparePreview,
+    createCaptureSession,
+    isStale: () => false,
+  });
+
+  const results = await handlers.capturePageScreenshots(
+    [1440, 768, 390].map((width) => ({
+      path: "/responsive",
+      source: "local" as const,
+      mode: "production" as const,
+      browserPath: "/browser",
+      viewport: { width, height: 900 },
+    }))
+  );
+
+  expect(results.map((result) => result.viewport.width)).toEqual([
+    1440, 768, 390,
+  ]);
+  expect(preparePreview).toHaveBeenCalledOnce();
+  expect(preview.startAndWait).toHaveBeenCalledOnce();
+  expect(createCaptureSession).toHaveBeenCalledOnce();
+  expect(capturePage).toHaveBeenCalledWith([
+    expect.objectContaining({ width: 1440, browserPath: "/browser" }),
+    expect.objectContaining({ width: 768, browserPath: "/browser" }),
+    expect.objectContaining({ width: 390, browserPath: "/browser" }),
+  ]);
+});
+
 test("times out a stalled responsive capture and releases its session", async () => {
   const close = vi.fn(async () => undefined);
   const preview = {
@@ -1086,7 +1161,7 @@ test.each([
           viewport: { width: 1440, height: 900 },
         },
       ])
-    ).rejects.toThrow("one session preview target and browser configuration");
+    ).rejects.toThrow("one generated preview target and browser configuration");
     expect(createCaptureSession).not.toHaveBeenCalled();
   }
 );

--- a/packages/cli/src/commands/mcp-preview.ts
+++ b/packages/cli/src/commands/mcp-preview.ts
@@ -173,11 +173,7 @@ export const resolveMcpScreenshotInput = async (
     isPortAvailable?: (host: string, port: number) => Promise<boolean>;
   } = {}
 ) => {
-  if (
-    input.url !== undefined ||
-    input.baseUrl !== undefined ||
-    input.source === "local"
-  ) {
+  if (input.url !== undefined || input.baseUrl !== undefined) {
     return input;
   }
   const runningPreviewPort = getRunningPreviewPort(previewStatus, input.host);
@@ -634,7 +630,6 @@ export const createMcpPreviewHandlers = ({
         const previewTarget = getPreviewTarget(firstInput);
         if (
           createCaptureSession === undefined ||
-          previewTarget.source === "local" ||
           inputs.some(
             (input) =>
               isSamePreviewTarget(getPreviewTarget(input), previewTarget) ===
@@ -646,7 +641,7 @@ export const createMcpPreviewHandlers = ({
           )
         ) {
           throw new Error(
-            "Resized screenshot capture requires one session preview target and browser configuration."
+            "Resized screenshot capture requires one generated preview target and browser configuration."
           );
         }
         const urls: string[] = [];

--- a/packages/cli/src/project-session.test.ts
+++ b/packages/cli/src/project-session.test.ts
@@ -238,6 +238,36 @@ describe("cli project session storage", () => {
     expect(await storage.list()).toHaveLength(19);
   });
 
+  test("persists session state without the Web Crypto global", async () => {
+    vi.stubGlobal("crypto", undefined);
+    const directory = await createTemporaryDirectory();
+    const state = createBuilderStateFromSnapshot({});
+    const snapshot = {
+      projectId: "project-1",
+      buildId: "build-1",
+      version: 1,
+      state,
+      freshness: createBuilderStateFreshness({ state, version: 1 }),
+      compatibilityVersion: "test",
+      compatibility: {
+        sessionVersion: "test",
+        runtimeContractVersion: "test-runtime",
+        projectSchemaVersion: "test-schema",
+      },
+    };
+
+    await expect(
+      createCliProjectSessionStorage(
+        join(directory, ".webstudio", "project-session.json")
+      ).save(snapshot, {})
+    ).resolves.toEqual({ revision: expect.any(String) });
+    await expect(
+      createCliProjectRestorePointStorage(
+        join(directory, ".webstudio", "restore-points.json")
+      ).create("Before mutation", snapshot)
+    ).resolves.toEqual(expect.objectContaining({ id: expect.any(String) }));
+  });
+
   test("persists builder state snapshots as JSON and checks revisions", async () => {
     const directory = await createTemporaryDirectory();
     const path = join(directory, ".webstudio", "project-session.json");

--- a/packages/cli/src/project-session.ts
+++ b/packages/cli/src/project-session.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { rm } from "node:fs/promises";
 import { release } from "node:os";
 import { join } from "node:path";
@@ -331,7 +332,7 @@ export const createCliProjectSessionStorage = (
     ) {
       throw new Error("Project session snapshot changed on disk.");
     }
-    const revision = crypto.randomUUID();
+    const revision = randomUUID();
     await writeFileAtomic(
       path,
       `${JSON.stringify(
@@ -397,7 +398,7 @@ export const createCliProjectRestorePointStorage = (
       return await withFileLock(path, async () => {
         const persisted = await load();
         const point: PersistedCliProjectRestorePoint = {
-          id: crypto.randomUUID(),
+          id: randomUUID(),
           name,
           createdAt: new Date().toISOString(),
           snapshot: serializePersistedSnapshot(snapshot),


### PR DESCRIPTION
## Summary

Allow responsive MCP screenshots to use local project data and remove the CLI session storage dependency on the Web Crypto global.

## Root causes

- Responsive capture rejected every `source: "local"` request before preview preparation, even though the generated preview and reusable browser session support local data.
- Local screenshot inputs skipped collision-free port resolution.
- Project session revisions and restore-point IDs called `crypto.randomUUID()` through the ambient global. Environments without the Web Crypto global failed after otherwise successful mutations.
- The production/session route-generation failure from #6161 is no longer reproducible on current `main`; the exact reported flow succeeds, so this PR does not add a speculative change for it.

## Technical choices

- Resolve an available preview port for local generated screenshots using the existing screenshot port path.
- Permit local and session sources through the same responsive generated-preview capture path.
- Keep mixed preview targets and mixed browser configurations rejected.
- Import `randomUUID` from `node:crypto` for session revisions and restore points.
- Preserve explicit URL and `baseUrl` capture behavior.

## Impact

A single `screenshot.responsive` call can prepare a local project once, reuse the configured browser, and capture desktop, tablet, and mobile viewports. Native MCP mutations can persist their session state without requiring the Web Crypto global.

## Checklist

- [x] Add fail-first coverage for local responsive preview preparation and port allocation
- [x] Add fail-first coverage for session persistence without the Web Crypto global
- [x] Verify a real local CLI capture at 1440×900, 768×1024, and 390×844
- [x] Verify the production/session scenario from #6161 on current `main`
- [x] Run the complete CLI test suite
- [x] Run CLI typecheck and lint
- [x] Review documentation impact: no user documentation changes are required because this restores the documented MCP behavior
- [ ] Run agent evaluations (requires explicit approval)

## Verification

- `pnpm --filter webstudio test` — 62 files, 983 tests passed
- `pnpm --filter webstudio typecheck`
- `pnpm exec oxlint --deny-warnings packages/cli/src/commands/mcp-preview.ts packages/cli/src/commands/mcp-preview.test.ts packages/cli/src/project-session.ts packages/cli/src/project-session.test.ts`
- `git diff --check`
- Real local-source production capture returned HTTP 200 at all three viewports using one generated preview and the requested Chrome executable

Closes #6156
Closes #6160
Ref #6161