### PR TITLE
fix: Recover responsive screenshots after DevTools disconnects

### DIFF
--- a/packages/vision/src/screenshot-browser-cdp.test.ts
+++ b/packages/vision/src/screenshot-browser-cdp.test.ts
@@ -919,6 +919,57 @@ test("restarts the shared browser once after an unexpected exit", async () => {
   expect(dependencies.rm).toHaveBeenCalledTimes(2);
 });
 
+test("restarts a responsive capture when the DevTools connection closes", async () => {
+  const firstProcess = new FakeBrowserProcess();
+  const secondProcess = new FakeBrowserProcess();
+  let recoveredSocket: FakeWebSocket | undefined;
+  const dependencies = createDependencies();
+  vi.mocked(dependencies.spawnBrowser)
+    .mockReturnValueOnce(firstProcess as never)
+    .mockReturnValueOnce(secondProcess as never);
+  vi.mocked(dependencies.createWebSocket)
+    .mockImplementationOnce(
+      () => new ClosingWebSocket() as unknown as WebSocket
+    )
+    .mockImplementationOnce(() => {
+      recoveredSocket = new FakeWebSocket();
+      return recoveredSocket as unknown as WebSocket;
+    });
+  const options = {
+    url: "https://example.com/responsive",
+    output: "/tmp/mobile.png",
+    width: 375,
+    height: 812,
+    browserPath: "/usr/bin/chromium",
+    waitUntil: "networkidle" as const,
+    waitForTimeout: 0,
+    timeout: 1000,
+  };
+  const session = await createBrowserScreenshotSession(options, dependencies);
+
+  await expect(
+    session.capturePage([
+      options,
+      { ...options, output: "/tmp/desktop.png", width: 1440, height: 900 },
+    ])
+  ).resolves.toHaveLength(2);
+
+  expect(dependencies.spawnBrowser).toHaveBeenCalledTimes(2);
+  expect(firstProcess.kill).toHaveBeenCalledOnce();
+  expect(dependencies.writeFile).toHaveBeenCalledTimes(2);
+  expect(
+    recoveredSocket?.sentMessages
+      .filter(
+        (message) => message.method === "Emulation.setDeviceMetricsOverride"
+      )
+      .map((message) => message.params?.width)
+  ).toEqual([375, 1440]);
+
+  await session.close();
+
+  expect(secondProcess.kill).toHaveBeenCalledOnce();
+});
+
 test("retries a browser restart after a transient startup failure", async () => {
   const firstProcess = new FakeBrowserProcess();
   const secondProcess = new FakeBrowserProcess();
@@ -1438,12 +1489,20 @@ test("times out when browser DevTools commands stop responding", async () => {
   });
 });
 
