### PR TITLE
fix: Support JSON content files in Builder

### DIFF
--- a/apps/builder/app/builder/features/text-file-editor/create-text-file-dialog.test.ts
+++ b/apps/builder/app/builder/features/text-file-editor/create-text-file-dialog.test.ts
@@ -1,6 +1,17 @@
 import { expect, test } from "vitest";
 import type { Asset } from "@webstudio-is/sdk";
-import { getTextFileNameError } from "./create-text-file-dialog";
+import {
+  createTextFileData,
+  getTextFileNameError,
+} from "./create-text-file-dialog";
+
+const readFile = (file: File) =>
+  new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.addEventListener("load", () => resolve(String(reader.result)));
+    reader.addEventListener("error", reject);
+    reader.readAsText(file);
+  });
 
 const existing: Asset = {
   id: "existing",
@@ -76,4 +87,23 @@ test("can restrict creation to the requested text format", () => {
       allowedExtensions: ["mdx"],
     })
   ).toBe("Use a supported editable text extension.");
+});
+
+test("creates valid initial content for editable file types", async () => {
+  const jsonFile = createTextFileData("data.json");
+  if (jsonFile === undefined) {
+    throw new Error("Expected JSON file data");
+  }
+  expect(jsonFile.name).toBe("data.json");
+  expect(jsonFile.type).toBe("application/json");
+  await expect(readFile(jsonFile)).resolves.toBe("{}\n");
+
+  const markdownFile = createTextFileData("post.md");
+  if (markdownFile === undefined) {
+    throw new Error("Expected Markdown file data");
+  }
+  expect(markdownFile.type).toBe("text/markdown");
+  await expect(readFile(markdownFile)).resolves.toBe("");
+
+  expect(createTextFileData("image.png")).toBeUndefined();
 });

--- a/apps/builder/app/builder/features/text-file-editor/create-text-file-dialog.tsx
+++ b/apps/builder/app/builder/features/text-file-editor/create-text-file-dialog.tsx
@@ -51,6 +51,16 @@ export const getTextFileNameError = ({
   }
 };
 
