### PR TITLE
fix: Make destructive dry-runs runtime independent

### DIFF
--- a/packages/project-build/package.json
+++ b/packages/project-build/package.json
@@ -65,6 +65,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@aws-crypto/sha256-js": "^5.2.0",
     "@emotion/hash": "^0.9.2",
     "@modelcontextprotocol/sdk": "^1.10.0",
     "@webstudio-is/content-engine": "workspace:*",

--- a/packages/project-build/src/confirmation-token.test.ts
+++ b/packages/project-build/src/confirmation-token.test.ts
@@ -1,8 +1,12 @@
-import { describe, expect, test, vi } from "vitest";
+import { afterEach, describe, expect, test, vi } from "vitest";
 import {
   createConfirmationToken,
   validateConfirmationToken,
 } from "./confirmation-token";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe("confirmation tokens", () => {
   test("bind a token to its signature and expiry", async () => {
@@ -29,5 +33,13 @@ describe("confirmation tokens", () => {
         b: 2,
       })
     ).toBe(true);
+  });
+
+  test("works without the Web Crypto API", async () => {
+    vi.stubGlobal("crypto", undefined);
+
+    const { token } = await createConfirmationToken("original", 1_000);
+
+    expect(await validateConfirmationToken(token, "original")).toBe(true);
   });
 });

--- a/packages/project-build/src/confirmation-token.ts
+++ b/packages/project-build/src/confirmation-token.ts
@@ -1,5 +1,7 @@
-const encodeDigest = (digest: ArrayBuffer) =>
-  btoa(String.fromCharCode(...new Uint8Array(digest)))
+import { Sha256 } from "@aws-crypto/sha256-js";
+
+const encodeDigest = (digest: Uint8Array) =>
+  btoa(String.fromCharCode(...digest))
     .replaceAll("+", "-")
     .replaceAll("/", "_")
     .replaceAll("=", "");
@@ -14,15 +16,11 @@ const stringifyCanonicalJson = (value: unknown) =>
     );
   });
 
-const getConfirmationDigest = async (payload: unknown, expiresAt: number) =>
-  encodeDigest(
-    await globalThis.crypto.subtle.digest(
-      "SHA-256",
-      new TextEncoder().encode(
-        `${expiresAt}:${stringifyCanonicalJson(payload)}`
-      )
-    )
-  );
+const getConfirmationDigest = async (payload: unknown, expiresAt: number) => {
+  const hash = new Sha256();
+  hash.update(`${expiresAt}:${stringifyCanonicalJson(payload)}`);
+  return encodeDigest(await hash.digest());
+};
 
 export const createConfirmationToken = async (
   payload: unknown,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2195,6 +2195,9 @@ importers:
 
   packages/project-build:
     dependencies:
+      '@aws-crypto/sha256-js':
+        specifier: ^5.2.0
+        version: 5.2.0
       '@emotion/hash':
         specifier: ^0.9.2
         version: 0.9.2


### PR DESCRIPTION
## Summary

- Generate destructive-operation confirmation tokens without depending on the Web Crypto global.
- Preserve SHA-256 token hashing with the workspace's portable JavaScript implementation.
- Cover token creation and validation when `globalThis.crypto` is unavailable.

## Root cause

Destructive MCP dry-runs generate a confirmation token after calculating the mutation plan. That token used `globalThis.crypto.subtle` directly, so runtimes without the Web Crypto global failed after planning and never returned the dry-run result.

## Impact

`styles.deleteDeclarations` and other destructive MCP dry-runs can now return their plan and confirmation token in runtimes where Web Crypto is unavailable.

## Checklist

- [x] Replace the Web Crypto dependency in confirmation-token generation.
- [x] Add a regression test for a missing Web Crypto global and demonstrate fail/pass behavior.
- [x] Run project-build tests, typecheck, lint, and formatting checks.
- [x] Build, test, and typecheck the CLI.
- [x] Review documentation impact; no schema, command, or documented workflow changed.
- [x] Review fixture impact; no fixture inputs or generated fixture outputs are affected.

## Verification

- `pnpm --filter @webstudio-is/project-build test` — 2,115 tests passed.
- `pnpm --filter @webstudio-is/project-build typecheck`
- `pnpm --filter webstudio build`
- `pnpm --filter webstudio typecheck`
- `pnpm --filter webstudio test` — 1,000 tests passed initially; three prebuild tests raced with the concurrent build and were rerun sequentially.
- `pnpm --filter webstudio exec vitest run src/prebuild.test.ts` — 59 tests passed.
- Targeted oxlint and oxfmt checks passed.
- Agent evaluations were not run because they require separate explicit approval.

Closes #6202