### PR TITLE
fix: Bound Webstudio JSX transformation time

### DIFF
--- a/packages/project-build/src/mcp.test.ts
+++ b/packages/project-build/src/mcp.test.ts
@@ -2465,6 +2465,55 @@ describe("project session mcp adapter", () => {
     expect(call?.input).not.toHaveProperty("source");
   });
 
+  test("converts a styled nested svg before executing insert-fragment", async () => {
+    const executeOperation = createExecuteOperation(async () =>
+      createEnvelope({
+        operationId: "instances.insertFragment",
+        result: {
+          rootInstanceIds: ["anchor"],
+          instanceIds: ["anchor", "svg", "path"],
+        },
+      })
+    );
+    const adapter = createProjectSessionMcpCore({
+      operations: publicMcpOperations,
+      createProjectSession: createSessionFactory(),
+      executeOperation,
+    });
+
+    await adapter.callTool({
+      name: "insert-fragment",
+      input: {
+        parentInstanceId: "body",
+        fragment:
+          '<ws.element ws:tag="a"><ws.element ws:tag="svg" ws:style={css`pointer-events: none;`}><ws.element ws:tag="path" /></ws.element></ws.element>',
+      },
+      dryRun: true,
+    });
+
+    const call = vi.mocked(executeOperation).mock.calls[0]?.[0];
+    expect(call).toMatchObject({
+      command: "insert-fragment",
+      dryRun: true,
+      input: {
+        parentInstanceId: "body",
+        fragment: {
+          instances: [
+            expect.objectContaining({ tag: "a" }),
+            expect.objectContaining({ tag: "svg" }),
+            expect.objectContaining({ tag: "path" }),
+          ],
+          styles: [
+            expect.objectContaining({
+              property: "pointerEvents",
+              value: { type: "keyword", value: "none" },
+            }),
+          ],
+        },
+      },
+    });
+  });
+
   test("inserts a fragment and verifies persisted bindings in one call", async () => {
     const executeOperation = createExecuteOperation(async ({ command }) =>
       command === "insert-fragment"

--- a/packages/project-build/src/runtime/jsx/evaluate.server.test.ts
+++ b/packages/project-build/src/runtime/jsx/evaluate.server.test.ts
@@ -1,0 +1,23 @@
+import { expect, test, vi } from "vitest";
+import { evaluateJsx } from "./evaluate.server";
+
+test("returns a structured validation error when jsx transformation stalls", async () => {
+  const stalledTransform = vi.fn(() => new Promise<never>(() => {}));
+
+  await expect(
+    evaluateJsx({
+      source: "<$.Box />",
+      createModule: (source) => source,
+      transformJsx: stalledTransform,
+      transformTimeoutMs: 1,
+    })
+  ).rejects.toMatchObject({
+    code: "INVALID_INPUT",
+    issues: [
+      expect.objectContaining({
+        code: "invalid_webstudio_jsx",
+        detail: "JSX transformation exceeded 1ms.",
+      }),
+    ],
+  });
+});

--- a/packages/project-build/src/runtime/jsx/evaluate.server.ts
+++ b/packages/project-build/src/runtime/jsx/evaluate.server.ts
@@ -6,6 +6,8 @@ import { getErrorMessage, throwWebstudioJsxValidationError } from "./errors";
 type EvaluateJsxOptions = {
   source: string;
   createModule: (source: string) => string;
+  transformJsx?: typeof transform;
+  transformTimeoutMs?: number;
   globals?: Record<string, unknown>;
   parseErrorMessage?: (error: unknown) => string;
   evaluationErrorMessage?: (error: unknown) => string;
@@ -15,6 +17,8 @@ type EvaluateJsxOptions = {
 export const evaluateJsx = async <Result>({
   source,
   createModule,
+  transformJsx = transform,
+  transformTimeoutMs = 5_000,
   globals,
   parseErrorMessage = (error) =>
     `Could not parse JSX. ${getErrorMessage(error)}`,
@@ -23,15 +27,27 @@ export const evaluateJsx = async <Result>({
   missingResultMessage = "JSX did not produce a value.",
 }: EvaluateJsxOptions): Promise<Result> => {
   let code: string;
+  let transformTimeout: ReturnType<typeof setTimeout> | undefined;
   try {
-    const result = await transform(createModule(source), {
-      loader: "tsx",
-      format: "cjs",
-      platform: "node",
-      jsx: "transform",
-      jsxFactory: "createElement",
-      jsxFragment: "Fragment",
-    });
+    const result = await Promise.race([
+      transformJsx(createModule(source), {
+        loader: "tsx",
+        format: "cjs",
+        platform: "node",
+        jsx: "transform",
+        jsxFactory: "createElement",
+        jsxFragment: "Fragment",
+      }),
+      new Promise<never>((_resolve, reject) => {
+        transformTimeout = setTimeout(
+          () =>
+            reject(
+              new Error(`JSX transformation exceeded ${transformTimeoutMs}ms.`)
+            ),
+          transformTimeoutMs
+        );
+      }),
+    ]);
     code = result.code;
   } catch (error) {
     return throwWebstudioJsxValidationError(
@@ -39,6 +55,8 @@ export const evaluateJsx = async <Result>({
       "valid_webstudio_jsx_syntax",
       getErrorMessage(error)
     );
+  } finally {
+    clearTimeout(transformTimeout);
   }
 
   const exports: { default?: Result } = {};


### PR DESCRIPTION
## Summary

- Bound asynchronous Webstudio JSX transformation to five seconds.
- Return the existing structured `INVALID_INPUT` validation result when transformation exceeds that deadline.
- Cover an `insert-fragment` dry run containing an anchor, nested inline SVG, and local `pointer-events` style.

## Root cause

The VM evaluation stage already had a one-second execution timeout, but the preceding asynchronous esbuild JSX transformation had no deadline. If that promise stopped settling, `insert-fragment` could remain pending without producing a structured tool result.

The deadline removes the unbounded wait. It does not cancel the underlying esbuild transform; that work may finish later, but the MCP call returns a diagnostic after five seconds.

## Checklist

1. [x] Add a bounded JSX transformation deadline.
2. [x] Preserve structured Webstudio JSX validation errors on timeout.
3. [x] Add the nested SVG and `pointer-events` MCP regression.
4. [x] Demonstrate the timeout test fails without the deadline and passes with it.
5. [x] Run Project Build tests, typecheck, lint, and formatting checks.
6. [x] Review fixture impact; no fixture inputs or generated fixture outputs are affected.
7. [x] Review documentation impact; this reliability fix does not change user-facing commands or documented behavior.

## Verification

- `pnpm --filter @webstudio-is/project-build test` — 2,113 passed.
- `pnpm --filter @webstudio-is/project-build typecheck` — passed.
- `pnpm exec oxlint --deny-warnings packages/project-build/src/runtime/jsx/evaluate.server.ts packages/project-build/src/runtime/jsx/evaluate.server.test.ts packages/project-build/src/mcp.test.ts` — passed.
- `pnpm exec oxfmt packages/project-build/src/runtime/jsx/evaluate.server.ts packages/project-build/src/runtime/jsx/evaluate.server.test.ts packages/project-build/src/mcp.test.ts` — passed.
- Timeout regression without the deadline — failed with the expected test timeout; restored implementation passes.

Closes #6132