+export const createTextFileData = (name: string): File | undefined => {
+  const format = getFileExtension(name)?.toLowerCase() ?? "";
+  if (isTextFileAsset({ format }) === false) {
+    return;
+  }
+  return new File([format === "json" ? "{}\n" : ""], name, {
+    type: getMimeTypeByExtension(format),
+  });
+};
+
 const createTextFile = async ({
   name,
   folderId,
@@ -58,13 +68,10 @@ const createTextFile = async ({
   name: string;
   folderId?: string;
 }): Promise<Asset | undefined> => {
-  const format = getFileExtension(name)?.toLowerCase() ?? "";
-  if (isTextFileAsset({ format }) === false) {
+  const file = createTextFileData(name);
+  if (file === undefined) {
     return;
   }
-  const file = new File([""], name, {
-    type: getMimeTypeByExtension(format),
-  });
   return uploadSingleAsset("file", file, { folderId });
 };
 

--- a/apps/builder/app/builder/features/text-file-editor/text-file-editor.tsx
+++ b/apps/builder/app/builder/features/text-file-editor/text-file-editor.tsx
@@ -60,6 +60,7 @@ import {
   type UrlInputValue,
 } from "~/builder/features/settings-panel/controls/url";
 import {
+  getTextFileContentError,
   getTextFileEditorExtensions,
   isMarkdownPreviewAsset,
   isMarkdownSyntaxAsset,
@@ -486,6 +487,16 @@ export const TextFileEditor = ({
     if (canEdit === false) {
       return;
     }
+    const currentAsset = currentAssetRef.current;
+    if (currentAsset === undefined) {
+      toast.error("Unable to save: asset not found");
+      return;
+    }
+    const contentError = getTextFileContentError(currentAsset, content);
+    if (contentError !== undefined) {
+      toast.error(contentError);
+      return;
+    }
     requestedContentRef.current = content;
     saveQueueRef.current = saveQueueRef.current.then(async () => {
       const requestedContent = requestedContentRef.current;
@@ -496,15 +507,15 @@ export const TextFileEditor = ({
         return;
       }
 
-      const currentAsset = currentAssetRef.current;
-      if (currentAsset === undefined) {
+      const assetToUpdate = currentAssetRef.current;
+      if (assetToUpdate === undefined) {
         toast.error("Unable to save: asset not found");
         return;
       }
 
       try {
         const updatedAsset = await updateAssetContent({
-          asset: currentAsset,
+          asset: assetToUpdate,
           content: requestedContent,
         });
         currentAssetRef.current = updatedAsset;

--- a/apps/builder/app/builder/features/text-file-editor/text-file-editor.tsx
+++ b/apps/builder/app/builder/features/text-file-editor/text-file-editor.tsx
@@ -60,10 +60,10 @@ import {
   type UrlInputValue,
 } from "~/builder/features/settings-panel/controls/url";
 import {
-  getTextFileContentError,
   getTextFileEditorExtensions,
   isMarkdownPreviewAsset,
   isMarkdownSyntaxAsset,
+  normalizeTextFileContent,
 } from "./text-file-utils";
 import { MarkdownSplitView } from "./markdown-preview";
 
@@ -492,12 +492,16 @@ export const TextFileEditor = ({
       toast.error("Unable to save: asset not found");
       return;
     }
-    const contentError = getTextFileContentError(currentAsset, content);
-    if (contentError !== undefined) {
-      toast.error(contentError);
+    const normalized = normalizeTextFileContent(currentAsset, content);
+    if ("error" in normalized) {
+      toast.error(normalized.error);
       return;
     }
-    requestedContentRef.current = content;
+    const normalizedContent = normalized.content;
+    if (normalizedContent !== content) {
+      setState({ status: "loaded", content: normalizedContent });
+    }
+    requestedContentRef.current = normalizedContent;
     saveQueueRef.current = saveQueueRef.current.then(async () => {
       const requestedContent = requestedContentRef.current;
       if (

--- a/apps/builder/app/builder/features/text-file-editor/text-file-utils.test.ts
+++ b/apps/builder/app/builder/features/text-file-editor/text-file-utils.test.ts
@@ -9,6 +9,7 @@ import {
   isMarkdownPreviewAsset,
   isMarkdownSyntaxAsset,
   normalizeTextFileContent,
+  normalizeTextFileConversion,
 } from "./text-file-utils";
 
 describe("text file assets", () => {
@@ -88,5 +89,14 @@ describe("text file assets", () => {
     expect(normalizeTextFileContent({ format: "json" }, "{ title:")).toEqual({
       error: "Enter a JSON-compatible value.",
     });
+  });
+
+  test("initializes empty content when converting a text file to JSON", () => {
+    expect(normalizeTextFileConversion({ format: "json" }, " \n")).toEqual({
+      content: "{}\n",
+    });
+    expect(
+      normalizeTextFileConversion({ format: "json" }, "not json")
+    ).toEqual({ error: "Enter a JSON-compatible value." });
   });
 });

--- a/apps/builder/app/builder/features/text-file-editor/text-file-utils.test.ts
+++ b/apps/builder/app/builder/features/text-file-editor/text-file-utils.test.ts
@@ -5,10 +5,10 @@ import {
   isTextFileAsset,
 } from "@webstudio-is/sdk";
 import {
-  getTextFileContentError,
   getTextFileEditorExtensions,
   isMarkdownPreviewAsset,
   isMarkdownSyntaxAsset,
+  normalizeTextFileContent,
 } from "./text-file-utils";
 
 describe("text file assets", () => {
@@ -54,18 +54,36 @@ describe("text file assets", () => {
     expect(isMarkdownPreviewAsset({ format: "mdx" })).toBe(false);
   });
 
-  test("validates that JSON content has an object root", () => {
+  test("normalizes JSON-compatible object expressions to strict JSON", () => {
     expect(
-      getTextFileContentError({ format: "json" }, '{"title":"Post"}')
-    ).toBeUndefined();
-    expect(getTextFileContentError({ format: "json" }, "not json")).toBe(
-      "Enter valid JSON."
-    );
-    expect(getTextFileContentError({ format: "json" }, "[]")).toBe(
-      "JSON content must have an object at its root."
-    );
+      normalizeTextFileContent(
+        { format: "json" },
+        "{ title: 'Post', tags: ['one', 'two'], }"
+      )
+    ).toEqual({
+      content:
+        '{\n  "title": "Post",\n  "tags": [\n    "one",\n    "two"\n  ]\n}\n',
+    });
+  });
+
+  test("rejects executable or non-object JSON content", () => {
     expect(
-      getTextFileContentError({ format: "md" }, "anything")
-    ).toBeUndefined();
+      normalizeTextFileContent({ format: "json" }, "{ value: fetch('/') }")
+    ).toEqual({ error: "Enter a JSON-compatible object." });
+    expect(normalizeTextFileContent({ format: "json" }, "[]")).toEqual({
+      error: "JSON content must have an object at its root.",
+    });
+  });
+
+  test("preserves non-JSON text content", () => {
+    expect(normalizeTextFileContent({ format: "md" }, "anything")).toEqual({
+      content: "anything",
+    });
+  });
+
+  test("rejects incomplete object syntax", () => {
+    expect(normalizeTextFileContent({ format: "json" }, "{ title:")).toEqual({
+      error: "Enter a JSON-compatible object.",
+    });
   });
 });

--- a/apps/builder/app/builder/features/text-file-editor/text-file-utils.test.ts
+++ b/apps/builder/app/builder/features/text-file-editor/text-file-utils.test.ts
@@ -5,6 +5,7 @@ import {
   isTextFileAsset,
 } from "@webstudio-is/sdk";
 import {
+  getTextFileContentError,
   getTextFileEditorExtensions,
   isMarkdownPreviewAsset,
   isMarkdownSyntaxAsset,
@@ -51,5 +52,20 @@ describe("text file assets", () => {
   test("limits the Markdown preview to .md files", () => {
     expect(isMarkdownPreviewAsset({ format: "MD" })).toBe(true);
     expect(isMarkdownPreviewAsset({ format: "mdx" })).toBe(false);
+  });
+
+  test("validates that JSON content has an object root", () => {
+    expect(
+      getTextFileContentError({ format: "json" }, '{"title":"Post"}')
+    ).toBeUndefined();
+    expect(getTextFileContentError({ format: "json" }, "not json")).toBe(
+      "Enter valid JSON."
+    );
+    expect(getTextFileContentError({ format: "json" }, "[]")).toBe(
+      "JSON content must have an object at its root."
+    );
+    expect(
+      getTextFileContentError({ format: "md" }, "anything")
+    ).toBeUndefined();
   });
 });

--- a/apps/builder/app/builder/features/text-file-editor/text-file-utils.test.ts
+++ b/apps/builder/app/builder/features/text-file-editor/text-file-utils.test.ts
@@ -66,12 +66,15 @@ describe("text file assets", () => {
     });
   });
 
-  test("rejects executable or non-object JSON content", () => {
+  test("rejects executable content and accepts every JSON root type", () => {
     expect(
       normalizeTextFileContent({ format: "json" }, "{ value: fetch('/') }")
-    ).toEqual({ error: "Enter a JSON-compatible object." });
-    expect(normalizeTextFileContent({ format: "json" }, "[]")).toEqual({
-      error: "JSON content must have an object at its root.",
+    ).toEqual({ error: "Enter a JSON-compatible value." });
+    expect(normalizeTextFileContent({ format: "json" }, "[1, 'two']")).toEqual({
+      content: '[\n  1,\n  "two"\n]\n',
+    });
+    expect(normalizeTextFileContent({ format: "json" }, "null")).toEqual({
+      content: "null\n",
     });
   });
 
@@ -83,7 +86,7 @@ describe("text file assets", () => {
 
   test("rejects incomplete object syntax", () => {
     expect(normalizeTextFileContent({ format: "json" }, "{ title:")).toEqual({
-      error: "Enter a JSON-compatible object.",
+      error: "Enter a JSON-compatible value.",
     });
   });
 });

--- a/apps/builder/app/builder/features/text-file-editor/text-file-utils.test.ts
+++ b/apps/builder/app/builder/features/text-file-editor/text-file-utils.test.ts
@@ -95,8 +95,8 @@ describe("text file assets", () => {
     expect(normalizeTextFileConversion({ format: "json" }, " \n")).toEqual({
       content: "{}\n",
     });
-    expect(
-      normalizeTextFileConversion({ format: "json" }, "not json")
-    ).toEqual({ error: "Enter a JSON-compatible value." });
+    expect(normalizeTextFileConversion({ format: "json" }, "not json")).toEqual(
+      { error: "Enter a JSON-compatible value." }
+    );
   });
 });

--- a/apps/builder/app/builder/features/text-file-editor/text-file-utils.ts
+++ b/apps/builder/app/builder/features/text-file-editor/text-file-utils.ts
@@ -46,11 +46,7 @@ export const normalizeTextFileContent = (
 
   const value = parseJsonExpression(content);
   if (value === undefined) {
-    return { error: "Enter a JSON-compatible object." };
-  }
-
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return { error: "JSON content must have an object at its root." };
+    return { error: "Enter a JSON-compatible value." };
   }
 
   return { content: `${JSON.stringify(value, undefined, 2)}\n` };

--- a/apps/builder/app/builder/features/text-file-editor/text-file-utils.ts
+++ b/apps/builder/app/builder/features/text-file-editor/text-file-utils.ts
@@ -34,3 +34,23 @@ export const isMarkdownSyntaxAsset = (asset: Pick<Asset, "format">) =>
 
 export const isMarkdownPreviewAsset = (asset: Pick<Asset, "format">) =>
   asset.format.toLowerCase() === "md";
+
+export const getTextFileContentError = (
+  asset: Pick<Asset, "format">,
+  content: string
+): string | undefined => {
+  if (getAssetTextEditorLanguage(asset) !== "json") {
+    return;
+  }
+
+  let value: unknown;
+  try {
+    value = JSON.parse(content);
+  } catch {
+    return "Enter valid JSON.";
+  }
+
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return "JSON content must have an object at its root.";
+  }
+};

--- a/apps/builder/app/builder/features/text-file-editor/text-file-utils.ts
+++ b/apps/builder/app/builder/features/text-file-editor/text-file-utils.ts
@@ -56,10 +56,7 @@ export const normalizeTextFileConversion = (
   asset: Pick<Asset, "format">,
   content: string
 ) => {
-  if (
-    getAssetTextEditorLanguage(asset) === "json" &&
-    content.trim() === ""
-  ) {
+  if (getAssetTextEditorLanguage(asset) === "json" && content.trim() === "") {
     return { content: "{}\n" };
   }
   return normalizeTextFileContent(asset, content);

--- a/apps/builder/app/builder/features/text-file-editor/text-file-utils.ts
+++ b/apps/builder/app/builder/features/text-file-editor/text-file-utils.ts
@@ -3,6 +3,7 @@ import { css } from "@codemirror/lang-css";
 import { html } from "@codemirror/lang-html";
 import { javascript } from "@codemirror/lang-javascript";
 import { markdown } from "@codemirror/lang-markdown";
+import { parseJsonExpression } from "@webstudio-is/expression";
 import {
   getAssetTextEditorLanguage,
   type Asset,
@@ -35,22 +36,22 @@ export const isMarkdownSyntaxAsset = (asset: Pick<Asset, "format">) =>
 export const isMarkdownPreviewAsset = (asset: Pick<Asset, "format">) =>
   asset.format.toLowerCase() === "md";
 
-export const getTextFileContentError = (
+export const normalizeTextFileContent = (
   asset: Pick<Asset, "format">,
   content: string
-): string | undefined => {
+): { content: string } | { error: string } => {
   if (getAssetTextEditorLanguage(asset) !== "json") {
-    return;
+    return { content };
   }
 
-  let value: unknown;
-  try {
-    value = JSON.parse(content);
-  } catch {
-    return "Enter valid JSON.";
+  const value = parseJsonExpression(content);
+  if (value === undefined) {
+    return { error: "Enter a JSON-compatible object." };
   }
 
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
-    return "JSON content must have an object at its root.";
+    return { error: "JSON content must have an object at its root." };
   }
+
+  return { content: `${JSON.stringify(value, undefined, 2)}\n` };
 };

--- a/apps/builder/app/builder/features/text-file-editor/text-file-utils.ts
+++ b/apps/builder/app/builder/features/text-file-editor/text-file-utils.ts
@@ -51,3 +51,16 @@ export const normalizeTextFileContent = (
 
   return { content: `${JSON.stringify(value, undefined, 2)}\n` };
 };
+
+export const normalizeTextFileConversion = (
+  asset: Pick<Asset, "format">,
+  content: string
+) => {
+  if (
+    getAssetTextEditorLanguage(asset) === "json" &&
+    content.trim() === ""
+  ) {
+    return { content: "{}\n" };
+  }
+  return normalizeTextFileContent(asset, content);
+};

--- a/apps/builder/app/builder/shared/asset-manager/asset-settings.test.tsx
+++ b/apps/builder/app/builder/shared/asset-manager/asset-settings.test.tsx
@@ -97,6 +97,23 @@ test("uses an auto-growing textarea for the asset description", () => {
   ).toEqual(["Name", "Folder", "Description", "ID"]);
 });
 
+test("lets users edit the complete asset filename", () => {
+  renderer.render(
+    <TooltipProvider>
+      <AssetSettings open onOpenChange={vi.fn()} asset={createImageAsset()}>
+        <button>Anchor</button>
+      </AssetSettings>
+    </TooltipProvider>
+  );
+
+  expect(
+    document.querySelector<HTMLInputElement>("#asset-manager-filename")?.value
+  ).toBe("image.png");
+  expect(
+    document.querySelector("#asset-manager-filename-extension")
+  ).toBeNull();
+});
+
 test("closes asset settings before replacing an asset", () => {
   const onOpenChange = vi.fn();
   const onReplace = vi.fn();

--- a/apps/builder/app/builder/shared/asset-manager/asset-settings.tsx
+++ b/apps/builder/app/builder/shared/asset-manager/asset-settings.tsx
@@ -4,7 +4,12 @@ import { useDebouncedCallback } from "use-debounce";
 import prettyBytes from "pretty-bytes";
 import { computed } from "nanostores";
 import { useStore } from "@nanostores/react";
-import { getAssetUrl, getMimeTypeByExtension } from "@webstudio-is/sdk";
+import {
+  getAssetUrl,
+  getFileNameParts,
+  getMimeTypeByExtension,
+  isTextFileAsset,
+} from "@webstudio-is/sdk";
 import type { Asset, Instance } from "@webstudio-is/sdk";
 import {
   Box,
@@ -29,6 +34,7 @@ import {
   TextArea,
   textVariants,
   theme,
+  toast,
   Tooltip,
 } from "@webstudio-is/design-system";
 import {
@@ -57,7 +63,8 @@ import { selectPage } from "~/shared/nano-states";
 import { findPageAndSelectorByInstanceId } from "@webstudio-is/project-build/runtime";
 import { $selectedPageId } from "~/shared/nano-states";
 import { executeRuntimeMutation } from "~/shared/instance-utils/data";
-import { deleteAssets } from "~/builder/shared/assets";
+import { deleteAssets, updateAssetContent } from "~/builder/shared/assets";
+import { normalizeTextFileContent } from "~/builder/features/text-file-editor/text-file-utils";
 import {
   $activeInspectorPanel,
   setActiveSidebarPanel,
@@ -313,33 +320,83 @@ const AssetSettingsContent = ({
 }) => {
   const { canDownloadAssets } = useStore($permissions);
   const { size, meta, id } = asset;
-  const { basename, ext } = getAssetDisplayNameParts(asset);
+  const { ext } = getAssetDisplayNameParts(asset);
   const [filenameError, setFilenameError] = useState<string>();
-  const [filename, setFilename] = useLocalValue(basename, (newFilename) => {
+  const saveFilename = async (newFilename: string) => {
     const assetId = asset.id;
-    // validate filename
     if (!isValidFilename(newFilename)) {
       setFilenameError("Invalid filename");
       return;
     }
-    // validate duplicates
-    for (const asset of $assets.get().values()) {
-      if (asset.id !== assetId) {
-        const { basename: filename } = getAssetDisplayNameParts(asset);
-        if (newFilename === filename) {
-          setFilenameError("Filename already used");
-          return;
-        }
+
+    const currentAsset = $assets.get().get(assetId) ?? asset;
+    const currentExtension = getAssetDisplayNameParts(currentAsset).ext;
+    const { basename, extension } = getFileNameParts(newFilename);
+    if (extension === "" && currentExtension !== "") {
+      setFilenameError("File extension is required");
+      return;
+    }
+
+    for (const candidate of $assets.get().values()) {
+      if (
+        candidate.id !== assetId &&
+        formatAssetName(candidate) === newFilename
+      ) {
+        setFilenameError("Filename already used");
+        return;
       }
     }
+
+    if (extension.toLowerCase() !== currentExtension.toLowerCase()) {
+      if (
+        !isTextFileAsset(currentAsset) ||
+        !isTextFileAsset({ format: extension })
+      ) {
+        setFilenameError("Only text file extensions can be changed");
+        return;
+      }
+
+      try {
+        const response = await fetch(
+          getAssetUrl(currentAsset, window.location.origin)
+        );
+        if (response.ok === false) {
+          throw new Error(`Unable to load asset: ${response.status}`);
+        }
+        const normalized = normalizeTextFileContent(
+          { format: extension },
+          await response.text()
+        );
+        if ("error" in normalized) {
+          setFilenameError(normalized.error);
+          return;
+        }
+        await updateAssetContent({
+          asset: currentAsset,
+          content: normalized.content,
+          extension,
+        });
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Unable to rename file";
+        setFilenameError(message);
+        toast.error(message);
+        return;
+      }
+    }
+
     executeRuntimeMutation({
       id: "assets.update",
       input: {
         assetId,
-        values: { filename: newFilename },
+        values: { filename: basename },
       },
     });
-  });
+  };
+  const [filename, setFilename] = useLocalValue(
+    formatAssetName(asset),
+    (newFilename) => void saveFilename(newFilename)
+  );
   const [description, setDescription] = useLocalValue(
     asset.description ?? "",
     (newDescription) => {
@@ -451,24 +508,10 @@ const AssetSettingsContent = ({
         >
           <InputField
             id="asset-manager-filename"
-            aria-describedby={
-              ext === "" ? undefined : "asset-manager-filename-extension"
-            }
             autoFocus={focusName}
             readOnly={authPermit === "view"}
             color={filenameError ? "error" : undefined}
             value={filename}
-            suffix={
-              ext === "" ? undefined : (
-                <Text
-                  id="asset-manager-filename-extension"
-                  color="subtle"
-                  variant="labels"
-                >
-                  .{ext}
-                </Text>
-              )
-            }
             onChange={(event) => {
               setFilename(event.target.value);
               setFilenameError(undefined);

--- a/apps/builder/app/builder/shared/asset-manager/asset-settings.tsx
+++ b/apps/builder/app/builder/shared/asset-manager/asset-settings.tsx
@@ -64,7 +64,7 @@ import { findPageAndSelectorByInstanceId } from "@webstudio-is/project-build/run
 import { $selectedPageId } from "~/shared/nano-states";
 import { executeRuntimeMutation } from "~/shared/instance-utils/data";
 import { deleteAssets, updateAssetContent } from "~/builder/shared/assets";
-import { normalizeTextFileContent } from "~/builder/features/text-file-editor/text-file-utils";
+import { normalizeTextFileConversion } from "~/builder/features/text-file-editor/text-file-utils";
 import {
   $activeInspectorPanel,
   setActiveSidebarPanel,
@@ -363,7 +363,7 @@ const AssetSettingsContent = ({
         if (response.ok === false) {
           throw new Error(`Unable to load asset: ${response.status}`);
         }
-        const normalized = normalizeTextFileContent(
+        const normalized = normalizeTextFileConversion(
           { format: extension },
           await response.text()
         );

--- a/apps/builder/app/builder/shared/assets/update-asset-content.test.ts
+++ b/apps/builder/app/builder/shared/assets/update-asset-content.test.ts
@@ -44,7 +44,7 @@ test("commits a content revision without changing the asset id", async () => {
   requestContentUpdate.mockResolvedValue({ asset: revision });
 
   await expect(
-    updateAssetContent({ asset, content: '{"a":1}' })
+    updateAssetContent({ asset, content: '{"a":1}', extension: "json" })
   ).resolves.toEqual(revision);
 
   expect(requestContentUpdate).toHaveBeenCalledWith(
@@ -52,6 +52,7 @@ test("commits a content revision without changing the asset id", async () => {
       assetId: "asset",
       projectId: "project",
       expectedName: "settings_old.json",
+      extension: "json",
       authToken: "token",
       requestOrigin: window.location.origin,
     })

--- a/apps/builder/app/builder/shared/assets/update-asset-content.ts
+++ b/apps/builder/app/builder/shared/assets/update-asset-content.ts
@@ -18,9 +18,11 @@ export const createUpdateAssetContent =
   async ({
     asset,
     content,
+    extension,
   }: {
     asset: Asset;
     content: string;
+    extension?: string;
   }): Promise<Asset> => {
     const projectId = $project.get()?.id;
     if (projectId === undefined) {
@@ -32,6 +34,7 @@ export const createUpdateAssetContent =
       assetId: asset.id,
       projectId,
       expectedName: asset.name,
+      extension,
       origin,
       authToken: $authToken.get(),
       readAssetData: async () => content,

--- a/apps/builder/app/builder/shared/assets/upload-assets.test.ts
+++ b/apps/builder/app/builder/shared/assets/upload-assets.test.ts
@@ -130,6 +130,24 @@ describe("upload-assets", () => {
     expect(onError).toHaveBeenCalledWith("network down");
   });
 
+  test("marks URL uploads separately from JSON file uploads", async () => {
+    request.mockResolvedValue(
+      Response.json({ uploadedAssets: [{ id: "asset" }] })
+    );
+
+    await submitAssetUpload({
+      authToken: undefined,
+      uploadName: "upload-name",
+      fileOrUrl: new URL("https://example.com/image.png"),
+      onCompleted: vi.fn(),
+      onError: vi.fn(),
+      request,
+    });
+
+    const [, init] = request.mock.calls[0] as [string, { headers: Headers }];
+    expect(init.headers.get("x-webstudio-asset-source")).toBe("url");
+  });
+
   test("keeps the selected folder throughout upload preparation", async () => {
     const [fileData] = await getFilesData(
       "image",

--- a/apps/builder/app/builder/shared/assets/upload-assets.tsx
+++ b/apps/builder/app/builder/shared/assets/upload-assets.tsx
@@ -255,6 +255,7 @@ const submitAssetUpload = async ({
 
     if (fileOrUrl instanceof URL) {
       headers.set("Content-Type", "application/json");
+      headers.set("x-webstudio-asset-source", "url");
     }
 
     let width = undefined;

--- a/apps/builder/app/routes/rest.assets.$assetId.content.tsx
+++ b/apps/builder/app/routes/rest.assets.$assetId.content.tsx
@@ -34,12 +34,18 @@ export const action = async ({ request, params }: ActionFunctionArgs) => {
     const expectedName = parseAssetRestFilename(
       url.searchParams.get("expectedName")
     );
+    const extensionValue = url.searchParams.get("extension");
+    const extension =
+      extensionValue === null
+        ? undefined
+        : parseAssetRestFilename(extensionValue);
 
     const asset = await (
       await createAssetRestRepository(request, "edit")
     ).updateContent({
       assetId,
       expectedName,
+      extension,
       data: requireAssetRestBody(request),
     });
     return json(

--- a/apps/builder/app/services/asset-upload.server.test.ts
+++ b/apps/builder/app/services/asset-upload.server.test.ts
@@ -39,6 +39,22 @@ test("keeps browser JSON file uploads as JSON file content", async () => {
   ).resolves.toBe(JSON.stringify({ value: 1 }));
 });
 
+test("keeps JSON files with a root URL field as file content", async () => {
+  const content = JSON.stringify({ url: "https://example.com/page" });
+  const request = new Request(
+    "https://webstudio.is/rest/assets/uploads/data.json",
+    {
+      method: "POST",
+      body: content,
+      headers: { "Content-Type": "application/json" },
+    }
+  );
+
+  await expect(
+    new Response(await getBrowserUploadBody(request, "application/json")).text()
+  ).resolves.toBe(content);
+});
+
 test("keeps browser URL image uploads by fetching the remote image body", async () => {
   const fetch = vi.fn(async () => new Response("remote image"));
   vi.stubGlobal("fetch", fetch);
@@ -47,7 +63,10 @@ test("keeps browser URL image uploads by fetching the remote image body", async 
     {
       method: "POST",
       body: JSON.stringify({ url: "https://example.com/image.png" }),
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "x-webstudio-asset-source": "url",
+      },
     }
   );
 
@@ -70,7 +89,10 @@ test("reports browser URL image fetch failures", async () => {
     {
       method: "POST",
       body: JSON.stringify({ url: "https://example.com/image.png" }),
-      headers: { "Content-Type": "application/json" },
+      headers: {
+        "Content-Type": "application/json",
+        "x-webstudio-asset-source": "url",
+      },
     }
   );
 

--- a/apps/builder/app/services/asset-upload.server.ts
+++ b/apps/builder/app/services/asset-upload.server.ts
@@ -9,44 +9,42 @@ export const getBrowserUploadBody = async (
   request: Request,
   contentType: string | null
 ) => {
-  let body = request.body;
+  const body = request.body;
   if (body === null) {
     throw new Error("Asset body is empty");
   }
 
-  if (
-    contentType?.includes("application/json") &&
-    request.headers.get("x-webstudio-asset-source") === "url"
-  ) {
-    const jsonBody = await request.json();
-    const urlParse = urlBody.safeParse(jsonBody);
-
-    if (urlParse.success) {
-      const { url } = urlParse.data;
-      const imageRequest = await fetch(url, {
-        method: "GET",
-        headers: {
-          Accept: RESIZABLE_IMAGE_MIME_TYPES.join(","),
-        },
-      });
-
-      if (imageRequest.ok === false) {
-        const error = await imageRequest.text();
-        throw new Error(
-          `An error occurred while fetching the image at ${url}: ${error.slice(0, 500)}`
-        );
-      }
-
-      if (imageRequest.body === null) {
-        throw new Error(
-          `An error occurred while fetching the image at ${url}: Image body is null`
-        );
-      }
-      body = imageRequest.body;
-    } else {
-      throw new Error("Invalid URL asset upload body");
-    }
+  if (request.headers.get("x-webstudio-asset-source") !== "url") {
+    return body;
+  }
+  if (contentType?.includes("application/json") !== true) {
+    throw new Error("Invalid URL asset upload content type");
   }
 
-  return body;
+  const urlParse = urlBody.safeParse(await request.json());
+  if (urlParse.success === false) {
+    throw new Error("Invalid URL asset upload body");
+  }
+
+  const { url } = urlParse.data;
+  const imageRequest = await fetch(url, {
+    method: "GET",
+    headers: {
+      Accept: RESIZABLE_IMAGE_MIME_TYPES.join(","),
+    },
+  });
+
+  if (imageRequest.ok === false) {
+    const error = await imageRequest.text();
+    throw new Error(
+      `An error occurred while fetching the image at ${url}: ${error.slice(0, 500)}`
+    );
+  }
+
+  if (imageRequest.body === null) {
+    throw new Error(
+      `An error occurred while fetching the image at ${url}: Image body is null`
+    );
+  }
+  return imageRequest.body;
 };

--- a/apps/builder/app/services/asset-upload.server.ts
+++ b/apps/builder/app/services/asset-upload.server.ts
@@ -14,7 +14,10 @@ export const getBrowserUploadBody = async (
     throw new Error("Asset body is empty");
   }
 
-  if (contentType?.includes("application/json")) {
+  if (
+    contentType?.includes("application/json") &&
+    request.headers.get("x-webstudio-asset-source") === "url"
+  ) {
     const jsonBody = await request.json();
     const urlParse = urlBody.safeParse(jsonBody);
 
@@ -39,12 +42,9 @@ export const getBrowserUploadBody = async (
           `An error occurred while fetching the image at ${url}: Image body is null`
         );
       }
-
       body = imageRequest.body;
     } else {
-      body = new Blob([JSON.stringify(jsonBody)], {
-        type: "application/json",
-      }).stream();
+      throw new Error("Invalid URL asset upload body");
     }
   }
 

--- a/docs/university/foundations/assets.md
+++ b/docs/university/foundations/assets.md
@@ -41,8 +41,8 @@ multiple selected assets does not insert multiple Image components.
 
 Open the add menu in the Assets panel and choose **Create text file**. Enter a
 supported filename, such as `notes.md`, `article.mdx`, or `data.json`.
-Webstudio creates the blank file in the current folder and opens it in the code
-editor. You can also choose **Create MDX file** from a Content Block's
+Webstudio creates the file in the current folder and opens it in the code
+editor. New JSON files start with an empty object. You can also choose **Create MDX file** from a Content Block's
 **Content source** control.
 
 You can open uploaded `txt`, `csv`, `md`, `mdx`, `js`, `css`, `json`, `html`,
@@ -53,7 +53,8 @@ Block to see its materialized result on the canvas.
 
 Edits save when the editor loses focus or when you press `Command + S` on
 macOS, `Ctrl + S` on Windows, or `Command/Ctrl + Enter`. The file extension is
-fixed, but you can rename its basename in Asset settings.
+fixed, but you can rename its basename in Asset settings. Invalid JSON is
+reported without saving the file.
 
 ### Use assets as content
 

--- a/docs/university/foundations/assets.md
+++ b/docs/university/foundations/assets.md
@@ -56,10 +56,10 @@ Edits save when the editor loses focus or when you press `Command + S` on
 macOS, `Ctrl + S` on Windows, or `Command/Ctrl + Enter`. Edit the complete
 filename in Asset settings to rename a text file or change its format. When you
 change the extension to `.json`, Webstudio validates the existing content and
-converts JSON-compatible object syntax to strict JSON before saving the new
-file revision. JSON files must contain an object at the root. The editor accepts
-unquoted keys, single-quoted strings, and trailing commas. It reports
-unsupported syntax instead of saving the file.
+converts JSON-compatible syntax to strict JSON before saving the new
+file revision. JSON files can contain any JSON value, including arrays and
+scalars. The editor accepts unquoted object keys, single-quoted strings, and
+trailing commas. It reports unsupported syntax instead of saving the file.
 
 ### Use assets as content
 

--- a/docs/university/foundations/assets.md
+++ b/docs/university/foundations/assets.md
@@ -53,12 +53,13 @@ formatting controls. The file editor previews `.md`; connect `.mdx` to a Content
 Block to see its materialized result on the canvas.
 
 Edits save when the editor loses focus or when you press `Command + S` on
-macOS, `Ctrl + S` on Windows, or `Command/Ctrl + Enter`. The file extension is
-fixed, but you can rename its basename in Asset settings. JSON files must
-contain an object at the root. The editor accepts JSON-compatible object syntax
-such as unquoted keys, single-quoted strings, and trailing commas, then formats
-and saves it as strict JSON. It reports unsupported syntax instead of saving
-the file.
+macOS, `Ctrl + S` on Windows, or `Command/Ctrl + Enter`. Edit the complete
+filename in Asset settings to rename a text file or change its format. When you
+change the extension to `.json`, Webstudio validates the existing content and
+converts JSON-compatible object syntax to strict JSON before saving the new
+file revision. JSON files must contain an object at the root. The editor accepts
+unquoted keys, single-quoted strings, and trailing commas. It reports
+unsupported syntax instead of saving the file.
 
 ### Use assets as content
 

--- a/docs/university/foundations/assets.md
+++ b/docs/university/foundations/assets.md
@@ -42,8 +42,9 @@ multiple selected assets does not insert multiple Image components.
 Open the add menu in the Assets panel and choose **Create text file**. Enter a
 supported filename, such as `notes.md`, `article.mdx`, or `data.json`.
 Webstudio creates the file in the current folder and opens it in the code
-editor. New JSON files start with an empty object. You can also choose **Create MDX file** from a Content Block's
-**Content source** control.
+editor. New JSON files start with an empty object so the Content Engine can
+index them immediately. You can also choose **Create MDX file** from a Content
+Block's **Content source** control.
 
 You can open uploaded `txt`, `csv`, `md`, `mdx`, `js`, `css`, `json`, `html`,
 `xml`, and `svg` assets in the same editor. Syntax highlighting follows the
@@ -53,8 +54,11 @@ Block to see its materialized result on the canvas.
 
 Edits save when the editor loses focus or when you press `Command + S` on
 macOS, `Ctrl + S` on Windows, or `Command/Ctrl + Enter`. The file extension is
-fixed, but you can rename its basename in Asset settings. Invalid JSON is
-reported without saving the file.
+fixed, but you can rename its basename in Asset settings. JSON files must
+contain an object at the root. The editor accepts JSON-compatible object syntax
+such as unquoted keys, single-quoted strings, and trailing commas, then formats
+and saves it as strict JSON. It reports unsupported syntax instead of saving
+the file.
 
 ### Use assets as content
 

--- a/docs/university/foundations/assets.md
+++ b/docs/university/foundations/assets.md
@@ -60,6 +60,7 @@ converts JSON-compatible syntax to strict JSON before saving the new
 file revision. JSON files can contain any JSON value, including arrays and
 scalars. The editor accepts unquoted object keys, single-quoted strings, and
 trailing commas. It reports unsupported syntax instead of saving the file.
+Converting an empty text file to `.json` initializes it with an empty object.
 
 ### Use assets as content
 

--- a/docs/university/foundations/content-engine.md
+++ b/docs/university/foundations/content-engine.md
@@ -97,7 +97,7 @@ in this guide use that ID to query only files in this folder.
 
 1. Open `blog/posts` in the Assets panel.
 2. Open the add menu and choose **Create text file**.
-3. Choose **Markdown** and name the file `hello-world.md`.
+3. Name the file `hello-world.md`.
 4. Add the article metadata between the two `---` lines, followed by the
    article body:
 
@@ -178,9 +178,11 @@ contain an object at its root:
 
 Its fields are also exposed under `properties`, such as `properties.name` and
 `properties.avatar`. Use JSON when the file contains structured data without a
-Markdown body. Choose **JSON** in the **Create text file** dialog to create a
-valid empty object, then add its fields in the editor. Invalid JSON is reported
-without saving the file.
+Markdown body. Name the file with a `.json` extension in the **Create text
+file** dialog to create a valid empty object, then add its fields in the editor.
+The editor accepts JSON-compatible object syntax and formats it as strict JSON
+when saving. Unsupported or incomplete syntax is reported without saving the
+file.
 
 ## 3. Query the articles for the overview
 

--- a/docs/university/foundations/content-engine.md
+++ b/docs/university/foundations/content-engine.md
@@ -165,8 +165,9 @@ asset ID or generated filename. This is what makes the content portable.
 
 ### JSON files
 
-The Content Engine can query JSON files as well as Markdown. A JSON file must
-contain an object at its root:
+The Content Engine can query JSON files as well as Markdown. JSON files can
+contain objects, arrays, or scalar values. A root object exposes its fields for
+structured queries:
 
 ```json
 {
@@ -176,15 +177,16 @@ contain an object at its root:
 }
 ```
 
-Its fields are also exposed under `properties`, such as `properties.name` and
-`properties.avatar`. Use JSON when the file contains structured data without a
-Markdown body. Name the file with a `.json` extension in the **Create text
-file** dialog to create a valid empty object, then add its fields in the editor.
-The editor accepts JSON-compatible object syntax and formats it as strict JSON
-when saving. Unsupported or incomplete syntax is reported without saving the
-file. You can also change an existing text file's extension to `.json` by
-editing its complete filename in Asset settings; Webstudio validates and
-formats the current content before converting it.
+The object's fields are exposed under `properties`, such as `properties.name`
+and `properties.avatar`. Root arrays and scalars remain valid JSON content but
+do not expose top-level `properties` fields. Use JSON when the file contains
+structured data without a Markdown body. Name the file with a `.json` extension
+in the **Create text file** dialog. A new file starts with an empty object, which
+you can replace with any JSON value. The editor accepts JSON-compatible syntax
+and formats it as strict JSON when saving. Unsupported or incomplete syntax is
+reported without saving the file. You can also change an existing text file's
+extension to `.json` by editing its complete filename in Asset settings;
+Webstudio validates and formats the current content before converting it.
 
 ## 3. Query the articles for the overview
 

--- a/docs/university/foundations/content-engine.md
+++ b/docs/university/foundations/content-engine.md
@@ -182,7 +182,9 @@ Markdown body. Name the file with a `.json` extension in the **Create text
 file** dialog to create a valid empty object, then add its fields in the editor.
 The editor accepts JSON-compatible object syntax and formats it as strict JSON
 when saving. Unsupported or incomplete syntax is reported without saving the
-file.
+file. You can also change an existing text file's extension to `.json` by
+editing its complete filename in Asset settings; Webstudio validates and
+formats the current content before converting it.
 
 ## 3. Query the articles for the overview
 

--- a/docs/university/foundations/content-engine.md
+++ b/docs/university/foundations/content-engine.md
@@ -97,7 +97,7 @@ in this guide use that ID to query only files in this folder.
 
 1. Open `blog/posts` in the Assets panel.
 2. Open the add menu and choose **Create text file**.
-3. Name the file `hello-world.md`.
+3. Choose **Markdown** and name the file `hello-world.md`.
 4. Add the article metadata between the two `---` lines, followed by the
    article body:
 
@@ -178,7 +178,9 @@ contain an object at its root:
 
 Its fields are also exposed under `properties`, such as `properties.name` and
 `properties.avatar`. Use JSON when the file contains structured data without a
-Markdown body.
+Markdown body. Choose **JSON** in the **Create text file** dialog to create a
+valid empty object, then add its fields in the editor. Invalid JSON is reported
+without saving the file.
 
 ## 3. Query the articles for the overview
 

--- a/packages/asset-uploader/src/asset-repository.ts
+++ b/packages/asset-uploader/src/asset-repository.ts
@@ -254,6 +254,7 @@ export interface AssetRepository {
   updateContent(input: {
     assetId: Asset["id"];
     expectedName: string;
+    extension?: string;
     data: ReadableStream<Uint8Array>;
   }): Promise<Asset>;
   updateMetadata(
@@ -518,6 +519,7 @@ export class PostgresAssetRepository implements AssetRepository {
   async updateContent({
     assetId,
     expectedName,
+    extension,
     data,
   }: Parameters<AssetRepository["updateContent"]>[0]) {
     await this.assertCanEdit();
@@ -526,6 +528,7 @@ export class PostgresAssetRepository implements AssetRepository {
         assetId,
         projectId: this.projectId,
         expectedName,
+        extension,
         data,
       },
       this.getWritableStore(),

--- a/packages/asset-uploader/src/revision.test.ts
+++ b/packages/asset-uploader/src/revision.test.ts
@@ -82,6 +82,13 @@ describe("asset content revisions", () => {
         filename: null,
       })
     ).toBe("test.md");
+    expect(
+      getRevisionFilename({
+        name: "settings_old-revision.md",
+        filename: "configuration",
+        extension: "json",
+      })
+    ).toBe("configuration.json");
   });
 
   test("uploads an immutable revision and keeps the asset id", async () => {

--- a/packages/asset-uploader/src/revision.ts
+++ b/packages/asset-uploader/src/revision.ts
@@ -1,5 +1,6 @@
 import {
   formatAssetName,
+  getFileNameParts,
   isTextFileAsset,
   type Asset,
 } from "@webstudio-is/sdk";
@@ -21,11 +22,18 @@ import { AssetRevisionConflictError } from "./content-repository";
 const getRevisionFilename = ({
   name,
   filename,
+  extension,
 }: {
   name: string;
   filename: string | null;
+  extension?: string;
 }) => {
-  return sanitizeS3Key(formatAssetName({ name, filename }));
+  const displayName = formatAssetName({ name, filename });
+  if (extension === undefined) {
+    return sanitizeS3Key(displayName);
+  }
+  const { basename } = getFileNameParts(displayName);
+  return sanitizeS3Key(`${basename}.${extension}`);
 };
 
 export const swapAssetFileWithClient = async (
@@ -96,11 +104,13 @@ export const updateAssetContent = async (
     assetId,
     projectId,
     expectedName,
+    extension,
     data,
   }: {
     assetId: Asset["id"];
     projectId: string;
     expectedName: string;
+    extension?: string;
     data: ReadableStream<Uint8Array>;
   },
   assetClient: AssetObjectStore,
@@ -129,11 +139,18 @@ export const updateAssetContent = async (
   if (isTextFileAsset({ format: currentAsset.file.format }) === false) {
     throw new Error("This asset is not an editable text file");
   }
+  if (
+    extension !== undefined &&
+    isTextFileAsset({ format: extension }) === false
+  ) {
+    throw new Error("The new extension must be an editable text file format");
+  }
 
   const revisionName = createUniqueAssetFilename(
     getRevisionFilename({
       name: currentAsset.name,
       filename: currentAsset.filename,
+      extension: extension?.toLowerCase(),
     })
   );
   const insertedFile = await context.postgrest.client.from("File").insert({

--- a/packages/cli/evaluations/high-impact/fixture-api.test.ts
+++ b/packages/cli/evaluations/high-impact/fixture-api.test.ts
@@ -145,7 +145,7 @@ describe("high-impact fixture API", () => {
       await fixtureApi.close();
       await rm(directory, { recursive: true, force: true });
     }
-  }, 60_000);
+  }, 120_000);
 
   test("creates a folder and uploads the Markdown blog files through the local CLI", async () => {
     const fixtureApi = await startHighImpactFixtureApi(markdownBlogFixture);

--- a/packages/cli/src/asset-files.test.ts
+++ b/packages/cli/src/asset-files.test.ts
@@ -68,6 +68,7 @@ test("creates asset content readers from inline content or a file", async () => 
   const fromContent = createLocalUpdateAssetContentInput({
     assetId: "asset",
     expectedName: "content_old.json",
+    extension: "json",
     content: '{"source":"inline"}',
     readFile,
   });
@@ -81,6 +82,7 @@ test("creates asset content readers from inline content or a file", async () => 
   await expect(fromContent.readAssetData()).resolves.toBe(
     '{"source":"inline"}'
   );
+  expect(fromContent.extension).toBe("json");
   await expect(fromPath.readAssetData()).resolves.toEqual(
     Buffer.from('{"source":"file"}')
   );

--- a/packages/cli/src/asset-files.ts
+++ b/packages/cli/src/asset-files.ts
@@ -96,12 +96,14 @@ export const createLocalUploadAssetsInput = <Asset extends { name: string }>({
 export const createLocalUpdateAssetContentInput = ({
   assetId,
   expectedName,
+  extension,
   path,
   content,
   readFile,
 }: {
   assetId: string;
   expectedName: string;
+  extension?: string;
   path?: string;
   content?: string;
   readFile: (path: string) => Promise<unknown>;
@@ -114,6 +116,7 @@ export const createLocalUpdateAssetContentInput = ({
   return {
     assetId,
     expectedName,
+    extension,
     readAssetData: async () =>
       path === undefined ? content : await readFile(resolve(path)),
   };

--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -1126,16 +1126,19 @@ test("adapts MCP asset content input to the shared revision client", async () =>
   const input = getMcpOperationInput("update-asset-content", {
     assetId: "asset-id",
     expectedName: "settings_hash.json",
+    extension: "json",
     content: '{"theme":"dark"}',
   }) as {
     assetId: string;
     expectedName: string;
+    extension?: string;
     readAssetData: () => Promise<unknown>;
   };
 
   expect(input).toMatchObject({
     assetId: "asset-id",
     expectedName: "settings_hash.json",
+    extension: "json",
   });
   await expect(input.readAssetData()).resolves.toBe('{"theme":"dark"}');
 });
@@ -1152,6 +1155,7 @@ test("exposes asset content editing through MCP discovery", () => {
       properties: {
         assetId: expect.any(Object),
         expectedName: expect.any(Object),
+        extension: expect.any(Object),
         path: expect.any(Object),
         content: expect.any(Object),
       },

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -211,6 +211,8 @@ const getMcpUpdateAssetContentInput = (input: unknown) => {
   return createLocalUpdateAssetContentInput({
     assetId: input.assetId,
     expectedName: input.expectedName,
+    extension:
+      typeof input.extension === "string" ? input.extension : undefined,
     path: typeof input.path === "string" ? input.path : undefined,
     content: typeof input.content === "string" ? input.content : undefined,
     readFile,

--- a/packages/http-client/src/index.test.ts
+++ b/packages/http-client/src/index.test.ts
@@ -1538,6 +1538,7 @@ test("updates asset content through the stable asset revision endpoint", async (
       ...apiParams,
       assetId: "asset/id",
       expectedName: "old_hash.json",
+      extension: "json",
       readAssetData: async () => '{"theme":"dark"}',
       request,
     })
@@ -1547,6 +1548,7 @@ test("updates asset content through the stable asset revision endpoint", async (
   expect(url.pathname).toBe("/rest/assets/asset%2Fid/content");
   expect(url.searchParams.get("projectId")).toBe(apiParams.projectId);
   expect(url.searchParams.get("expectedName")).toBe("old_hash.json");
+  expect(url.searchParams.get("extension")).toBe("json");
   expect(init).toMatchObject({ method: "PUT", body: '{"theme":"dark"}' });
   expect(new Headers(init.headers).get("x-auth-token")).toBe(
     apiParams.authToken

--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -752,6 +752,7 @@ export const updateProjectAssetContent = async (
     authToken?: string;
     assetId: string;
     expectedName: string;
+    extension?: string;
     readAssetData: () => Promise<AssetContentData>;
     request?: typeof fetch;
     requestOrigin?: string;
@@ -764,6 +765,9 @@ export const updateProjectAssetContent = async (
     path: getAssetContentApiUrl(params.assetId),
   });
   url.searchParams.set("expectedName", params.expectedName);
+  if (params.extension !== undefined) {
+    url.searchParams.set("extension", params.extension);
+  }
   try {
     return await requestAssetRestJson(request, url, {
       method: "PUT",

--- a/packages/protocol/src/asset-resource-api.ts
+++ b/packages/protocol/src/asset-resource-api.ts
@@ -1158,6 +1158,12 @@ export const createAssetResourceOpenApi = ({
               true,
               assetResourceLimits.assetFilenameCharacters
             ),
+            queryParameter(
+              "extension",
+              "Optional editable text format for the replacement revision",
+              false,
+              assetResourceLimits.assetFilenameCharacters
+            ),
           ],
           requestBody: {
             required: true,

--- a/packages/protocol/src/builder-api/local-operation-inputs.ts
+++ b/packages/protocol/src/builder-api/local-operation-inputs.ts
@@ -26,6 +26,7 @@ const localUploadAssetsInput = z.object({
 const localUpdateAssetContentInput = z.object({
   assetId: z.string().min(1),
   expectedName: z.string().min(1),
+  extension: z.string().min(1).optional(),
   path: z.string().min(1).optional(),
   content: z.string().optional(),
 });

--- a/packages/protocol/src/builder-api/operation-docs.ts
+++ b/packages/protocol/src/builder-api/operation-docs.ts
@@ -833,8 +833,8 @@ const curatedPublicApiOperationDocumentation = [
     description:
       "Replace a text asset's content or extension while preserving its stable asset id; provide exactly one of path or content and use the current asset name as expectedName",
     examples: [
-      'MCP/API: update-asset-content {"assetId":"asset-id","expectedName":"settings_hash.json","content":"{\\"theme\\":\\"dark\\"}"}',
-      'MCP/API: update-asset-content {"assetId":"asset-id","expectedName":"settings_hash.md","extension":"json","content":"{\\"theme\\":\\"dark\\"}"}',
+      `MCP/API: update-asset-content {"assetId":"asset-id","expectedName":"settings_hash.json","content":"{theme:'dark'}"}`,
+      `MCP/API: update-asset-content {"assetId":"asset-id","expectedName":"settings_hash.md","extension":"json","content":"{theme:'dark'}"}`,
       'MCP/API: update-asset-content {"assetId":"asset-id","expectedName":"styles_hash.css","path":"./styles.css"}',
     ],
   },

--- a/packages/protocol/src/builder-api/operation-docs.ts
+++ b/packages/protocol/src/builder-api/operation-docs.ts
@@ -831,9 +831,10 @@ const curatedPublicApiOperationDocumentation = [
   {
     command: "update-asset-content",
     description:
-      "Replace a text asset's content while preserving its stable asset id; provide exactly one of path or content and use the current asset name as expectedName",
+      "Replace a text asset's content or extension while preserving its stable asset id; provide exactly one of path or content and use the current asset name as expectedName",
     examples: [
       'MCP/API: update-asset-content {"assetId":"asset-id","expectedName":"settings_hash.json","content":"{\\"theme\\":\\"dark\\"}"}',
+      'MCP/API: update-asset-content {"assetId":"asset-id","expectedName":"settings_hash.md","extension":"json","content":"{\\"theme\\":\\"dark\\"}"}',
       'MCP/API: update-asset-content {"assetId":"asset-id","expectedName":"styles_hash.css","path":"./styles.css"}',
     ],
   },


### PR DESCRIPTION
## Summary

- make the complete asset filename editable in Asset settings
- convert existing editable text assets when their extension changes while preserving the asset ID
- accept every JSON root type and normalize JSON-compatible syntax into formatted strict JSON
- expose the same optional extension change through MCP/API `update-asset-content`
- initialize new JSON files and empty text-to-JSON conversions with a valid empty object
- distinguish browser URL imports from JSON file uploads so JSON objects with a root `url` field remain file content
- update the Assets and Content Engine documentation

## Root cause

Asset settings rendered the extension as a fixed suffix outside the name input. The metadata rename mutation could only change the display basename, while content revisions always inherited the current storage extension. As a result, changing `.md` to `.json` was impossible in the UI and unavailable through the shared MCP/API revision command.

Asset settings now edits the complete filename. Ordinary renames keep using the metadata mutation. A text-extension change loads the current content, validates it for the target format, and writes a new immutable revision through the existing conflict-safe content endpoint. The existing Acorn-backed `parseJsonExpression` utility accepts JSON-compatible syntax without evaluating code and serializes it as strict JSON. Objects, arrays, strings, numbers, booleans, and `null` are all accepted.

## Checklist

- [x] Create JSON files by entering a `.json` filename
- [x] Edit the complete filename in Asset settings
- [x] Convert editable text-file extensions while preserving the asset ID
- [x] Expose extension conversion through `update-asset-content`
- [x] Create JSON files and convert empty text files with a valid empty object
- [x] Normalize safe JSON-compatible syntax to strict JSON
- [x] Accept objects, arrays, and scalar JSON roots
- [x] Reject executable or incomplete content
- [x] Preserve browser-uploaded JSON object shapes
- [x] Review and update authoritative Builder documentation
- [x] Add focused UI, revision, HTTP-client, CLI/MCP, protocol, and upload regression tests
- [x] Run affected typechecks, lint, documentation checks, and the Builder production build
- [ ] Manually verify create, edit, rename `.md` to `.json`, reload persistence, and Content Engine query in a browser
- [ ] Run the complete local agent evaluation suite if approved

## Verification

- 217 focused tests passed across Builder, asset revisions, HTTP client, CLI/MCP, and protocol
- Builder, asset-uploader, HTTP-client, protocol, CLI, and project-build typechecks passed
- Builder production build passed
- MCP and Content Engine documentation checks passed
- `oxlint` on changed TypeScript files passed
- `git diff --check` passed
- Regression tests were demonstrated failing before the implementation and passing afterward

A disposable E2E database and PostgREST stack bootstrapped successfully in the earlier real-path test, but UI automation remained blocked because no controllable browser was available. Fixture inputs and generated fixture outputs are not affected. Agent evaluations were not run because approval is required and was not requested.

Closes #6167