### PR TITLE
fix: Report terminated MCP single-op calls

### DIFF
--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -14,7 +14,12 @@ import {
 } from "@webstudio-is/project-build/mcp";
 import { publicApiOperations } from "@webstudio-is/protocol";
 import { updatePersistedMcpCheckpoint } from "./mcp-checkpoint";
-import { __testing__, mcpOptions, prepareMcpProjectSession } from "./mcp";
+import {
+  __testing__,
+  mcpOptions,
+  mcpSingleOpCall,
+  prepareMcpProjectSession,
+} from "./mcp";
 
 const {
   assertSingleOpCallToolSupported,
@@ -898,6 +903,46 @@ test("reports termination while inserting a styled nested SVG", async () => {
     },
   });
   expect(setExitCode).not.toHaveBeenCalled();
+});
+
+test("installs termination reporting for an active MCP single-op call", async () => {
+  const previousExitCode = process.exitCode;
+  const consoleInfo = vi.spyOn(console, "info").mockImplementation(() => {});
+  const stderrWrite = vi
+    .spyOn(process.stderr, "write")
+    .mockImplementation(() => true);
+
+  try {
+    const call = mcpSingleOpCall({
+      tool: "insert-fragment",
+      input: "{invalid-json",
+      dryRun: true,
+    });
+    process.emit("beforeExit", 0);
+    await expect(call).rejects.toBeDefined();
+
+    const results = consoleInfo.mock.calls.map(([output]) =>
+      JSON.parse(String(output))
+    );
+    expect(results).toContainEqual({
+      ok: false,
+      error: {
+        code: "MCP_CALL_TERMINATED",
+        message:
+          "MCP single-op-call insert-fragment terminated before returning a result.",
+      },
+      meta: {
+        elapsedMs: expect.any(Number),
+        termination: { type: "beforeExit", exitCode: 0 },
+      },
+    });
+    expect(stderrWrite).toHaveBeenCalledWith(
+      "[webstudio mcp] single-op-call insert-fragment terminated: MCP single-op-call insert-fragment terminated before returning a result.\n"
+    );
+    expect(process.exitCode).toBe(1);
+  } finally {
+    process.exitCode = previousExitCode;
+  }
 });
 
 test("preserves completed calls when a run terminates during an asset query preview", () => {

--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -26,6 +26,7 @@ const {
   createMcpStatusReporter,
   getLoadedProjectSessionSnapshot,
   getMcpOperationInput,
+  reportMcpSingleOpCallTermination,
   reportMcpRunTermination,
   createMcpRunTerminationController,
   parseMcpRunCalls,
@@ -839,6 +840,64 @@ test("formats MCP run failures as structured JSON payloads", () => {
       elapsedMs: 12,
     },
   });
+});
+
+test("reports termination while inserting a styled nested SVG", async () => {
+  const operation = publicApiOperations.find(
+    ({ command }) => command === "insert-fragment"
+  );
+  if (operation === undefined) {
+    throw new Error("Expected insert-fragment operation");
+  }
+  const executeOperation = vi.fn(async () => {
+    throw new Error("Simulated interrupted operation");
+  });
+  const core = createProjectSessionMcpCore({
+    operations: [operation],
+    createProjectSession: () => {
+      throw new Error("insert-fragment must use executeOperation");
+    },
+    executeOperation,
+  });
+  const fragment = `<ws.element ws:tag="a">
+    <ws.element ws:tag="svg" ws:style={css\`pointer-events: none;\`}>
+      <ws.element ws:tag="path" />
+    </ws.element>
+  </ws.element>`;
+
+  await expect(
+    core.callTool({
+      name: "insert-fragment",
+      input: { parentInstanceId: "body", fragment },
+      dryRun: true,
+    })
+  ).rejects.toThrow("Simulated interrupted operation");
+  expect(executeOperation).toHaveBeenCalledOnce();
+
+  const writeResult = vi.fn();
+  const setExitCode = vi.fn();
+  reportMcpSingleOpCallTermination({
+    termination: { type: "signal", signal: "SIGTERM" },
+    tool: "insert-fragment",
+    elapsedMs: 123,
+    writeStatus: vi.fn(),
+    writeResult,
+    setExitCode,
+  });
+
+  expect(writeResult).toHaveBeenCalledWith({
+    ok: false,
+    error: {
+      code: "MCP_CALL_TERMINATED",
+      message:
+        "MCP single-op-call insert-fragment terminated before returning a result.",
+    },
+    meta: {
+      elapsedMs: 123,
+      termination: { type: "signal", signal: "SIGTERM" },
+    },
+  });
+  expect(setExitCode).not.toHaveBeenCalled();
 });
 
 test("preserves completed calls when a run terminates during an asset query preview", () => {

--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -924,18 +924,20 @@ test("installs termination reporting for an active MCP single-op call", async ()
     const results = consoleInfo.mock.calls.map(([output]) =>
       JSON.parse(String(output))
     );
-    expect(results).toContainEqual({
-      ok: false,
-      error: {
-        code: "MCP_CALL_TERMINATED",
-        message:
-          "MCP single-op-call insert-fragment terminated before returning a result.",
+    expect(results).toEqual([
+      {
+        ok: false,
+        error: {
+          code: "MCP_CALL_TERMINATED",
+          message:
+            "MCP single-op-call insert-fragment terminated before returning a result.",
+        },
+        meta: {
+          elapsedMs: expect.any(Number),
+          termination: { type: "beforeExit", exitCode: 0 },
+        },
       },
-      meta: {
-        elapsedMs: expect.any(Number),
-        termination: { type: "beforeExit", exitCode: 0 },
-      },
-    });
+    ]);
     expect(stderrWrite).toHaveBeenCalledWith(
       "[webstudio mcp] single-op-call insert-fragment terminated: MCP single-op-call insert-fragment terminated before returning a result.\n"
     );

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1325,6 +1325,7 @@ export const mcpSingleOpCall = async (options: McpSingleOpCallOptions) => {
     )}\n`
   );
   let activeCall: ActiveMcpRunCall | undefined = { number: 1, tool };
+  let didTerminate = false;
   let disposeHost: () => Promise<void> = async () => undefined;
   const disposeTerminationHandlers = installMcpRunTerminationHandlers({
     getActiveCall: () => activeCall,
@@ -1333,6 +1334,7 @@ export const mcpSingleOpCall = async (options: McpSingleOpCallOptions) => {
     startedAt,
     disposeHost: () => disposeHost(),
     reportTermination: ({ termination, activeCall, elapsedMs }) => {
+      didTerminate = true;
       reportMcpSingleOpCallTermination({
         termination,
         tool: activeCall.tool,
@@ -1344,10 +1346,16 @@ export const mcpSingleOpCall = async (options: McpSingleOpCallOptions) => {
     assertSingleOpCallToolSupported(tool);
     const input = await parseMcpSingleOpCallInput(options);
     validateSingleOpCallInput(tool, input);
+    if (didTerminate) {
+      throw new HandledCliError();
+    }
     await withMcpHost(
       async () => {
         const mcpHost = await createCliMcpHost({ projectId: options.project });
         disposeHost = mcpHost.dispose;
+        if (didTerminate) {
+          throw new HandledCliError();
+        }
         return mcpHost;
       },
       async ({ host, apiContract, scope }) => {
@@ -1364,12 +1372,18 @@ export const mcpSingleOpCall = async (options: McpSingleOpCallOptions) => {
         );
         if (options.refresh === true && tool !== "refresh") {
           await core.callTool({ name: "refresh" });
+          if (didTerminate) {
+            throw new HandledCliError();
+          }
         }
         const result = await core.callTool({
           name: tool,
           input,
           dryRun: options.dryRun,
         });
+        if (didTerminate) {
+          throw new HandledCliError();
+        }
         if (isMcpToolCallFailure(result)) {
           activeCall = undefined;
           stderr.write(
@@ -1393,6 +1407,9 @@ export const mcpSingleOpCall = async (options: McpSingleOpCallOptions) => {
           structuredContent: result.structuredContent,
           scope,
         });
+        if (didTerminate) {
+          throw new HandledCliError();
+        }
         const session = result.structuredContent.meta.session;
         const committed =
           session === undefined ? "" : `; committed=${session.committed}`;
@@ -1411,6 +1428,9 @@ export const mcpSingleOpCall = async (options: McpSingleOpCallOptions) => {
     );
   } catch (error) {
     activeCall = undefined;
+    if (didTerminate) {
+      throw new HandledCliError();
+    }
     if (isHandledCliError(error)) {
       throw error;
     }

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1365,11 +1365,17 @@ export const mcpSingleOpCall = async (options: McpSingleOpCallOptions) => {
           tool === "checkpoint.ack"
             ? await readPersistedMcpCheckpoint(scope)
             : undefined;
+        if (didTerminate) {
+          throw new HandledCliError();
+        }
         await assertPersistedMcpCheckpointAcknowledged(
           tool,
           core.listTools(),
           scope
         );
+        if (didTerminate) {
+          throw new HandledCliError();
+        }
         if (options.refresh === true && tool !== "refresh") {
           await core.callTool({ name: "refresh" });
           if (didTerminate) {

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -701,6 +701,43 @@ type McpRunTermination =
   | { type: "beforeExit"; exitCode: number }
   | { type: "signal"; signal: NodeJS.Signals };
 
+const reportMcpSingleOpCallTermination = ({
+  termination,
+  tool,
+  elapsedMs,
+  writeStatus = (message) => stderr.write(`${message}\n`),
+  writeResult = printJson,
+  setExitCode = (code) => {
+    process.exitCode = code;
+  },
+}: {
+  termination: McpRunTermination;
+  tool: string;
+  elapsedMs: number;
+  writeStatus?: (message: string) => void;
+  writeResult?: (result: unknown) => void;
+  setExitCode?: (code: number) => void;
+}) => {
+  const error = {
+    code: "MCP_CALL_TERMINATED",
+    message: `MCP single-op-call ${tool} terminated before returning a result.`,
+  };
+  const payload = createMcpSingleOpCallErrorPayload({ error, elapsedMs });
+  writeStatus(
+    formatMcpStatusLine(`single-op-call ${tool} terminated: ${error.message}`)
+  );
+  writeResult({
+    ...payload,
+    meta: {
+      ...payload.meta,
+      termination,
+    },
+  });
+  if (termination.type === "beforeExit") {
+    setExitCode(1);
+  }
+};
+
 const mcpRunTerminationCleanupTimeout = 5000;
 
 const reportMcpRunTermination = ({
@@ -816,12 +853,14 @@ const installMcpRunTerminationHandlers = ({
   results,
   startedAt,
   disposeHost,
+  reportTermination = reportMcpRunTermination,
 }: {
   getActiveCall: () => ActiveMcpRunCall | undefined;
   totalCalls: number;
   results: unknown[];
   startedAt: number;
   disposeHost: () => Promise<void>;
+  reportTermination?: typeof reportMcpRunTermination;
 }) => {
   const controller = createMcpRunTerminationController({
     getActiveCall,
@@ -829,6 +868,7 @@ const installMcpRunTerminationHandlers = ({
     results,
     startedAt,
     disposeHost,
+    reportTermination,
   });
   const terminationSignals = ["SIGHUP", "SIGINT", "SIGTERM"] as const;
   const signalHandlers = new Map<NodeJS.Signals, () => void>();
@@ -1284,12 +1324,32 @@ export const mcpSingleOpCall = async (options: McpSingleOpCallOptions) => {
       `single-op-call ${tool} started${options.dryRun === true ? " (dry run)" : ""}`
     )}\n`
   );
+  let activeCall: ActiveMcpRunCall | undefined = { number: 1, tool };
+  let disposeHost: () => Promise<void> = async () => undefined;
+  const disposeTerminationHandlers = installMcpRunTerminationHandlers({
+    getActiveCall: () => activeCall,
+    totalCalls: 1,
+    results: [],
+    startedAt,
+    disposeHost: () => disposeHost(),
+    reportTermination: ({ termination, activeCall, elapsedMs }) => {
+      reportMcpSingleOpCallTermination({
+        termination,
+        tool: activeCall.tool,
+        elapsedMs,
+      });
+    },
+  });
   try {
     assertSingleOpCallToolSupported(tool);
     const input = await parseMcpSingleOpCallInput(options);
     validateSingleOpCallInput(tool, input);
     await withMcpHost(
-      () => createCliMcpHost({ projectId: options.project }),
+      async () => {
+        const mcpHost = await createCliMcpHost({ projectId: options.project });
+        disposeHost = mcpHost.dispose;
+        return mcpHost;
+      },
       async ({ host, apiContract, scope }) => {
         assertMcpToolServerSupport(tool, apiContract);
         const core = createCliMcpCore(host);
@@ -1311,6 +1371,7 @@ export const mcpSingleOpCall = async (options: McpSingleOpCallOptions) => {
           dryRun: options.dryRun,
         });
         if (isMcpToolCallFailure(result)) {
+          activeCall = undefined;
           stderr.write(
             `${formatMcpStatusLine(
               `single-op-call ${tool} failed in ${Date.now() - startedAt}ms`
@@ -1335,6 +1396,7 @@ export const mcpSingleOpCall = async (options: McpSingleOpCallOptions) => {
         const session = result.structuredContent.meta.session;
         const committed =
           session === undefined ? "" : `; committed=${session.committed}`;
+        activeCall = undefined;
         stderr.write(
           `${formatMcpStatusLine(
             `single-op-call ${tool} succeeded in ${Date.now() - startedAt}ms${committed}`
@@ -1348,6 +1410,7 @@ export const mcpSingleOpCall = async (options: McpSingleOpCallOptions) => {
       }
     );
   } catch (error) {
+    activeCall = undefined;
     if (isHandledCliError(error)) {
       throw error;
     }
@@ -1362,6 +1425,9 @@ export const mcpSingleOpCall = async (options: McpSingleOpCallOptions) => {
     );
     printJson(payload);
     throw new HandledCliError();
+  } finally {
+    activeCall = undefined;
+    disposeTerminationHandlers();
   }
 };
 
@@ -1755,6 +1821,7 @@ export const __testing__ = {
     meta: { elapsedMs },
   }),
   createMcpRunErrorPayload,
+  reportMcpSingleOpCallTermination,
   reportMcpRunTermination,
   createMcpRunTerminationController,
   createMcpRunCheckpointStopPayload,


### PR DESCRIPTION
## Summary

- return structured `MCP_CALL_TERMINATED` output when a one-shot MCP call receives SIGHUP, SIGINT, or SIGTERM, or reaches `beforeExit` without a result
- reuse the existing bounded host-cleanup and signal-preservation path from `mcp run`
- cover the reported anchor → inline SVG → `pointer-events: none` fragment through the real MCP normalization path

## Evidence and scope

The reported fragment itself does not hang: it normalizes in about 20–30 ms on both CLI 0.290.0 and current main, including Node 26.0.0. The reproducible gap is in the surrounding process lifecycle: `mcp run` reports interrupted calls, while `mcp single-op-call` had no termination handlers. An external caller timeout could therefore end a one-shot call without a structured result.

The original long-running project-session condition could not be reproduced with the available credentials. This PR fixes the missing termination diagnostic; it does not claim that nested SVG parsing caused the stall.

## Technical choices

- Install termination handling before input parsing and project-session startup so every active phase is covered.
- Re-check termination after every asynchronous preflight phase so refreshes and mutations cannot start during cleanup.
- Stop reporting the call as active once success or failure output is ready, preventing duplicate JSON during cleanup.
- Preserve the original terminating signal after bounded cleanup instead of converting it to an ordinary exit.
- Do not add an arbitrary operation timeout: a timed-out committed mutation can still finish remotely and would make retry safety ambiguous.

## Todo

- [x] Reproduce the reported fragment on CLI 0.290.0, current main, and Node 26.0.0
- [x] Add structured termination reporting to `mcp single-op-call`
- [x] Cover the nested SVG style input and termination payload
- [x] Exercise the installed one-shot `beforeExit` lifecycle, not only the payload formatter
- [x] Stop execution after asynchronous checkpoint preflight resumes from termination
- [x] Review documentation impact — existing CLI docs already promise structured JSON for failed one-shot calls; no content update is required

## Verification

- Nested-SVG reporter regression demonstrated fail-before (`reportMcpSingleOpCallTermination is not a function`) and pass-after
- Installed-lifecycle regression demonstrated fail-before when the active-call hook was disabled and pass-after when restored
- `pnpm --filter webstudio exec vitest run src/commands/mcp.test.ts` — 43 passed
- `pnpm --filter webstudio typecheck`
- `pnpm exec oxlint --deny-warnings packages/cli/src/commands/mcp.ts packages/cli/src/commands/mcp.test.ts`
- `pnpm --filter webstudio exec vitest run src/bin.test.ts` — 3 passed
- `pnpm --filter webstudio test` — 998 passed; two unrelated concurrent-suite timeouts (`src/bin.test.ts` and `evaluations/high-impact/fixture-api.test.ts`). The launcher test passed in isolation. The evaluation fixture was not rerun because evaluations require separate approval.

## Known limitations

- SIGKILL cannot be intercepted, so no process can emit a final diagnostic in that case.
- This change does not impose an internal operation deadline or cancel in-flight mutations.
- A real authenticated reproduction is still needed to identify why the original project-session call remained active.

Ref #6132