### PR TITLE
fix: Reconnect responsive screenshots after preview restart

### DIFF
--- a/packages/cli/src/commands/mcp-preview.test.ts
+++ b/packages/cli/src/commands/mcp-preview.test.ts
@@ -1,5 +1,8 @@
 import { expect, test, vi } from "vitest";
-import { BrowserStartupError } from "@webstudio-is/vision/browser";
+import {
+  BrowserSessionClosedError,
+  BrowserStartupError,
+} from "@webstudio-is/vision/browser";
 import {
   createScreenshotCaptureSession,
   defaultScreenshotDependencies,
@@ -651,6 +654,93 @@ test("reuses and closes one browser capture session for session screenshots", as
 
   expect(close).toHaveBeenCalledOnce();
   expect(preview.stop).toHaveBeenCalledOnce();
+});
+
+test("reconnects a screenshot session after preview restart", async () => {
+  let running = false;
+  const preview = {
+    status: vi.fn(() =>
+      running
+        ? {
+            url: "http://127.0.0.1:3000/",
+            running: true as const,
+            mode: "iterative" as const,
+          }
+        : { running: false as const }
+    ),
+    startAndWait: vi.fn(async () => {
+      running = true;
+      return {
+        url: "http://127.0.0.1:3000/",
+        running: true as const,
+        mode: "iterative" as const,
+      };
+    }),
+    resolveUrl: vi.fn((path: string) => `http://127.0.0.1:3000${path}`),
+  };
+  const connectionClosed = new BrowserSessionClosedError(
+    "Browser DevTools connection closed."
+  );
+  const firstClose = vi.fn(async () => undefined);
+  const firstCapturePage = vi.fn(async () => {
+    throw connectionClosed;
+  });
+  const captureScreenshot = createCaptureScreenshotMock([]);
+  const secondCapturePage = vi.fn(
+    async (optionsList) => await Promise.all(optionsList.map(captureScreenshot))
+  );
+  const createCaptureSession = vi
+    .fn()
+    .mockReturnValueOnce({
+      capture: vi.fn(),
+      capturePage: firstCapturePage,
+      close: firstClose,
+    })
+    .mockReturnValueOnce({
+      capture: vi.fn(),
+      capturePage: secondCapturePage,
+      close: vi.fn(async () => undefined),
+    });
+  const progress: string[] = [];
+  const handlers = createMcpPreviewHandlers({
+    preview,
+    isStale: () => false,
+    preparePreview: vi.fn(async () => ({ cwd: "/tmp/preview" })),
+    createCaptureSession,
+  });
+
+  await handlers.startPreview({ source: "session", mode: "iterative" });
+  await expect(
+    handlers.capturePageScreenshots(
+      [
+        {
+          path: "/",
+          source: "session",
+          viewport: { width: 1440, height: 900 },
+          fullPage: true,
+        },
+      ],
+      { report: (message) => progress.push(message) }
+    )
+  ).resolves.toEqual([
+    expect.objectContaining({
+      viewport: { width: 1440, height: 900 },
+    }),
+  ]);
+
+  expect(preview.startAndWait).toHaveBeenCalledOnce();
+  expect(createCaptureSession).toHaveBeenCalledTimes(2);
+  expect(firstCapturePage).toHaveBeenCalledOnce();
+  expect(firstClose).toHaveBeenCalledOnce();
+  expect(secondCapturePage).toHaveBeenCalledWith([
+    expect.objectContaining({
+      url: "http://127.0.0.1:3000/",
+      width: 1440,
+      height: 900,
+      fullPage: true,
+    }),
+  ]);
+  expect(progress).toContain("tool screenshot reconnecting browser session");
 });
 
 test("times out a stalled screenshot after preview start and releases its session", async () => {

--- a/packages/cli/src/commands/mcp-preview.ts
+++ b/packages/cli/src/commands/mcp-preview.ts
@@ -11,7 +11,10 @@ import {
 } from "../screenshot";
 import { inspectGeneratedBuildMetrics } from "../generated-build-metrics";
 import { createExclusiveAsyncRunner, withTimeout } from "../async-utils";
-import { defaultScreenshotTimeout } from "@webstudio-is/vision/browser";
+import {
+  defaultScreenshotTimeout,
+  isBrowserSessionClosedError,
+} from "@webstudio-is/vision/browser";
 import {
   preparePreviewProject,
   previewDefaultTemplate,
@@ -355,6 +358,24 @@ export const createMcpPreviewHandlers = ({
     captureSessionConfig = nextConfig;
     return captureSession;
   };
+  const captureWithSessionReconnect = async <Result>(
+    input: McpScreenshotInput,
+    progress: McpToolProgress | undefined,
+    capture: (
+      session: Awaited<ReturnType<typeof getCaptureSession>>
+    ) => Promise<Result>
+  ) => {
+    try {
+      return await capture(await getCaptureSession(input));
+    } catch (error) {
+      if (isBrowserSessionClosedError(error) === false) {
+        throw error;
+      }
+      progress?.report("tool screenshot reconnecting browser session");
+      await closeCaptureSession().catch(() => undefined);
+      return await capture(await getCaptureSession(input));
+    }
+  };
   const isPreviewTargetCompatible = (
     input: McpPreviewInput,
     mode: PreviewMode,
@@ -579,21 +600,29 @@ export const createMcpPreviewHandlers = ({
         const result = await captureWithTimeout(
           async () => {
             if (managedCapture && createCaptureSession !== undefined) {
-              const captureSession = await getCaptureSession(input);
-              let captureResult = await captureSession.capture(captureOptions);
-              for (
-                let retry = 0;
-                retry < 2 &&
-                captureResult.navigation?.generatedSiteRootPresent === false;
-                retry += 1
-              ) {
-                progress?.report(
-                  "tool screenshot waiting for refreshed generated route"
-                );
-                await sleep(1000);
-                captureResult = await captureSession.capture(captureOptions);
-              }
-              return captureResult;
+              return await captureWithSessionReconnect(
+                input,
+                progress,
+                async (captureSession) => {
+                  let captureResult =
+                    await captureSession.capture(captureOptions);
+                  for (
+                    let retry = 0;
+                    retry < 2 &&
+                    captureResult.navigation?.generatedSiteRootPresent ===
+                      false;
+                    retry += 1
+                  ) {
+                    progress?.report(
+                      "tool screenshot waiting for refreshed generated route"
+                    );
+                    await sleep(1000);
+                    captureResult =
+                      await captureSession.capture(captureOptions);
+                  }
+                  return captureResult;
+                }
+              );
             }
             return await captureScreenshot({
               ...captureOptions,
@@ -656,15 +685,21 @@ export const createMcpPreviewHandlers = ({
         );
         const results = await captureWithTimeout(
           async () => {
-            const captureSession = await getCaptureSession(firstInput);
-            return await captureSession.capturePage(
-              inputs.map((input, index) => {
-                const url = urls[index];
-                if (url === undefined) {
-                  throw new Error("Screenshot URL resolution was incomplete.");
-                }
-                return getCaptureOptions(input, url);
-              })
+            return await captureWithSessionReconnect(
+              firstInput,
+              progress,
+              async (captureSession) =>
+                await captureSession.capturePage(
+                  inputs.map((input, index) => {
+                    const url = urls[index];
+                    if (url === undefined) {
+                      throw new Error(
+                        "Screenshot URL resolution was incomplete."
+                      );
+                    }
+                    return getCaptureOptions(input, url);
+                  })
+                )
             );
           },
           timeout,

--- a/packages/vision/src/screenshot-browser-cdp.ts
+++ b/packages/vision/src/screenshot-browser-cdp.ts
@@ -163,7 +163,16 @@ type CdpMessage = {
   error?: { message?: string };
 };
 
-class BrowserSessionClosedError extends Error {}
+export class BrowserSessionClosedError extends Error {
+  readonly code = "BROWSER_SESSION_CLOSED";
+}
+
+export const isBrowserSessionClosedError = (
+  error: unknown
+): error is BrowserSessionClosedError =>
+  error instanceof Error &&
+  "code" in error &&
+  error.code === "BROWSER_SESSION_CLOSED";
 
 class CdpSession {
   #nextId = 1;


### PR DESCRIPTION
## Summary

Reconnect the reusable browser capture session and retry once when a managed screenshot reports that its Browser DevTools connection closed.

The active generated-site preview remains running, so the retry recreates only the failed browser session and replays the requested single or multi-viewport capture.

## Root cause

Vision already performs a bounded recovery inside its browser runtime. If that recovery still surfaced a DevTools session closure, the MCP preview handler reset the failed session during error cleanup but returned the failure to the caller. The next manual screenshot call could succeed, but the first screenshot after a preview restart still failed.

## Technical choices

- Give browser-session closure errors a stable typed code at the Vision boundary.
- Detect that typed failure in the MCP preview handler.
- Close and recreate only the reusable browser capture session.
- Retry the complete capture once against the existing active preview.
- Apply the same recovery to one-viewport and responsive batch captures.
- Report the reconnect as a screenshot lifecycle progress checkpoint.

## Impact

A one-viewport responsive screenshot after preview restart now recovers automatically from a closed DevTools connection. Other screenshot errors retain their existing behavior, and repeated connection failure remains bounded.

## Checklist

- [x] Add a fail-first regression for preview restart followed by a one-viewport responsive capture
- [x] Recreate the failed browser session without restarting the active preview
- [x] Retry the complete screenshot request once
- [x] Preserve existing behavior for non-session errors
- [x] Verify the recovery through a real preview server, Chrome, CDP, rendering, and PNG output
- [x] Review fixture impact: no fixture inputs or generated fixture outputs are affected
- [x] Review documentation impact: no update is required because this restores documented automatic screenshot behavior
- [ ] Run agent evaluations (requires separate explicit approval)

## Verification

- Regression failed before the implementation with `Browser DevTools connection closed.` and passed after it
- Real-browser harness with Google Chrome:
  - restarted a real local HTTP preview and captured a full-page `1440×900` PNG successfully on the first call
  - forcibly closed the real CDP socket during `Page.captureScreenshot` twice and confirmed the lower browser retry surfaced the typed session-closed failure
  - confirmed the MCP handler created a new browser session, replayed the full capture successfully, and emitted `tool screenshot reconnecting browser session`
  - confirmed browser recovery did not restart the active preview
  - closed all Chrome processes, preview resources, temporary profiles, and screenshot artifacts
- `pnpm --filter webstudio exec vitest run src/commands/mcp-preview.test.ts` — 44 tests passed
- `pnpm --filter @webstudio-is/vision test` — 13 files, 81 tests passed
- `pnpm --filter webstudio typecheck`
- `pnpm --filter @webstudio-is/vision typecheck`
- `pnpm exec oxlint --deny-warnings packages/vision/src/screenshot-browser-cdp.ts packages/cli/src/commands/mcp-preview.ts packages/cli/src/commands/mcp-preview.test.ts`
- `pnpm exec oxfmt packages/vision/src/screenshot-browser-cdp.ts packages/cli/src/commands/mcp-preview.ts packages/cli/src/commands/mcp-preview.test.ts`
- `git diff --check`

The DevTools failures were injected deterministically at the screenshot command. The ordinary post-restart capture used the same real preview and Chrome path without fault injection.

Agent evaluations were not run because repository policy requires separate explicit approval.

Closes #6200