### PR TITLE
fix: canonicalize trailing-slash page URLs

### DIFF
--- a/docs/university/foundations/page-settings.md
+++ b/docs/university/foundations/page-settings.md
@@ -61,8 +61,10 @@ Path rules:
 - Wildcards such as `*` and `:path*` must be the final segment
 - Parameter names can contain letters, numbers, and underscores
 
-Published sites permanently redirect a trailing-slash URL such as `/about/` to
-the page path `/about` and preserve its query string.
+Webstudio Cloud sites and exported JavaScript applications permanently redirect
+a trailing-slash URL such as `/about/` to the page path `/about` and preserve
+its query string. For static exports, the hosting platform controls
+[trailing-slash behavior](../self-hosting/#static-site-url-behavior).
 
 ## Status code
 

--- a/docs/university/foundations/page-settings.md
+++ b/docs/university/foundations/page-settings.md
@@ -61,6 +61,9 @@ Path rules:
 - Wildcards such as `*` and `:path*` must be the final segment
 - Parameter names can contain letters, numbers, and underscores
 
+Published sites permanently redirect a trailing-slash URL such as `/about/` to
+the page path `/about` and preserve its query string.
+
 ## Status code
 
 The HTTP status code returned when this page is requested. Defaults to `200`.

--- a/docs/university/self-hosting/README.md
+++ b/docs/university/self-hosting/README.md
@@ -111,6 +111,24 @@ While static site exporting and hosting are less technical, this comes at the co
 * No robots.txt
 * No sitemap.xml
 
+#### Static site URL behavior
+
+Webstudio static exports cannot redirect requests by themselves. The hosting
+platform decides whether `/about`, `/about/`, or both URLs serve a generated
+page such as `about/index.html`.
+
+| Platform | Default behavior for a Webstudio static export |
+| --- | --- |
+| Cloudflare Pages | Redirects `/about` to `/about/` for a generated `about/index.html` file. See [Cloudflare Pages serving behavior](https://developers.cloudflare.com/pages/configuration/serving-pages/). |
+| Netlify | Pretty URLs are enabled by default and normalize the generated page to `/about/`. Netlify applies this normalization before redirect rules, so a static redirect rule cannot change it to `/about`. See [Netlify redirect options](https://docs.netlify.com/manage/routing/redirects/redirect-options/). |
+| Vercel | Serves both `/about` and `/about/` unless the project sets `trailingSlash`. Set `"trailingSlash": false` in `vercel.json` to redirect `/about/` to `/about`. See [Vercel project configuration](https://vercel.com/docs/project-configuration/vercel-json#trailingslash). |
+| Other static hosts | Behavior depends on how the host resolves directory index files and normalizes URLs. Configure redirects or canonical URLs with the host. |
+
+If every URL must redirect to the slashless Webstudio page path, use an
+exported JavaScript application. On static hosting, enforcing that convention
+on Netlify or Cloudflare Pages requires request-handling code at the edge rather
+than static redirect files.
+
 #### Local
 
 To run a project locally, you must run a simple local server. Use the command `npx serve .` to spin one up. This is required because the static files use absolute URLs.

--- a/docs/university/self-hosting/cloudflare-pages.md
+++ b/docs/university/self-hosting/cloudflare-pages.md
@@ -16,6 +16,10 @@ See [export types](./#export-types) for more information about JavaScript applic
 
 Learn how to upload your static site to Cloudflare Pages.
 
+Cloudflare Pages uses a trailing slash for generated directory index pages.
+Review the [static site URL behavior](./#static-site-url-behavior) before
+deployment.
+
 <figure><img src="../../.gitbook/assets/cloudflare-pages-new-project.png" alt="Cloudflare Pages new project dashboard"><figcaption></figcaption></figure>
 
 ### Prerequisites

--- a/docs/university/self-hosting/netlify.md
+++ b/docs/university/self-hosting/netlify.md
@@ -84,6 +84,9 @@ When you make changes in Webstudio:
 
 Learn how to upload your static site to Netlify.
 
+Netlify uses a trailing slash for generated directory index pages. Review the
+[static site URL behavior](./#static-site-url-behavior) before deployment.
+
 <figure><img src="../../.gitbook/assets/netlify-new-project.png" alt="netlify new site dashboard"><figcaption></figcaption></figure>
 
 ### Prerequisites

--- a/docs/university/self-hosting/vercel.md
+++ b/docs/university/self-hosting/vercel.md
@@ -41,6 +41,10 @@ Vercel injects a few [files](https://github.com/vercel/vercel/blob/a8ad176262ef8
 
 Learn how to upload your static site to Vercel.
 
+Vercel serves both forms of a path by default, but can redirect to slashless
+paths with project configuration. Review the
+[static site URL behavior](./#static-site-url-behavior) before deployment.
+
 <figure><img src="../../.gitbook/assets/vercel-new-project.png" alt="Vercel add new project dashboard"><figcaption></figcaption></figure>
 
 ### Prerequisites

--- a/fixtures/react-router-cloudflare/app/redirect-url.ts
+++ b/fixtures/react-router-cloudflare/app/redirect-url.ts
@@ -166,6 +166,10 @@ export const redirectRequest = (
   }
 
   const url = new URL(request.url);
+  if (url.pathname.startsWith("//")) {
+    return;
+  }
+
   const pathname = removeTrailingSlash(url.pathname);
   if (pathname === url.pathname) {
     return;

--- a/fixtures/react-router-cloudflare/app/redirect-url.ts
+++ b/fixtures/react-router-cloudflare/app/redirect-url.ts
@@ -5,6 +5,7 @@ import {
   parsePath,
   redirect,
 } from "react-router";
+import { removeTrailingSlash } from "@webstudio-is/sdk";
 
 type RedirectItem = {
   old: string;
@@ -160,8 +161,15 @@ export const redirectRequest = (
   redirects: RedirectItem[]
 ): Response | undefined => {
   const matchedRedirect = matchRedirect(request.url, redirects);
-  if (matchedRedirect === undefined) {
+  if (matchedRedirect !== undefined) {
+    return redirect(matchedRedirect.url, matchedRedirect.status);
+  }
+
+  const url = new URL(request.url);
+  const pathname = removeTrailingSlash(url.pathname);
+  if (pathname === url.pathname) {
     return;
   }
-  return redirect(matchedRedirect.url, matchedRedirect.status);
+
+  return redirect(`${pathname}${url.search}`, 301);
 };

--- a/fixtures/react-router-docker/app/redirect-url.ts
+++ b/fixtures/react-router-docker/app/redirect-url.ts
@@ -166,6 +166,10 @@ export const redirectRequest = (
   }
 
   const url = new URL(request.url);
+  if (url.pathname.startsWith("//")) {
+    return;
+  }
+
   const pathname = removeTrailingSlash(url.pathname);
   if (pathname === url.pathname) {
     return;

--- a/fixtures/react-router-docker/app/redirect-url.ts
+++ b/fixtures/react-router-docker/app/redirect-url.ts
@@ -5,6 +5,7 @@ import {
   parsePath,
   redirect,
 } from "react-router";
+import { removeTrailingSlash } from "@webstudio-is/sdk";
 
 type RedirectItem = {
   old: string;
@@ -160,8 +161,15 @@ export const redirectRequest = (
   redirects: RedirectItem[]
 ): Response | undefined => {
   const matchedRedirect = matchRedirect(request.url, redirects);
-  if (matchedRedirect === undefined) {
+  if (matchedRedirect !== undefined) {
+    return redirect(matchedRedirect.url, matchedRedirect.status);
+  }
+
+  const url = new URL(request.url);
+  const pathname = removeTrailingSlash(url.pathname);
+  if (pathname === url.pathname) {
     return;
   }
-  return redirect(matchedRedirect.url, matchedRedirect.status);
+
+  return redirect(`${pathname}${url.search}`, 301);
 };

--- a/fixtures/react-router-netlify/app/redirect-url.ts
+++ b/fixtures/react-router-netlify/app/redirect-url.ts
@@ -166,6 +166,10 @@ export const redirectRequest = (
   }
 
   const url = new URL(request.url);
+  if (url.pathname.startsWith("//")) {
+    return;
+  }
+
   const pathname = removeTrailingSlash(url.pathname);
   if (pathname === url.pathname) {
     return;

--- a/fixtures/react-router-netlify/app/redirect-url.ts
+++ b/fixtures/react-router-netlify/app/redirect-url.ts
@@ -5,6 +5,7 @@ import {
   parsePath,
   redirect,
 } from "react-router";
+import { removeTrailingSlash } from "@webstudio-is/sdk";
 
 type RedirectItem = {
   old: string;
@@ -160,8 +161,15 @@ export const redirectRequest = (
   redirects: RedirectItem[]
 ): Response | undefined => {
   const matchedRedirect = matchRedirect(request.url, redirects);
-  if (matchedRedirect === undefined) {
+  if (matchedRedirect !== undefined) {
+    return redirect(matchedRedirect.url, matchedRedirect.status);
+  }
+
+  const url = new URL(request.url);
+  const pathname = removeTrailingSlash(url.pathname);
+  if (pathname === url.pathname) {
     return;
   }
-  return redirect(matchedRedirect.url, matchedRedirect.status);
+
+  return redirect(`${pathname}${url.search}`, 301);
 };

--- a/fixtures/react-router-vercel/app/redirect-url.ts
+++ b/fixtures/react-router-vercel/app/redirect-url.ts
@@ -166,6 +166,10 @@ export const redirectRequest = (
   }
 
   const url = new URL(request.url);
+  if (url.pathname.startsWith("//")) {
+    return;
+  }
+
   const pathname = removeTrailingSlash(url.pathname);
   if (pathname === url.pathname) {
     return;

--- a/fixtures/react-router-vercel/app/redirect-url.ts
+++ b/fixtures/react-router-vercel/app/redirect-url.ts
@@ -5,6 +5,7 @@ import {
   parsePath,
   redirect,
 } from "react-router";
+import { removeTrailingSlash } from "@webstudio-is/sdk";
 
 type RedirectItem = {
   old: string;
@@ -160,8 +161,15 @@ export const redirectRequest = (
   redirects: RedirectItem[]
 ): Response | undefined => {
   const matchedRedirect = matchRedirect(request.url, redirects);
-  if (matchedRedirect === undefined) {
+  if (matchedRedirect !== undefined) {
+    return redirect(matchedRedirect.url, matchedRedirect.status);
+  }
+
+  const url = new URL(request.url);
+  const pathname = removeTrailingSlash(url.pathname);
+  if (pathname === url.pathname) {
     return;
   }
-  return redirect(matchedRedirect.url, matchedRedirect.status);
+
+  return redirect(`${pathname}${url.search}`, 301);
 };

--- a/fixtures/webstudio-cloudflare-template/app/redirect-url.ts
+++ b/fixtures/webstudio-cloudflare-template/app/redirect-url.ts
@@ -166,6 +166,10 @@ export const redirectRequest = (
   }
 
   const url = new URL(request.url);
+  if (url.pathname.startsWith("//")) {
+    return;
+  }
+
   const pathname = removeTrailingSlash(url.pathname);
   if (pathname === url.pathname) {
     return;

--- a/fixtures/webstudio-cloudflare-template/app/redirect-url.ts
+++ b/fixtures/webstudio-cloudflare-template/app/redirect-url.ts
@@ -5,6 +5,7 @@ import {
   parsePath,
 } from "@remix-run/react";
 import { redirect } from "@remix-run/server-runtime";
+import { removeTrailingSlash } from "@webstudio-is/sdk";
 
 type RedirectItem = {
   old: string;
@@ -160,8 +161,15 @@ export const redirectRequest = (
   redirects: RedirectItem[]
 ): Response | undefined => {
   const matchedRedirect = matchRedirect(request.url, redirects);
-  if (matchedRedirect === undefined) {
+  if (matchedRedirect !== undefined) {
+    return redirect(matchedRedirect.url, matchedRedirect.status);
+  }
+
+  const url = new URL(request.url);
+  const pathname = removeTrailingSlash(url.pathname);
+  if (pathname === url.pathname) {
     return;
   }
-  return redirect(matchedRedirect.url, matchedRedirect.status);
+
+  return redirect(`${pathname}${url.search}`, 301);
 };

--- a/fixtures/webstudio-features/app/redirect-url.ts
+++ b/fixtures/webstudio-features/app/redirect-url.ts
@@ -166,6 +166,10 @@ export const redirectRequest = (
   }
 
   const url = new URL(request.url);
+  if (url.pathname.startsWith("//")) {
+    return;
+  }
+
   const pathname = removeTrailingSlash(url.pathname);
   if (pathname === url.pathname) {
     return;

--- a/fixtures/webstudio-features/app/redirect-url.ts
+++ b/fixtures/webstudio-features/app/redirect-url.ts
@@ -5,6 +5,7 @@ import {
   parsePath,
   redirect,
 } from "react-router";
+import { removeTrailingSlash } from "@webstudio-is/sdk";
 
 type RedirectItem = {
   old: string;
@@ -160,8 +161,15 @@ export const redirectRequest = (
   redirects: RedirectItem[]
 ): Response | undefined => {
   const matchedRedirect = matchRedirect(request.url, redirects);
-  if (matchedRedirect === undefined) {
+  if (matchedRedirect !== undefined) {
+    return redirect(matchedRedirect.url, matchedRedirect.status);
+  }
+
+  const url = new URL(request.url);
+  const pathname = removeTrailingSlash(url.pathname);
+  if (pathname === url.pathname) {
     return;
   }
-  return redirect(matchedRedirect.url, matchedRedirect.status);
+
+  return redirect(`${pathname}${url.search}`, 301);
 };

--- a/packages/cli/src/redirect-url.test.ts
+++ b/packages/cli/src/redirect-url.test.ts
@@ -655,6 +655,15 @@ for (const {
       expect(redirectRequest(new Request(url("/")), [])).toBeUndefined();
     });
 
+    test.each(["//other.example/", "///other.example/"])(
+      "does not create an external redirect from %s",
+      (requestPath) => {
+        expect(
+          redirectRequest(new Request(url(requestPath)), [])
+        ).toBeUndefined();
+      }
+    );
+
     test("gives an exact project redirect precedence", () => {
       const response = redirectRequest(new Request(url("/old/")), [
         { old: "/old/", new: "/new" },

--- a/packages/cli/src/redirect-url.test.ts
+++ b/packages/cli/src/redirect-url.test.ts
@@ -530,11 +530,6 @@ for (const {
         redirects: [{ old: "/old", new: "/new" }],
       },
       {
-        name: "does not normalize trailing slash",
-        requestPath: "/old/",
-        redirects: [{ old: "/old", new: "/new" }],
-      },
-      {
         name: "matches paths case-sensitively",
         requestPath: "/path",
         redirects: [{ old: "/Path", new: "/target" }],
@@ -613,6 +608,59 @@ for (const {
 
     test.each(nonMatchingCases)("$name", ({ requestPath, redirects }) => {
       expect(matchRedirect(url(requestPath), redirects)).toBeUndefined();
+    });
+
+    test("does not use a project redirect for its trailing-slash variant", () => {
+      expect(
+        matchRedirect(url("/old/"), [{ old: "/old", new: "/new" }])
+      ).toBeUndefined();
+    });
+
+    test.each([
+      {
+        name: "normalizes a static path",
+        requestPath: "/about/",
+        location: "/about",
+      },
+      {
+        name: "normalizes a concrete dynamic path",
+        requestPath: "/blog/post/",
+        location: "/blog/post",
+      },
+      {
+        name: "preserves the query string",
+        requestPath: "/about/?campaign=launch",
+        location: "/about?campaign=launch",
+      },
+      {
+        name: "removes repeated trailing slashes",
+        requestPath: "/about///",
+        location: "/about",
+      },
+      {
+        name: "preserves encoded path segments",
+        requestPath: "/file%2Fname/",
+        location: "/file%2Fname",
+      },
+    ])(
+      "returns canonical redirect response: $name",
+      ({ requestPath, location }) => {
+        const response = redirectRequest(new Request(url(requestPath)), []);
+        expect(response?.status).toBe(301);
+        expect(response?.headers.get("Location")).toBe(location);
+      }
+    );
+
+    test("does not redirect the root path", () => {
+      expect(redirectRequest(new Request(url("/")), [])).toBeUndefined();
+    });
+
+    test("gives an exact project redirect precedence", () => {
+      const response = redirectRequest(new Request(url("/old/")), [
+        { old: "/old/", new: "/new" },
+      ]);
+      expect(response?.status).toBe(301);
+      expect(response?.headers.get("Location")).toBe("/new");
     });
 
     test.each(nonMatchingCases)(

--- a/packages/cli/templates/defaults/app/redirect-url.ts
+++ b/packages/cli/templates/defaults/app/redirect-url.ts
@@ -166,6 +166,10 @@ export const redirectRequest = (
   }
 
   const url = new URL(request.url);
+  if (url.pathname.startsWith("//")) {
+    return;
+  }
+
   const pathname = removeTrailingSlash(url.pathname);
   if (pathname === url.pathname) {
     return;

--- a/packages/cli/templates/defaults/app/redirect-url.ts
+++ b/packages/cli/templates/defaults/app/redirect-url.ts
@@ -5,6 +5,7 @@ import {
   parsePath,
 } from "@remix-run/react";
 import { redirect } from "@remix-run/server-runtime";
+import { removeTrailingSlash } from "@webstudio-is/sdk";
 
 type RedirectItem = {
   old: string;
@@ -160,8 +161,15 @@ export const redirectRequest = (
   redirects: RedirectItem[]
 ): Response | undefined => {
   const matchedRedirect = matchRedirect(request.url, redirects);
-  if (matchedRedirect === undefined) {
+  if (matchedRedirect !== undefined) {
+    return redirect(matchedRedirect.url, matchedRedirect.status);
+  }
+
+  const url = new URL(request.url);
+  const pathname = removeTrailingSlash(url.pathname);
+  if (pathname === url.pathname) {
     return;
   }
-  return redirect(matchedRedirect.url, matchedRedirect.status);
+
+  return redirect(`${pathname}${url.search}`, 301);
 };

--- a/packages/cli/templates/react-router/app/redirect-url.ts
+++ b/packages/cli/templates/react-router/app/redirect-url.ts
@@ -166,6 +166,10 @@ export const redirectRequest = (
   }
 
   const url = new URL(request.url);
+  if (url.pathname.startsWith("//")) {
+    return;
+  }
+
   const pathname = removeTrailingSlash(url.pathname);
   if (pathname === url.pathname) {
     return;

--- a/packages/cli/templates/react-router/app/redirect-url.ts
+++ b/packages/cli/templates/react-router/app/redirect-url.ts
@@ -5,6 +5,7 @@ import {
   parsePath,
   redirect,
 } from "react-router";
+import { removeTrailingSlash } from "@webstudio-is/sdk";
 
 type RedirectItem = {
   old: string;
@@ -160,8 +161,15 @@ export const redirectRequest = (
   redirects: RedirectItem[]
 ): Response | undefined => {
   const matchedRedirect = matchRedirect(request.url, redirects);
-  if (matchedRedirect === undefined) {
+  if (matchedRedirect !== undefined) {
+    return redirect(matchedRedirect.url, matchedRedirect.status);
+  }
+
+  const url = new URL(request.url);
+  const pathname = removeTrailingSlash(url.pathname);
+  if (pathname === url.pathname) {
     return;
   }
-  return redirect(matchedRedirect.url, matchedRedirect.status);
+
+  return redirect(`${pathname}${url.search}`, 301);
 };

--- a/packages/project-build/src/runtime/redirect-loop-detection.test.ts
+++ b/packages/project-build/src/runtime/redirect-loop-detection.test.ts
@@ -8,6 +8,10 @@ describe("wouldCreateLoop", () => {
       expect(wouldCreateLoop("/about", "/about", [])).toBe(true);
     });
 
+    test("returns true for self-redirect through trailing-slash normalization", () => {
+      expect(wouldCreateLoop("/about", "/about/", [])).toBe(true);
+    });
+
     test("returns true for self-redirect with existing redirects", () => {
       const existing: PageRedirect[] = [
         { old: "/other", new: "/page", status: "301" },
@@ -67,6 +71,13 @@ describe("wouldCreateLoop", () => {
         { old: "/b", new: "/a", status: "301" },
       ];
       expect(wouldCreateLoop("/a", "/b", existing)).toBe(true);
+    });
+
+    test("returns true when targets loop through trailing-slash normalization", () => {
+      const existing: PageRedirect[] = [
+        { old: "/b", new: "/a/", status: "301" },
+      ];
+      expect(wouldCreateLoop("/a", "/b/", existing)).toBe(true);
     });
 
     test("returns false when no loop exists", () => {

--- a/packages/project-build/src/runtime/redirect-loop-detection.ts
+++ b/packages/project-build/src/runtime/redirect-loop-detection.ts
@@ -1,6 +1,7 @@
-import type { PageRedirect } from "@webstudio-is/sdk";
+import { removeTrailingSlash, type PageRedirect } from "@webstudio-is/sdk";
 import {
   doesRedirectSourceMatchLocalUrl,
+  getRedirectSourceSearchIndex,
   getRedirectSourcePathname,
   normalizeRedirectSource,
 } from "./redirect-source";
@@ -29,6 +30,13 @@ const resolveLocalTarget = (source: string, target: string) => {
   } catch {
     return;
   }
+};
+
+const normalizeTrailingSlash = (url: string) => {
+  const searchIndex = getRedirectSourceSearchIndex(url);
+  const pathname = searchIndex === -1 ? url : url.slice(0, searchIndex);
+  const search = searchIndex === -1 ? "" : url.slice(searchIndex);
+  return `${removeTrailingSlash(pathname)}${search}`;
 };
 
 export const wouldCreateLoop = (
@@ -77,7 +85,10 @@ export const wouldCreateLoop = (
       }
     }
     if (next === undefined) {
-      return false;
+      next = normalizeTrailingSlash(current);
+      if (next === current) {
+        return false;
+      }
     }
 
     current = next;

--- a/packages/sdk/src/url-pattern.test.ts
+++ b/packages/sdk/src/url-pattern.test.ts
@@ -1,5 +1,17 @@
 import { expect, test, describe } from "vitest";
-import { isPathnamePattern, isAbsoluteUrl } from "./url-pattern";
+import {
+  isPathnamePattern,
+  isAbsoluteUrl,
+  removeTrailingSlash,
+} from "./url-pattern";
+
+test("removes trailing slashes without changing the root path", () => {
+  expect(removeTrailingSlash("/")).toBe("/");
+  expect(removeTrailingSlash("/about")).toBe("/about");
+  expect(removeTrailingSlash("/about/")).toBe("/about");
+  expect(removeTrailingSlash("/about///")).toBe("/about");
+  expect(removeTrailingSlash("/file%2Fname/")).toBe("/file%2Fname");
+});
 
 test("check pathname is pattern", () => {
   expect(isPathnamePattern("/:name")).toEqual(true);

--- a/packages/sdk/src/url-pattern.ts
+++ b/packages/sdk/src/url-pattern.ts
@@ -14,6 +14,14 @@ export const matchPathnameParams = (pathname: string) => {
   return pathname.matchAll(tokenRegexGlobal);
 };
 
+export const removeTrailingSlash = (pathname: string) => {
+  let end = pathname.length;
+  while (end > 1 && pathname[end - 1] === "/") {
+    end -= 1;
+  }
+  return pathname.slice(0, end);
+};
+
 /**
  * Check if a string is an absolute URL (has a valid protocol)
  */


### PR DESCRIPTION
## Outcome

Canonical page URLs now omit a trailing slash in Webstudio Cloud sites and exported JavaScript applications. A request such as `/about/?campaign=launch` receives a permanent `301` redirect to `/about?campaign=launch`, preventing both URL variants from serving identical page content.

The behavior is implemented once in the generated root redirect handler, so it covers fixed and dynamic application routes without generating an extra route per page. Exact project redirects remain authoritative. Protocol-relative-looking paths such as `//example.com/` are left untouched so canonicalization cannot become an external redirect.

Static exports cannot redirect requests themselves. Their URL behavior remains host-specific and is documented for Cloudflare Pages, Netlify, Vercel, and other static hosts.

## Implementation

- Add one shared pathname normalizer in the SDK.
- Apply canonicalization after exact authored redirect matching in both generated application runtimes.
- Ignore repeated leading slashes before constructing a redirect location.
- Extend redirect-loop detection to model the implicit canonical redirect.
- Regenerate the affected fixture applications from their templates.
- Document application canonicalization and host-specific static export behavior.

## Todo

1. [x] Add central trailing-slash canonicalization.
2. [x] Preserve query strings, encoded path segments, and the root path.
3. [x] Cover concrete dynamic URLs without per-route generation.
4. [x] Preserve explicit project redirect precedence.
5. [x] Detect redirect loops that pass through canonicalization.
6. [x] Prevent protocol-relative external redirects.
7. [x] Regenerate and review fixture output.
8. [x] Review documentation impact; document application and SSG behavior.
9. [x] Run targeted and repository-level verification.

## Verification

- SDK tests: 548 passed
- SDK typecheck: passed
- Project Build tests: 2,379 passed
- Project Build typecheck: passed
- CLI tests: 997 passed; two tests timed out only while three package suites ran concurrently, then both affected files passed in isolation (6/6)
- Redirect regression suite after security follow-up: 302 passed
- CLI typecheck: passed
- `pnpm lint`: passed
- `pnpm check:package-boundaries`: passed
- `pnpm fixtures`: passed
- Documentation internal anchors and Markdown whitespace: checked
- New regression tests were confirmed failing before their implementations and passing afterward
- Agent evaluations were not run because they require separate explicit approval

Closes #6172
Closes https://github.com/webstudio-is/webstudio/issues/4327