### PR TITLE
fix: Restore scoped descendant selectors

### DIFF
--- a/docs/university/foundations/css-variables.md
+++ b/docs/university/foundations/css-variables.md
@@ -156,7 +156,7 @@ Here are some use cases for local variables:
 
 With CSS variables, you can interact with the parent and modify the styles of any of the children.
 
-This is an alternative to a [descendant custom state](states-and-selectors.md#custom-states) such as `:hover .button`. CSS variables are useful when one parent state coordinates several properties or children: define a variable on the parent, use it for the relevant property on each child, and change the variable's value in the parent's `:hover` state.
+Prefer CSS variables over a [descendant custom state](states-and-selectors.md#custom-states) such as `:hover .button` for parent-child interactions. They keep each property on the child that uses it and are especially useful when one parent state coordinates several properties or children. Define a variable on the parent, use it for the relevant property on each child, and change the variable's value in the parent's `:hover` state.
 
 <figure><img src="../../.gitbook/assets/parent-child-demo.gif" alt=""><figcaption><p>Hovering the link and the children change (icon color, icon bg, and arrow appears)</p></figcaption></figure>
 

--- a/docs/university/foundations/css-variables.md
+++ b/docs/university/foundations/css-variables.md
@@ -156,7 +156,7 @@ Here are some use cases for local variables:
 
 With CSS variables, you can interact with the parent and modify the styles of any of the children.
 
-This creates the same visual result as a descendant selector such as `.card:hover .button` without authoring that selector. Define a variable on the parent, use it for the relevant property on the child, and change the variable's value in the parent's `:hover` state.
+This is an alternative to a [descendant custom state](states-and-selectors.md#custom-states) such as `:hover .button`. CSS variables are useful when one parent state coordinates several properties or children: define a variable on the parent, use it for the relevant property on each child, and change the variable's value in the parent's `:hover` state.
 
 <figure><img src="../../.gitbook/assets/parent-child-demo.gif" alt=""><figcaption><p>Hovering the link and the children change (icon color, icon bg, and arrow appears)</p></figcaption></figure>
 

--- a/docs/university/foundations/css-variables.md
+++ b/docs/university/foundations/css-variables.md
@@ -156,6 +156,8 @@ Here are some use cases for local variables:
 
 With CSS variables, you can interact with the parent and modify the styles of any of the children.
 
+This creates the same visual result as a descendant selector such as `.card:hover .button` without authoring that selector. Define a variable on the parent, use it for the relevant property on the child, and change the variable's value in the parent's `:hover` state.
+
 <figure><img src="../../.gitbook/assets/parent-child-demo.gif" alt=""><figcaption><p>Hovering the link and the children change (icon color, icon bg, and arrow appears)</p></figcaption></figure>
 
 {% embed url="https://youtu.be/rg49mmDvdlE" %}

--- a/docs/university/foundations/states-and-selectors.md
+++ b/docs/university/foundations/states-and-selectors.md
@@ -38,6 +38,8 @@ You can type any valid CSS pseudo-class into the Style Sources dropdown. If it's
 {% hint style="info" %}
 Custom states can target descendants while staying scoped to the selected instance. For example, `:hover .button` targets descendants with the [custom class](custom-classes-and-attributes.md) `button` while the selected instance is hovered, and `:hover > .icon` targets only direct children with the custom class `icon`.
 
+Prefer [CSS variables for parent-child interactions](css-variables.md#parent-child-interactions). They keep each property on the child that uses it, can coordinate several children from one parent state, and do not couple the interaction to descendant classes or structure. Use a descendant custom state when the interaction specifically requires selector-based targeting.
+
 Start the selector with a pseudo-class, pseudo-element, or attribute selector for the selected instance. You can then use a descendant (` `) or child (`>`) combinator. Selector lists, selectors that start with a type, class, or ID, and sibling combinators (`+` and `~`) are rejected because they can target elements outside the selected instance.
 {% endhint %}
 

--- a/docs/university/foundations/states-and-selectors.md
+++ b/docs/university/foundations/states-and-selectors.md
@@ -36,7 +36,7 @@ States are CSS pseudo-classes that apply styles when a condition is true, such a
 You can type any valid CSS pseudo-class into the Style Sources dropdown. If it's not in the predefined list, Webstudio will accept it as a custom selector.
 
 {% hint style="info" %}
-Custom selectors are useful for advanced cases, but stick to the predefined states when possible — they are validated and shown in autocomplete.
+Custom states must stay scoped to the selected instance. Descendant and child combinators such as `:hover .child` and `:hover > .child` are not accepted in this field. To change child styles when a parent is hovered, use [CSS variables for parent-child interactions](css-variables.md#parent-child-interactions).
 {% endhint %}
 
 ## Pseudo-elements

--- a/docs/university/foundations/states-and-selectors.md
+++ b/docs/university/foundations/states-and-selectors.md
@@ -36,7 +36,9 @@ States are CSS pseudo-classes that apply styles when a condition is true, such a
 You can type any valid CSS pseudo-class into the Style Sources dropdown. If it's not in the predefined list, Webstudio will accept it as a custom selector.
 
 {% hint style="info" %}
-Custom states must stay scoped to the selected instance. Descendant and child combinators such as `:hover .child` and `:hover > .child` are not accepted in this field. To change child styles when a parent is hovered, use [CSS variables for parent-child interactions](css-variables.md#parent-child-interactions).
+Custom states can target descendants while staying scoped to the selected instance. For example, `:hover .button` targets descendants with the [custom class](custom-classes-and-attributes.md) `button` while the selected instance is hovered, and `:hover > .icon` targets only direct children with the custom class `icon`.
+
+Start the selector with a pseudo-class, pseudo-element, or attribute selector for the selected instance. You can then use a descendant (` `) or child (`>`) combinator. Selector lists, selectors that start with a type, class, or ID, and sibling combinators (`+` and `~`) are rejected because they can target elements outside the selected instance.
 {% endhint %}
 
 ## Pseudo-elements
@@ -87,7 +89,7 @@ Pseudo-elements target virtual parts of an element, such as inserting content be
 
 States work together with [Tokens](design-tokens.md). When you have a Token selected, adding a state applies styles for that state _within that Token_. This keeps hover styles, focus styles, and base styles neatly organized.
 
-You can also use [CSS variables](css-variables.md) to create parent-child interactions — define variables on the parent, then change their values on the `:hover` state so all children update at once. See [Parent-child interactions](css-variables.md#parent-child-interactions) for details.
+You can also use [CSS variables](css-variables.md) to coordinate several parent-child style changes — define variables on the parent, then change their values on the `:hover` state so all children update at once. See [Parent-child interactions](css-variables.md#parent-child-interactions) for details.
 
 ## Related
 

--- a/packages/css-data/src/selector-validation.test.ts
+++ b/packages/css-data/src/selector-validation.test.ts
@@ -4,11 +4,11 @@ import { validateSelector } from "./selector-validation";
 describe("validateSelector", () => {
   test.each([
     ":hover, body",
-    ":hover > div",
-    ":hover .child",
     "body:hover",
     ".class",
     "#identifier",
+    ":hover + .tooltip",
+    ":hover ~ .tooltip",
   ])(
     "rejects selector syntax that can escape element scope: %s",
     (selector) => {
@@ -21,6 +21,16 @@ describe("validateSelector", () => {
     "[data-state=open]:hover",
     ":not(.disabled, [aria-disabled=true])",
   ])("accepts compound state suffixes: %s", (selector) => {
+    expect(validateSelector(selector).success).toBe(true);
+  });
+
+  test.each([
+    ":hover .button",
+    ":focus-within input",
+    "[data-state=open] [data-part=content]",
+    ":hover > .icon",
+    ":not(.disabled) > [aria-hidden=true]",
+  ])("accepts states targeting descendants: %s", (selector) => {
     expect(validateSelector(selector).success).toBe(true);
   });
 

--- a/packages/css-data/src/selector-validation.ts
+++ b/packages/css-data/src/selector-validation.ts
@@ -10,9 +10,10 @@ export type SelectorValidationResult =
  * Validates an open CSS state suffix scoped to the current element.
  *
  * Builder states are not a closed component-state enum. Valid pseudo-classes,
- * pseudo-elements, and attribute selectors may be compounded, but selector
- * lists, type/class/id selectors, and combinators are rejected because the CSS
- * engine appends this value directly to the generated instance selector.
+ * pseudo-elements, and attribute selectors may be compounded. Descendant and
+ * child selectors may follow that state because the CSS engine anchors the
+ * complete suffix to the generated instance selector. Selector lists,
+ * unanchored selectors, and sibling combinators are rejected.
  * @param selector - The selector to validate (e.g., ":hover", "::before", "[data-state=open]")
  * @returns SelectorValidationResult with success status and type or error message
  */
@@ -41,21 +42,37 @@ export const validateSelector = (
       };
     }
     const parsedSelector = ast.children.first;
+    const selectorNodes =
+      parsedSelector?.type === "Selector"
+        ? parsedSelector.children.toArray()
+        : [];
+    const firstCombinatorIndex = selectorNodes.findIndex(
+      (node) => node.type === "Combinator"
+    );
+    const stateNodes = selectorNodes.slice(
+      0,
+      firstCombinatorIndex === -1 ? undefined : firstCombinatorIndex
+    );
     if (
       parsedSelector?.type !== "Selector" ||
-      parsedSelector.children
-        .toArray()
-        .some(
-          (node) =>
-            node.type !== "PseudoClassSelector" &&
-            node.type !== "PseudoElementSelector" &&
-            node.type !== "AttributeSelector"
-        )
+      stateNodes.length === 0 ||
+      stateNodes.some(
+        (node) =>
+          node.type !== "PseudoClassSelector" &&
+          node.type !== "PseudoElementSelector" &&
+          node.type !== "AttributeSelector"
+      ) ||
+      selectorNodes.some(
+        (node) =>
+          node.type === "Combinator" && node.name !== " " && node.name !== ">"
+      ) ||
+      (firstCombinatorIndex !== -1 &&
+        stateNodes.some((node) => node.type === "PseudoElementSelector"))
     ) {
       return {
         success: false,
         error:
-          "Selector must be a pseudo-class, pseudo-element, or attribute suffix scoped to the current element",
+          "Selector must be an element-scoped state, optionally followed by a descendant or child selector",
       };
     }
 

--- a/packages/project-build/src/runtime/audit.ts
+++ b/packages/project-build/src/runtime/audit.ts
@@ -915,7 +915,7 @@ export const auditRules = {
     "styles",
     "warning",
     "The style state selector is not a valid element-scoped suffix and may escape its component or generate invalid CSS.",
-    "Replace it with one pseudo-class, pseudo-element, attribute selector, or a compound suffix that remains scoped to the styled element."
+    "Start with a pseudo-class, pseudo-element, or attribute selector. Descendant and child selectors may follow, but selector lists and sibling combinators are not supported."
   ),
   "orphan-style-breakpoint": rule(
     "styles",

--- a/packages/project-build/src/runtime/styles.test.ts
+++ b/packages/project-build/src/runtime/styles.test.ts
@@ -1067,7 +1067,12 @@ const instance = (id: string): Instance => ({
 });
 
 describe("runtime style operations", () => {
-  test.each([":hover, body", ":hover > div", "body:hover"])(
+  test.each([
+    ":hover, body",
+    "body:hover",
+    ":hover + .tooltip",
+    ":hover ~ .tooltip",
+  ])(
     "rejects state selectors that escape the styled element when writing: %s",
     (state) => {
       expect(
@@ -1103,56 +1108,74 @@ describe("runtime style operations", () => {
     ).toMatchObject({ success: true });
   });
 
-  test("preserves an editable compound state through mutation and generated CSS", () => {
-    const state = ":hover:focus-visible";
-    const mutation = updateStyleDeclarations(
-      {
-        breakpoints: runtimeBreakpoints,
-        instances: toMap([instance("box")]),
-        styles: new Map(),
-        styleSources: sources([local("local")]),
-        styleSourceSelections: new Map([
-          ["box", { instanceId: "box", values: ["local"] }],
-        ]),
-      },
-      {
-        updates: [
-          {
-            instanceId: "box",
-            property: "borderTopColor",
-            value: { type: "keyword", value: "currentcolor" },
-            state,
-          },
-        ],
-      },
-      { createId }
-    );
-    const patch = mutation.payload
-      .find((change) => change.namespace === "styles")
-      ?.patches.at(0);
-    if (patch === undefined || patch.op === "remove") {
-      throw new Error("Expected a style declaration patch");
+  test.each([
+    [":hover .button", ".box:hover .button"],
+    [":focus-within input", ".box:focus-within input"],
+    [
+      "[data-state=open] > [data-part=content]",
+      ".box[data-state=open] > [data-part=content]",
+    ],
+  ])(
+    "preserves an editable descendant state through mutation and generated CSS: %s",
+    (state, generatedSelector) => {
+      expect(
+        styleUpdateInput.safeParse({
+          instanceId: "box",
+          property: "borderTopColor",
+          value: { type: "keyword", value: "currentcolor" },
+          state,
+        })
+      ).toMatchObject({ success: true });
+
+      const mutation = updateStyleDeclarations(
+        {
+          breakpoints: runtimeBreakpoints,
+          instances: toMap([instance("box")]),
+          styles: new Map(),
+          styleSources: sources([local("local")]),
+          styleSourceSelections: new Map([
+            ["box", { instanceId: "box", values: ["local"] }],
+          ]),
+        },
+        {
+          updates: [
+            {
+              instanceId: "box",
+              property: "borderTopColor",
+              value: { type: "keyword", value: "currentcolor" },
+              state,
+            },
+          ],
+        },
+        { createId }
+      );
+      const patch = mutation.payload
+        .find((change) => change.namespace === "styles")
+        ?.patches.at(0);
+      if (patch === undefined || patch.op === "remove") {
+        throw new Error("Expected a style declaration patch");
+      }
+      const declaration = patch.value as StyleDecl;
+
+      expect(declaration).toMatchObject({
+        property: "borderTopColor",
+        state,
+        breakpointId: "desktop",
+      });
+
+      const sheet = createRegularStyleSheet();
+      const rule = sheet.addNestingRule(".box");
+      rule.setDeclaration({
+        breakpoint: declaration.breakpointId,
+        selector: declaration.state ?? "",
+        property: declaration.property,
+        value: declaration.value,
+      });
+      expect(rule.toString({ breakpoint: "desktop" })).toContain(
+        `${generatedSelector} {\n  border-top-color: currentcolor\n}`
+      );
     }
-    const declaration = patch.value as StyleDecl;
-
-    expect(declaration).toMatchObject({
-      property: "borderTopColor",
-      state,
-      breakpointId: "desktop",
-    });
-
-    const sheet = createRegularStyleSheet();
-    const rule = sheet.addNestingRule(".box");
-    rule.setDeclaration({
-      breakpoint: declaration.breakpointId,
-      selector: declaration.state ?? "",
-      property: declaration.property,
-      value: declaration.value,
-    });
-    expect(rule.toString({ breakpoint: "desktop" })).toContain(
-      ".box:hover:focus-visible {\n  border-top-color: currentcolor\n}"
-    );
-  });
+  );
 
   test("rejects declarations for unknown breakpoints", () => {
     expect(() =>


### PR DESCRIPTION
## Summary

Restore custom state selectors that target descendants of the selected instance, including `:hover .button` and `:hover > .icon`.

The CSS engine already generated these selectors correctly. #5886 unintentionally rejected them while hardening MCP style inputs against selectors that can escape instance scope.

## Technical choices

- Parse exactly one selector with `css-tree`.
- Require the selector to begin with a pseudo-class, pseudo-element, or attribute state anchored to the selected instance.
- Allow only descendant and direct-child combinators after that anchor.
- Continue rejecting selector lists, unanchored type/class/ID selectors, sibling combinators, unknown pseudo-selectors, and pseudo-elements used as ancestors.
- Document CSS variables as the preferred parent-child interaction pattern; use descendant selectors when selector-based targeting is specifically required.

## Todo

- [x] Restore scoped descendant and direct-child selectors.
- [x] Preserve instance-scope protections.
- [x] Cover real authoring inputs and generated CSS.
- [x] Demonstrate new tests fail without the restored behavior and scope guards.
- [x] Verify the reported workflow through the local CLI/MCP and generated preview.
- [x] Review documentation impact and update the authoritative Builder docs.
- [x] Verify generated API contracts remain current.

## Verification

- `pnpm --filter @webstudio-is/css-data test` — 4,623 passed, 1 skipped
- `pnpm --filter @webstudio-is/css-data typecheck`
- `pnpm --filter @webstudio-is/project-build exec vitest run src/runtime/styles.test.ts src/runtime/audit.test.ts` — 198 passed
- `pnpm --filter @webstudio-is/project-build typecheck`
- `pnpm lint`
- `pnpm check:generated-api`
- Documentation targets and anchors verified
- Local MCP disposable-fixture workflow:
  - Discovered `insert-fragment` and `update-styles` through MCP metadata.
  - Inserted a card with a descendant `<button class="button">`.
  - Dry-run and committed `state: ":hover .button"`; `get-styles` returned the persisted state.
  - MCP preview generated `.chjrfuf:hover .button` while the card used the `chjrfuf` instance class, proving the selector remained instance-anchored.
  - Preview screenshot completed and returned HTTP 200.
- Agent evaluations were not run because the suite has no custom-selector coverage

## Known limitation

Sibling combinators remain unsupported because they can select elements outside the selected instance. Selector lists remain unsupported because later list entries can escape the generated instance prefix.

Closes #6175