-test("rejects pending commands when the DevTools socket closes", async () => {
-  const browserProcess = new FakeBrowserProcess();
-  const dependencies = createDependencies({
-    browserProcess,
-    socket: new ClosingWebSocket(),
-  });
+test("rejects after the DevTools socket closes twice", async () => {
+  const firstProcess = new FakeBrowserProcess();
+  const secondProcess = new FakeBrowserProcess();
+  const dependencies = createDependencies();
+  vi.mocked(dependencies.spawnBrowser)
+    .mockReturnValueOnce(firstProcess as never)
+    .mockReturnValueOnce(secondProcess as never);
+  vi.mocked(dependencies.createWebSocket)
+    .mockImplementationOnce(
+      () => new ClosingWebSocket() as unknown as WebSocket
+    )
+    .mockImplementationOnce(
+      () => new ClosingWebSocket() as unknown as WebSocket
+    );
 
   await expect(
     captureBrowserScreenshot(
@@ -1461,7 +1520,9 @@ test("rejects pending commands when the DevTools socket closes", async () => {
     )
   ).rejects.toThrow("Browser DevTools connection closed.");
 
-  expect(browserProcess.kill).toHaveBeenCalled();
+  expect(dependencies.spawnBrowser).toHaveBeenCalledTimes(2);
+  expect(firstProcess.kill).toHaveBeenCalledOnce();
+  expect(secondProcess.kill).toHaveBeenCalledOnce();
 });
 
 test("times out when browser page target creation does not respond", async () => {

--- a/packages/vision/src/screenshot-browser-cdp.ts
+++ b/packages/vision/src/screenshot-browser-cdp.ts
@@ -163,6 +163,8 @@ type CdpMessage = {
   error?: { message?: string };
 };
 
+class BrowserSessionClosedError extends Error {}
+
 class CdpSession {
   #nextId = 1;
   #callbacks = new Map<
@@ -180,7 +182,9 @@ class CdpSession {
   constructor(socket: WebSocket) {
     this.#socket = socket;
     this.#socket.addEventListener("close", () => {
-      this.#rejectPending(new Error("Browser DevTools connection closed."));
+      this.#rejectPending(
+        new BrowserSessionClosedError("Browser DevTools connection closed.")
+      );
     });
     this.#socket.addEventListener("message", (event) => {
       const message = JSON.parse(String(event.data)) as CdpMessage;
@@ -1248,8 +1252,6 @@ export class BrowserStartupError extends Error {
     this.name = "BrowserStartupError";
   }
 }
-
-class BrowserSessionClosedError extends Error {}
 
 const getBrowserExitMessage = (message: string, reason?: string) =>
   `${message}${reason === undefined ? "" : ` (${reason})`}. Check the browser installation or provide a supported Chromium executable.`;


### PR DESCRIPTION
## Summary

Recover responsive screenshot batches when the Browser DevTools WebSocket closes transiently.

The capture session now treats a DevTools socket closure as the same recoverable session failure as an unexpected browser exit. It restarts Chromium once and reruns the complete viewport batch, so callers receive a consistent set of screenshots instead of partial artifacts.

## Root cause

The DevTools socket close handler rejected pending commands with a generic `Error`. The reusable browser retry boundary only recovered typed browser-session closures or a browser process that had exited, so a closed socket with a still-running Chromium process escaped as `MCP_TOOL_FAILED`.

## Technical choices

- Classify a DevTools WebSocket closure as `BrowserSessionClosedError` at the CDP boundary.
- Reuse the existing bounded browser-session restart path instead of adding a separate MCP-layer retry.
- Retry the complete responsive batch once so results remain all-or-nothing.
- Preserve the original `Browser DevTools connection closed.` diagnostic when the replacement connection also closes.

## Impact

A transient DevTools disconnect during a responsive capture automatically restarts the reusable browser and captures every requested viewport. Repeated connection loss still fails after one retry without looping indefinitely.

## Checklist

- [x] Add a fail-first regression for a two-viewport responsive capture
- [x] Verify mobile and desktop widths are both recaptured after reconnect
- [x] Verify a second consecutive disconnect returns the original error
- [x] Independently verify recovery with real Chrome, CDP, rendering, and PNG output
- [x] Review fixture impact: no fixture inputs or generated fixture outputs are affected
- [x] Review documentation impact: no user-facing documentation changes are required because this restores documented behavior
- [ ] Run agent evaluations (requires separate approval)

## Verification

- New responsive reconnect regression failed before the implementation with `Browser DevTools connection closed.` and passes after it
- Independent real-browser harness with Google Chrome `151.0.7922.138`:
  - served a real local responsive page and captured `375×812` and `1440×900`
  - forcibly closed the first real CDP WebSocket during `Page.captureScreenshot`
  - observed Chrome #1 terminate, its profile get removed, Chrome #2 launch, and the complete viewport batch replay
  - produced valid PNGs at both requested dimensions and left no browser processes or temporary profiles behind
- `pnpm --filter @webstudio-is/vision test` — 13 files, 81 tests passed
- `pnpm --filter @webstudio-is/vision typecheck`
- `pnpm --filter webstudio exec vitest run src/commands/mcp-preview.test.ts` — 43 tests passed
- `pnpm --filter webstudio typecheck`
- `pnpm exec oxlint --deny-warnings packages/vision/src/screenshot-browser-cdp.ts packages/vision/src/screenshot-browser-cdp.test.ts`
- `pnpm exec oxfmt packages/vision/src/screenshot-browser-cdp.ts packages/vision/src/screenshot-browser-cdp.test.ts`
- `git diff --check`

The real-browser fault was injected deterministically at the first screenshot command rather than produced by an organic OS or network failure. It exercised the reported DevTools closure boundary and complete responsive-batch recovery.

Agent evaluations were not run because they require separate explicit approval.

Closes #6169