### PR TITLE
fix: Capture preview failure diagnostics

### DIFF
--- a/apps/builder/app/services/github-issue-report.server.test.ts
+++ b/apps/builder/app/services/github-issue-report.server.test.ts
@@ -26,6 +26,18 @@ const report: IssueReportInput = {
     architecture: "arm64",
     executionMode: "mcp",
     apiContractVersion: "public-api:client",
+    bundleVersion: "bundle:client",
+    recentFailure: {
+      tool: "preview.start",
+      code: "PROJECT_BUNDLE_INVALID",
+      issues: [
+        {
+          path: ["assets", "0", "type"],
+          code: "invalid_value",
+          constraint: 'one of "font"|"image"|"video"|"file"',
+        },
+      ],
+    },
   },
   report: {
     userStory:
@@ -55,6 +67,13 @@ describe("GitHub issue reports", () => {
     expect(body).toContain("- Operating system: linux 6 (arm64)");
     expect(body).toContain("- Execution mode: mcp");
     expect(body).toContain("- API contract: public-api:client");
+    expect(body).toContain("- Bundle contract: bundle:client");
+    expect(body).toContain("## Captured failure diagnostics");
+    expect(body).toContain("- Tool: `preview.start`");
+    expect(body).toContain("- Error code: `PROJECT_BUNDLE_INVALID`");
+    expect(body).toContain(
+      '- `assets.0.type`: `invalid_value` (one of "font"|"image"|"video"|"file")'
+    );
     expect(body).toContain("- Model: gpt-5.6-sol");
     expect(body).toContain("- Reasoning effort: medium");
     expect(body).toContain(

--- a/apps/builder/app/services/github-issue-report.server.ts
+++ b/apps/builder/app/services/github-issue-report.server.ts
@@ -35,8 +35,33 @@ const formatRuntime = (runtime: IssueReportInput["runtime"]) =>
           `- Operating system: ${runtime.os} ${runtime.osVersion} (${runtime.architecture})`,
           `- Execution mode: ${runtime.executionMode}`,
           `- API contract: ${runtime.apiContractVersion}`,
+          `- Bundle contract: ${runtime.bundleVersion ?? "unknown"}`,
         ]),
   ].join("\n");
+
+const formatFailureDiagnostics = (runtime: IssueReportInput["runtime"]) => {
+  const failure = runtime?.recentFailure;
+  if (failure === undefined) {
+    return "";
+  }
+  const issues = failure.issues ?? [];
+  return [
+    "## Captured failure diagnostics",
+    "",
+    `- Tool: \`${failure.tool}\``,
+    `- Error code: \`${failure.code}\``,
+    ...(issues.length === 0
+      ? []
+      : [
+          "- Invalid fields:",
+          ...issues.map(
+            (issue) =>
+              `  - \`${issue.path.join(".") || "input"}\`: \`${issue.code}\` (${issue.constraint})`
+          ),
+        ]),
+    "",
+  ].join("\n");
+};
 
 export const formatIssueReport = ({
   agent,
@@ -89,6 +114,8 @@ ${report.technicalContext}
 - Category: ${category}
 
 ${formatRuntime(runtime)}
+
+${formatFailureDiagnostics(runtime)}
 
 ## Acceptance criteria
 

--- a/packages/cli/src/commands/mcp.test.ts
+++ b/packages/cli/src/commands/mcp.test.ts
@@ -157,17 +157,26 @@ test("keeps every MCP API tool aligned with its public API contract", () => {
         ? ["confirmDestructive", "confirmationToken"]
         : []),
     ];
+    const cliOwnedFields =
+      operation.command === "report-issue" ? ["runtime"] : [];
     const schemaMetadata = getInputJsonSchemaMetadata(schema);
     const semanticFields = schemaMetadata.inputFields.filter(
       (field) => transportFields.includes(field) === false
     );
     expect(new Set(semanticFields), operation.command).toEqual(
-      new Set(operation.inputFields)
+      new Set(
+        operation.inputFields.filter(
+          (field) => cliOwnedFields.includes(field) === false
+        )
+      )
     );
 
     const apiProperties = getInputJsonSchemaProperties(operation.inputSchema);
     const mcpProperties = getInputJsonSchemaProperties(schema);
     for (const field of operation.inputFields) {
+      if (cliOwnedFields.includes(field)) {
+        continue;
+      }
       const isRepresentationOverride =
         (operation.command === "insert-fragment" &&
           ["parentInstanceId", "fragment"].includes(field)) ||
@@ -181,7 +190,9 @@ test("keeps every MCP API tool aligned with its public API contract", () => {
       ).toEqual(apiProperties?.[field]);
     }
 
-    const requiredFields = [...operation.requiredInputFields];
+    const requiredFields = operation.requiredInputFields.filter(
+      (field) => cliOwnedFields.includes(field) === false
+    );
     if (
       operation.command === "insert-fragment" &&
       requiredFields.includes("parentInstanceId") === false

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -1234,8 +1234,8 @@ const createCliMcpHost = async ({
     host,
     apiContract,
     toolCount: operations.length,
-    recordToolFailure(tool: string, error: unknown) {
-      recentFailure = createIssueReportFailure(tool, error);
+    recordToolFailure(canonicalTool: string, error: unknown) {
+      recentFailure = createIssueReportFailure(canonicalTool, error);
     },
     reportLog(message: string) {
       if (message.startsWith("ready with ")) {

--- a/packages/cli/src/commands/mcp.ts
+++ b/packages/cli/src/commands/mcp.ts
@@ -15,6 +15,7 @@ import { diffPngFiles } from "@webstudio-is/vision/diff";
 import {
   publicApiOperationRequiresServerSupport,
   publicApiOperations,
+  type IssueReportRecentFailure,
 } from "@webstudio-is/protocol";
 import * as httpClient from "@webstudio-is/http-client";
 import packageJson from "../../package.json" with { type: "json" };
@@ -33,6 +34,8 @@ import {
   assertCliServerOperationSupported,
   createCliProjectRestorePointStorage,
   createCliProjectSession,
+  createIssueReportFailure,
+  createIssueReportRuntime,
   getCliProjectRestorePointsFile,
   getCliServerApiContract,
   getSupportedPublicApiOperations,
@@ -985,10 +988,12 @@ const createCliMcpHost = async ({
   };
   const apiContract = await getCliServerApiContract(apiConnection);
   const operations = getSupportedPublicApiOperations(apiContract);
+  let recentFailure: IssueReportRecentFailure | undefined;
   const session = createCliProjectSession({
     connection: apiConnection,
     projectRoot,
     sessionProjectId: projectId,
+    issueReportRuntime: () => createIssueReportRuntime(recentFailure),
   });
   const restorePointStorage = createCliProjectRestorePointStorage(
     getCliProjectRestorePointsFile(projectRoot, projectId)
@@ -1229,6 +1234,9 @@ const createCliMcpHost = async ({
     host,
     apiContract,
     toolCount: operations.length,
+    recordToolFailure(tool: string, error: unknown) {
+      recentFailure = createIssueReportFailure(tool, error);
+    },
     reportLog(message: string) {
       if (message.startsWith("ready with ")) {
         return;
@@ -1806,10 +1814,16 @@ export const mcp = async (
   stdin.once("end", reportClose);
   stdin.once("close", reportClose);
   status.starting();
-  const { host, toolCount, reportLog, apiContract, dispose } =
-    await createCliMcpHost({
-      projectId: options.project,
-    });
+  const {
+    host,
+    toolCount,
+    reportLog,
+    recordToolFailure,
+    apiContract,
+    dispose,
+  } = await createCliMcpHost({
+    projectId: options.project,
+  });
   disposeHost = dispose;
   if (didReportClose) {
     await disposeHost().catch(() => undefined);
@@ -1822,6 +1836,7 @@ export const mcp = async (
     ...host,
     toolNameFormat: options.toolNameFormat,
     getErrorCode: getStableErrorCode,
+    onToolFailure: recordToolFailure,
     reportLog: (_level, message) => {
       reportLog(message);
     },

--- a/packages/cli/src/error-codes.test.ts
+++ b/packages/cli/src/error-codes.test.ts
@@ -20,6 +20,12 @@ describe("getStableErrorCode", () => {
       )
     ).toBe("NOT_FOUND");
   });
+
+  test("rejects dynamic values as stable error codes", () => {
+    expect(getStableErrorCode({ code: "customer-specific-code" })).toBe(
+      undefined
+    );
+  });
 });
 
 describe("getCliErrorMessage", () => {

--- a/packages/cli/src/error-codes.ts
+++ b/packages/cli/src/error-codes.ts
@@ -9,6 +9,7 @@ import {
 
 const missingProjectOwnerForTokenPattern =
   /^Project owner can't be found for token\b/;
+const stableErrorCodePattern = /^[A-Z][A-Z0-9_]{0,159}$/;
 
 const getErrorMessage = (error: unknown) =>
   typeof error === "object" &&
@@ -21,16 +22,14 @@ const getErrorMessage = (error: unknown) =>
       : String(error);
 
 export const getStableErrorCode = (error: unknown) => {
-  const apiErrorCode = getApiErrorCode(error);
-  if (apiErrorCode !== undefined) {
-    return apiErrorCode;
-  }
-  if (typeof error === "object" && error !== null && "code" in error) {
-    const code = (error as { code?: unknown }).code;
-    if (typeof code === "string") {
-      return code;
-    }
-  }
+  const directErrorCode =
+    typeof error === "object" && error !== null && "code" in error
+      ? (error as { code?: unknown }).code
+      : undefined;
+  const code = getApiErrorCode(error) ?? directErrorCode;
+  return typeof code === "string" && stableErrorCodePattern.test(code)
+    ? code
+    : undefined;
 };
 
 export const isMissingApiAccessError = (error: unknown) => {

--- a/packages/cli/src/prebuild.test.ts
+++ b/packages/cli/src/prebuild.test.ts
@@ -3000,4 +3000,28 @@ sitemap.map((page) => page.path);`
       "Project bundle is invalid, please make sure the project is synced. Invalid fields: page: Required"
     );
   });
+
+  test("exposes anonymous structured diagnostics for invalid asset fields", async () => {
+    const data = structuredClone(createSiteData()) as unknown as {
+      assets: Array<Record<string, unknown>>;
+    };
+    data.assets[0] = { ...data.assets[0], type: "future-video" };
+    await writeFile(".webstudio/data.json", JSON.stringify(data));
+
+    try {
+      await prebuild({ assets: false, template: ["defaults"] });
+      throw new Error("Expected invalid bundle to fail.");
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: "PROJECT_BUNDLE_INVALID",
+        bundleVersion,
+        issues: expect.arrayContaining([
+          expect.objectContaining({
+            path: ["assets", "0", "type"],
+            code: "invalid_value",
+          }),
+        ]),
+      });
+    }
+  });
 });

--- a/packages/cli/src/prebuild.ts
+++ b/packages/cli/src/prebuild.ts
@@ -57,7 +57,10 @@ import {
   type ComponentBuildContribution,
 } from "@webstudio-is/sdk";
 import { migratePages } from "@webstudio-is/project-migrations/pages";
-import { collectFontFamiliesFromStyleDecls } from "@webstudio-is/project-build/runtime";
+import {
+  collectFontFamiliesFromStyleDecls,
+  getZodValidationIssues,
+} from "@webstudio-is/project-build/runtime";
 import {
   assetQueryFilter,
   type AssetRuntimeData,
@@ -83,6 +86,7 @@ import {
   getQueryConditions,
 } from "@webstudio-is/query-builder/runtime";
 import {
+  bundleVersion,
   publishedProjectBundle,
   type PublishedProjectBundle,
 } from "@webstudio-is/protocol";
@@ -911,11 +915,18 @@ export const prebuild = async (options: {
   }
   const parsedSiteData = publishedProjectBundle.safeParse(loadedSiteData);
   if (parsedSiteData.success === false) {
-    throw new Error(
-      `Project bundle is invalid, please make sure the project is synced. Invalid fields: ${formatZodIssues(
-        parsedSiteData.error.issues,
-        loadedSiteData
-      )}`
+    throw Object.assign(
+      new Error(
+        `Project bundle is invalid, please make sure the project is synced. Invalid fields: ${formatZodIssues(
+          parsedSiteData.error.issues,
+          loadedSiteData
+        )}`
+      ),
+      {
+        code: "PROJECT_BUNDLE_INVALID",
+        bundleVersion,
+        issues: getZodValidationIssues(parsedSiteData.error),
+      }
     );
   }
   const siteData = parsedSiteData.data;

--- a/packages/cli/src/project-session.test.ts
+++ b/packages/cli/src/project-session.test.ts
@@ -11,6 +11,7 @@ import {
   createCliProjectRestorePointStorage,
   createCliProjectSessionStorage,
   createCliProjectSessionTransport,
+  createIssueReportFailure,
   addIssueReportRuntime,
   getCliServerApiContract,
   getCliProjectSessionFile,
@@ -30,6 +31,18 @@ test("adds anonymous local runtime metadata only to issue reports", () => {
     architecture: "arm64",
     executionMode: "mcp" as const,
     apiContractVersion: "public-api:client",
+    bundleVersion: "bundle:client",
+    recentFailure: {
+      tool: "preview.start",
+      code: "PROJECT_BUNDLE_INVALID",
+      issues: [
+        {
+          path: ["assets", "0", "type"],
+          code: "invalid_value",
+          constraint: "one of supported asset types",
+        },
+      ],
+    },
   };
 
   expect(addIssueReportRuntime("report-issue", report, runtime)).toEqual({
@@ -37,6 +50,43 @@ test("adds anonymous local runtime metadata only to issue reports", () => {
     runtime,
   });
   expect(addIssueReportRuntime("audit", report, runtime)).toBe(report);
+});
+
+test("keeps only anonymous structured fields from the latest tool failure", () => {
+  const error = Object.assign(new Error("Asset customer-logo.png is invalid"), {
+    code: "PROJECT_BUNDLE_INVALID",
+    issues: [
+      {
+        path: ["assets", "0", "type"],
+        code: "invalid_value",
+        message: "Customer-specific value is unsupported",
+        constraint: "one of supported asset types",
+        detail: "Asset customer-logo.png belongs to project-123",
+      },
+    ],
+  });
+
+  expect(createIssueReportFailure("preview.start", error)).toEqual({
+    tool: "preview.start",
+    code: "PROJECT_BUNDLE_INVALID",
+    issues: [
+      {
+        path: ["assets", "0", "type"],
+        code: "invalid_value",
+        constraint: "one of supported asset types",
+      },
+    ],
+  });
+
+  expect(
+    createIssueReportFailure("customer/project", {
+      code: "dynamic-code",
+      issues: error.issues,
+    })
+  ).toEqual({
+    tool: "unknown",
+    code: "MCP_TOOL_FAILED",
+  });
 });
 
 test("scopes project session files for explicitly selected projects", () => {
@@ -949,6 +999,7 @@ describe("cli project session transport", () => {
       architecture: process.arch,
       executionMode: "mcp",
       apiContractVersion: expect.any(String),
+      bundleVersion: expect.any(String),
     });
   });
 });

--- a/packages/cli/src/project-session.test.ts
+++ b/packages/cli/src/project-session.test.ts
@@ -79,7 +79,7 @@ test("keeps only anonymous structured fields from the latest tool failure", () =
   });
 
   expect(
-    createIssueReportFailure("customer/project", {
+    createIssueReportFailure("unknown", {
       code: "dynamic-code",
       issues: error.issues,
     })

--- a/packages/cli/src/project-session.ts
+++ b/packages/cli/src/project-session.ts
@@ -251,7 +251,7 @@ export const createIssueReportRuntime = (
 });
 
 export const createIssueReportFailure = (
-  tool: string,
+  canonicalTool: string,
   error: unknown
 ): IssueReportRecentFailure => {
   const errorCode = getStableErrorCode(error);
@@ -266,11 +266,8 @@ export const createIssueReportFailure = (
           }))
       : undefined;
   return {
-    tool: /^[a-z][a-z0-9.-]{0,159}$/.test(tool) ? tool : "unknown",
-    code:
-      errorCode !== undefined && /^[A-Z][A-Z0-9_]{0,159}$/.test(errorCode)
-        ? errorCode
-        : "MCP_TOOL_FAILED",
+    tool: canonicalTool,
+    code: errorCode ?? "MCP_TOOL_FAILED",
     ...(issues === undefined || issues.length === 0 ? {} : { issues }),
   };
 };

--- a/packages/cli/src/project-session.ts
+++ b/packages/cli/src/project-session.ts
@@ -17,6 +17,7 @@ import {
   publicApiOperationRequiresServerSupport,
   publicApiOperations,
   type IssueReportRuntime,
+  type IssueReportRecentFailure,
   type PublicApiCommand,
   type PublishedProjectBundle,
 } from "@webstudio-is/protocol";
@@ -53,6 +54,7 @@ import {
   type SerializedBuilderStateSnapshot,
 } from "@webstudio-is/project-build/state";
 import { removeLegacyProjectSettingsFromPages } from "@webstudio-is/project-build";
+import { getValidationIssues } from "@webstudio-is/project-build/runtime";
 import type { BuilderStateFreshness } from "@webstudio-is/project-build/state";
 import { getLocalProjectStateDirectory, LOCAL_DATA_FILE } from "./config";
 import type { ApiConnection } from "./api-connection";
@@ -234,7 +236,9 @@ const publicOperationById = new Map(
   publicApiOperations.map((operation) => [operation.id, operation])
 );
 
-const getIssueReportRuntime = (): IssueReportRuntime => ({
+export const createIssueReportRuntime = (
+  recentFailure?: IssueReportRecentFailure
+): IssueReportRuntime => ({
   cliVersion: packageJson.version,
   nodeVersion: process.versions.node,
   os: process.platform,
@@ -242,12 +246,39 @@ const getIssueReportRuntime = (): IssueReportRuntime => ({
   architecture: process.arch,
   executionMode: "mcp",
   apiContractVersion: publicApiContractVersion,
+  bundleVersion,
+  recentFailure,
 });
+
+export const createIssueReportFailure = (
+  tool: string,
+  error: unknown
+): IssueReportRecentFailure => {
+  const errorCode = getStableErrorCode(error);
+  const issues =
+    errorCode === "PROJECT_BUNDLE_INVALID"
+      ? getValidationIssues(error)
+          ?.slice(0, 30)
+          .map((issue) => ({
+            path: issue.path,
+            code: issue.code,
+            constraint: issue.constraint,
+          }))
+      : undefined;
+  return {
+    tool: /^[a-z][a-z0-9.-]{0,159}$/.test(tool) ? tool : "unknown",
+    code:
+      errorCode !== undefined && /^[A-Z][A-Z0-9_]{0,159}$/.test(errorCode)
+        ? errorCode
+        : "MCP_TOOL_FAILED",
+    ...(issues === undefined || issues.length === 0 ? {} : { issues }),
+  };
+};
 
 export const addIssueReportRuntime = (
   command: PublicApiCommand,
   input: unknown,
-  runtime: IssueReportRuntime = getIssueReportRuntime()
+  runtime: IssueReportRuntime = createIssueReportRuntime()
 ) => {
   if (command !== "report-issue" || isPlainRecord(input) === false) {
     return input;
@@ -259,10 +290,12 @@ const executePublicServerOperation = async ({
   connection,
   operationId,
   input,
+  issueReportRuntime,
 }: {
   connection: ApiConnection;
   operationId: string;
   input: unknown;
+  issueReportRuntime?: () => IssueReportRuntime;
 }) => {
   const operation = publicOperationById.get(operationId);
   if (operation === undefined) {
@@ -278,10 +311,11 @@ const executePublicServerOperation = async ({
   }
   return await client({
     ...connection,
-    ...(addIssueReportRuntime(operation.command, input) as Record<
-      string,
-      unknown
-    >),
+    ...(addIssueReportRuntime(
+      operation.command,
+      input,
+      issueReportRuntime?.() ?? createIssueReportRuntime()
+    ) as Record<string, unknown>),
     projectId: connection.projectId,
   });
 };
@@ -438,11 +472,13 @@ export const createCliProjectSessionTransport = ({
   executeServerOperation,
   getBuildSnapshot = httpClient.getBuildSnapshot,
   getPermissions,
+  issueReportRuntime,
 }: {
   connection: ApiConnection;
   executeServerOperation?: ProjectSessionTransport["executeServerOperation"];
   getBuildSnapshot?: typeof httpClient.getBuildSnapshot;
   getPermissions?: ProjectSessionTransport["getPermissions"];
+  issueReportRuntime?: () => IssueReportRuntime;
 }): ProjectSessionTransport => ({
   async getCompatibility() {
     return createCliProjectSessionCompatibility(connection);
@@ -515,7 +551,12 @@ export const createCliProjectSessionTransport = ({
       input: unknown;
     }) =>
       (await withMappedRemoteError(() =>
-        executePublicServerOperation({ connection, operationId, input })
+        executePublicServerOperation({
+          connection,
+          operationId,
+          input,
+          issueReportRuntime,
+        })
       )) as Result),
 });
 
@@ -526,6 +567,7 @@ export const createCliProjectSession = ({
   sessionProjectId,
   executeServerOperation,
   getPermissions,
+  issueReportRuntime,
 }: {
   connection: ApiConnection;
   storage?: ProjectSessionStorage;
@@ -533,6 +575,7 @@ export const createCliProjectSession = ({
   sessionProjectId?: string;
   executeServerOperation?: ProjectSessionTransport["executeServerOperation"];
   getPermissions?: ProjectSessionTransport["getPermissions"];
+  issueReportRuntime?: () => IssueReportRuntime;
 }) =>
   createProjectSession({
     projectId: connection.projectId,
@@ -540,6 +583,7 @@ export const createCliProjectSession = ({
       connection,
       executeServerOperation,
       getPermissions,
+      issueReportRuntime,
     }),
     storage:
       storage ??

--- a/packages/project-build/src/mcp.test.ts
+++ b/packages/project-build/src/mcp.test.ts
@@ -8622,6 +8622,7 @@ describe("project session mcp adapter", () => {
       "Project session snapshot changed on disk."
     ) as Error & { code: string };
     error.code = "PROJECT_SESSION_BUSY";
+    const onToolFailure = vi.fn();
     const server = await createProjectSessionMcpServer({
       operations: publicMcpOperations,
       createProjectSession: createSessionFactory(),
@@ -8632,6 +8633,7 @@ describe("project session mcp adapter", () => {
         typeof error === "object" && error !== null && "code" in error
           ? (error as { code?: string }).code
           : undefined,
+      onToolFailure,
     });
     const { client, close } = await createConnectedClient(server);
 
@@ -8654,6 +8656,7 @@ describe("project session mcp adapter", () => {
           },
         })
       );
+      expect(onToolFailure).toHaveBeenCalledWith("list-pages", error);
     } finally {
       await close();
     }

--- a/packages/project-build/src/mcp.test.ts
+++ b/packages/project-build/src/mcp.test.ts
@@ -1197,6 +1197,29 @@ describe("project session mcp adapter", () => {
     );
   });
 
+  test("omits CLI-owned issue runtime from the MCP input schema", () => {
+    const [tool] = listProjectSessionMcpTools([
+      publicOperation({
+        command: "report-issue",
+        id: "reports.issue",
+        description: "Report an issue",
+        localCapable: false,
+        serverOnly: true,
+        inputSchema: getTestInputSchema(
+          z.object({
+            title: z.string(),
+            runtime: z
+              .object({ recentFailure: z.unknown().optional() })
+              .optional(),
+          })
+        ),
+      }),
+    ]);
+
+    expect(tool?.inputSchema.properties).toHaveProperty("title");
+    expect(tool?.inputSchema.properties).not.toHaveProperty("runtime");
+  });
+
   test("documents the queried Assets result shape in focused tools", () => {
     const contracts = runtimeOperationContracts.filter(({ id }) =>
       ["assetsResources.create", "assetsResources.update"].includes(id)

--- a/packages/project-build/src/mcp.test.ts
+++ b/packages/project-build/src/mcp.test.ts
@@ -8680,6 +8680,12 @@ describe("project session mcp adapter", () => {
         })
       );
       expect(onToolFailure).toHaveBeenCalledWith("list-pages", error);
+
+      await client.callTool({
+        name: "customer/project",
+        arguments: {},
+      });
+      expect(onToolFailure.mock.calls.at(-1)?.[0]).toBe("unknown");
     } finally {
       await close();
     }

--- a/packages/project-build/src/mcp.ts
+++ b/packages/project-build/src/mcp.ts
@@ -8420,7 +8420,7 @@ export const createProjectSessionMcpServer = async <
   onInitialized?: (clientName: string | undefined) => void;
   toolNameFormat?: "canonical" | "underscores";
   toolHeartbeatIntervalMs?: number;
-  onToolFailure?: (tool: string, error: unknown) => void;
+  onToolFailure?: (canonicalTool: string, error: unknown) => void;
 }) => {
   const server = new Server(
     { name: "webstudio", version: "0.0.0" },
@@ -8536,6 +8536,7 @@ export const createProjectSessionMcpServer = async <
   server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
     const params = getRequestParams(request);
     const exposedName = typeof params.name === "string" ? params.name : "";
+    const canonicalName = toolNameIndex.get(exposedName)?.name;
     const name = toolNameIndex.resolve(exposedName);
     const { input, dryRun } = getToolCallInput(params.arguments ?? {});
     const startedAt = Date.now();
@@ -8559,7 +8560,7 @@ export const createProjectSessionMcpServer = async <
       sendLog("info", `tool ${name} succeeded in ${Date.now() - startedAt}ms`);
       return result;
     } catch (error) {
-      onToolFailure?.(name, error);
+      onToolFailure?.(canonicalName ?? "unknown", error);
       sendLog(
         "error",
         `tool ${name} failed in ${Date.now() - startedAt}ms: ${

--- a/packages/project-build/src/mcp.ts
+++ b/packages/project-build/src/mcp.ts
@@ -8405,12 +8405,14 @@ export const createProjectSessionMcpServer = async <
   onInitialized,
   toolNameFormat = "canonical",
   toolHeartbeatIntervalMs = 10_000,
+  onToolFailure,
 }: Omit<ProjectSessionMcpCoreOptions<Command>, "reportToolProgress"> & {
   getErrorCode?: McpErrorCodeResolver;
   reportLog?: (level: McpLogLevel, message: string) => void;
   onInitialized?: (clientName: string | undefined) => void;
   toolNameFormat?: "canonical" | "underscores";
   toolHeartbeatIntervalMs?: number;
+  onToolFailure?: (tool: string, error: unknown) => void;
 }) => {
   const server = new Server(
     { name: "webstudio", version: "0.0.0" },
@@ -8549,6 +8551,7 @@ export const createProjectSessionMcpServer = async <
       sendLog("info", `tool ${name} succeeded in ${Date.now() - startedAt}ms`);
       return result;
     } catch (error) {
+      onToolFailure?.(name, error);
       sendLog(
         "error",
         `tool ${name} failed in ${Date.now() - startedAt}ms: ${

--- a/packages/project-build/src/mcp.ts
+++ b/packages/project-build/src/mcp.ts
@@ -1400,6 +1400,14 @@ const getMcpOperationInputSchema = (
   let schema = constrainUnconstrainedInputSchemas(
     options.schema ?? getOperationInputSchema(operation)
   );
+  if (operation.command === "report-issue") {
+    const { runtime: _runtime, ...properties } = schema.properties ?? {};
+    schema = {
+      ...schema,
+      properties,
+      required: schema.required?.filter((field) => field !== "runtime"),
+    };
+  }
   const properties = getInputJsonSchemaProperties(schema);
   if (
     schema.additionalProperties === true &&

--- a/packages/protocol/src/builder-api/__generated__/server-only-router-operation-metadata.ts
+++ b/packages/protocol/src/builder-api/__generated__/server-only-router-operation-metadata.ts
@@ -188,6 +188,57 @@ export const serverOnlyRouterOperationMetadata = {
               minLength: 1,
               maxLength: 100,
             },
+            bundleVersion: {
+              type: "string",
+              minLength: 1,
+              maxLength: 100,
+            },
+            recentFailure: {
+              type: "object",
+              properties: {
+                tool: {
+                  type: "string",
+                  minLength: 1,
+                  maxLength: 160,
+                },
+                code: {
+                  type: "string",
+                  minLength: 1,
+                  maxLength: 160,
+                },
+                issues: {
+                  maxItems: 30,
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      path: {
+                        maxItems: 30,
+                        type: "array",
+                        items: {
+                          type: "string",
+                          maxLength: 200,
+                        },
+                      },
+                      code: {
+                        type: "string",
+                        minLength: 1,
+                        maxLength: 100,
+                      },
+                      constraint: {
+                        type: "string",
+                        minLength: 1,
+                        maxLength: 500,
+                      },
+                    },
+                    required: ["path", "code", "constraint"],
+                    additionalProperties: false,
+                  },
+                },
+              },
+              required: ["tool", "code"],
+              additionalProperties: false,
+            },
           },
           required: [
             "cliVersion",

--- a/packages/protocol/src/issue-report.test.ts
+++ b/packages/protocol/src/issue-report.test.ts
@@ -20,6 +20,18 @@ const report = {
     architecture: "arm64",
     executionMode: "mcp",
     apiContractVersion: "public-api:client",
+    bundleVersion: "bundle:client",
+    recentFailure: {
+      tool: "preview.start",
+      code: "PROJECT_BUNDLE_INVALID",
+      issues: [
+        {
+          path: ["assets", "0", "type"],
+          code: "invalid_value",
+          constraint: 'one of "font"|"image"|"video"|"file"',
+        },
+      ],
+    },
   },
   report: {
     userStory:

--- a/packages/protocol/src/issue-report.ts
+++ b/packages/protocol/src/issue-report.ts
@@ -38,6 +38,22 @@ const issueReportAgent = z
   })
   .strict();
 
+const issueReportFailureIssue = z
+  .object({
+    path: z.array(z.string().max(200)).max(30),
+    code: z.string().trim().min(1).max(100),
+    constraint: z.string().trim().min(1).max(500),
+  })
+  .strict();
+
+const issueReportRecentFailure = z
+  .object({
+    tool: z.string().trim().min(1).max(160),
+    code: z.string().trim().min(1).max(160),
+    issues: z.array(issueReportFailureIssue).max(30).optional(),
+  })
+  .strict();
+
 const issueReportRuntime = z
   .object({
     cliVersion: z.string().trim().min(1).max(100),
@@ -47,6 +63,8 @@ const issueReportRuntime = z
     architecture: z.string().trim().min(1).max(100),
     executionMode: z.enum(["mcp"]),
     apiContractVersion: z.string().trim().min(1).max(100),
+    bundleVersion: z.string().trim().min(1).max(100).optional(),
+    recentFailure: issueReportRecentFailure.optional(),
   })
   .strict()
   .describe(
@@ -101,3 +119,4 @@ export const issueReportResult = z
 export type IssueReportInput = z.infer<typeof issueReportInput>;
 export type IssueReportResult = z.infer<typeof issueReportResult>;
 export type IssueReportRuntime = z.infer<typeof issueReportRuntime>;
+export type IssueReportRecentFailure = z.infer<typeof issueReportRecentFailure>;


### PR DESCRIPTION
## Summary

- Give invalid project bundles a stable `PROJECT_BUNDLE_INVALID` error code and structured validation issues.
- Remember the latest failed MCP tool call and attach sanitized diagnostics to automatic issue reports.
- Render the tool, error code, bundle contract, and invalid schema paths in a dedicated issue section.

## Scope and issue assessment

This PR improves diagnostics; it does not change which asset shapes `preview.start` accepts.

Issue #6198 came from CLI 0.290.0 and did not include the rejected field, value, or bundle contract, so its exact root cause cannot be established. Node 22 is not implicated by the available evidence. Canonical video assets were added separately in #6189, which may explain an old-CLI schema mismatch, but that relationship is an inference rather than a confirmed reproduction.

Per project triage policy, this PR closes #6198 despite being diagnostics-only. If the failure still exists on a current CLI, the enriched report will provide enough evidence to reopen or file a new actionable issue.

## Implementation

Bundle validation exposes structured paths such as `assets.0.type`. The MCP host records the latest failure and injects it into CLI-owned runtime metadata when `report-issue` is called.

The MCP registry supplies either a canonical known tool name or `unknown`. Stable error codes are validated once by the CLI error-code boundary. Detailed paths are included only for `PROJECT_BUNDLE_INVALID`, capped at 30 issues, and omit received values, error messages, examples, filenames, IDs, details, and stack traces. The bundle-contract field remains optional so reports from older CLI versions still validate.

CLI-owned runtime metadata is not advertised as model-authored MCP input, keeping the handshake compact and making ownership explicit.

## Checklist

- [x] Add structured bundle validation diagnostics.
- [x] Capture the latest MCP failure in issue-report runtime metadata.
- [x] Render deterministic diagnostics in GitHub issue bodies.
- [x] Add fail/pass regression coverage and privacy constraints.
- [x] Keep CLI-owned runtime fields out of the model-facing MCP schema.
- [x] Regenerate the server-only API contract.
- [x] Review documentation impact — no product documentation changes are required; this only enriches internal anonymous issue reports.
- [ ] Run agent evaluations — not run because repository policy requires explicit approval.

## Verification

- Real Node 22.22.1 stdio MCP run with an isolated malformed local bundle returned `PROJECT_BUNDLE_INVALID`, path `assets.0.type`, code `invalid_value`, and constraint `one_of:["image"]`.
- The following real `report-issue` call was accepted by the server and deduplicated to existing issue #6198; it created no duplicate issue and changed no linked project.
- Project-build: 2,115 tests passed.
- CLI: all 1,005 unaffected tests passed; one unrelated process-supervisor timing test failed once and its exact two owner-disconnect cases passed on immediate rerun.
- Project-build and CLI typechecks passed.
- Formatter and diff checks passed.
- All latest GitHub workflows passed, including both test/typecheck matrices, visual regression, size and generated checks, packaged SSG, and all six Builder E2E shards.

Closes #6198