### PR TITLE
fix: transfer pasted assets across deployments

### DIFF
--- a/apps/builder/app/builder/shared/assets/upload-assets.test.ts
+++ b/apps/builder/app/builder/shared/assets/upload-assets.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, test, expect, vi } from "vitest";
-import { assetType } from "@webstudio-is/sdk";
-import { __testing__ } from "./upload-assets";
+import { assetType, type Asset } from "@webstudio-is/sdk";
+import type { Project } from "@webstudio-is/project";
+import { $assets, $project } from "~/shared/sync/data-stores";
+import { __testing__, importAssets } from "./upload-assets";
 
 const {
   createUploadTicket,
@@ -14,6 +16,8 @@ const request = vi.fn<typeof fetch>();
 describe("upload-assets", () => {
   beforeEach(() => {
     request.mockReset();
+    $project.set(undefined);
+    $assets.set(new Map());
   });
 
   test("requests upload tickets without client-supplied asset ids", async () => {
@@ -105,6 +109,178 @@ describe("upload-assets", () => {
     expect(init.body.get("displayFilename")).toBe("Campaign photo");
   });
 
+  test("imports every asset type through the production upload queue", async () => {
+    $project.set({ id: "target-project" } as Project);
+    $assets.set(new Map());
+    const sources: Asset[] = [
+      {
+        id: "font",
+        projectId: "source-project",
+        name: "brand.woff2",
+        type: "font",
+        format: "woff2",
+        size: 1,
+        createdAt: "2026-01-01",
+        description: "Brand font",
+        meta: { family: "Brand", style: "normal", weight: 400 },
+      },
+      {
+        id: "video",
+        projectId: "source-project",
+        name: "demo.mp4",
+        type: "video",
+        format: "mp4",
+        size: 1,
+        createdAt: "2026-01-01",
+        meta: { width: 1920, height: 1080 },
+      },
+      {
+        id: "file",
+        projectId: "source-project",
+        name: "guide.pdf",
+        type: "file",
+        format: "pdf",
+        size: 1,
+        createdAt: "2026-01-01",
+        meta: {},
+      },
+    ];
+    const importedById = new Map(
+      sources.map((asset) => [
+        `imported-${asset.id}`,
+        { ...asset, id: `imported-${asset.id}`, projectId: "target-project" },
+      ])
+    );
+    const upload: NonNullable<
+      NonNullable<Parameters<typeof importAssets>[2]>["upload"]
+    > = vi.fn(async (type, [url]) => {
+      return new Map([[url, `imported-${type}`]]);
+    });
+    const waitForUpload = vi.fn(async (assetId: string) => {
+      const asset = importedById.get(assetId);
+      if (asset === undefined) {
+        throw new Error("Missing imported test asset");
+      }
+      return asset;
+    });
+
+    await expect(
+      importAssets(
+        "target-project",
+        sources.map((asset) => ({
+          asset,
+          url: `https://source.example.com/${asset.name}`,
+        })),
+        { upload, waitForUpload }
+      )
+    ).resolves.toEqual(
+      new Map(
+        sources.map((asset) => [
+          asset.id,
+          importedById.get(`imported-${asset.id}`),
+        ])
+      )
+    );
+
+    expect(upload).toHaveBeenNthCalledWith(
+      1,
+      "font",
+      [new URL("https://source.example.com/brand.woff2")],
+      {}
+    );
+    expect(upload).toHaveBeenNthCalledWith(
+      2,
+      "video",
+      [new URL("https://source.example.com/demo.mp4")],
+      { dimensions: { width: 1920, height: 1080 } }
+    );
+    expect(upload).toHaveBeenNthCalledWith(
+      3,
+      "file",
+      [new URL("https://source.example.com/guide.pdf")],
+      {}
+    );
+  });
+
+  test("uploads cross-deployment assets when destination metadata matches", async () => {
+    $project.set({ id: "target-project" } as Project);
+    const sourceAsset = {
+      id: "shared-id",
+      projectId: "source-project",
+      name: "hero.png",
+      type: "image",
+      format: "png",
+      size: 1,
+      createdAt: "2026-01-01",
+      description: null,
+      meta: { width: 100, height: 100 },
+    } satisfies Asset;
+    const existingAsset = {
+      ...sourceAsset,
+      projectId: "target-project",
+    } satisfies Asset;
+    const importedAsset = {
+      ...sourceAsset,
+      id: "imported-id",
+      projectId: "target-project",
+    } satisfies Asset;
+    $assets.set(new Map([[existingAsset.id, existingAsset]]));
+    const upload = vi.fn(async (_type, [url]: URL[]) => {
+      return new Map([[url, importedAsset.id]]);
+    });
+    const waitForUpload = vi.fn(async () => importedAsset);
+
+    await expect(
+      importAssets(
+        "target-project",
+        [
+          {
+            asset: sourceAsset,
+            url: "https://source.example.com/cgi/image/hero.png?format=raw",
+          },
+        ],
+        { upload, waitForUpload }
+      )
+    ).resolves.toEqual(new Map([[sourceAsset.id, importedAsset]]));
+
+    expect(upload).toHaveBeenCalledOnce();
+    expect(waitForUpload).toHaveBeenCalledWith(importedAsset.id);
+  });
+
+  test("reuses matching assets from the current deployment", async () => {
+    $project.set({ id: "target-project" } as Project);
+    const existingAsset = {
+      id: "existing-id",
+      projectId: "target-project",
+      name: "hero.png",
+      type: "image",
+      format: "png",
+      size: 1,
+      createdAt: "2026-01-01",
+      description: null,
+      meta: { width: 100, height: 100 },
+    } satisfies Asset;
+    $assets.set(new Map([[existingAsset.id, existingAsset]]));
+    const upload = vi.fn();
+    const waitForUpload = vi.fn();
+
+    await expect(
+      importAssets(
+        "target-project",
+        [
+          {
+            asset: existingAsset,
+            url: `${window.location.origin}/cgi/image/hero.png?format=raw`,
+          },
+        ],
+        { upload, waitForUpload }
+      )
+    ).resolves.toEqual(new Map([[existingAsset.id, existingAsset]]));
+
+    expect(upload).not.toHaveBeenCalled();
+    expect(waitForUpload).not.toHaveBeenCalled();
+  });
+
   test("passes the existing browser content hash to the shared upload ticket", async () => {
     request.mockResolvedValue(
       new Response(
@@ -171,6 +347,27 @@ describe("upload-assets", () => {
 
     const [, init] = request.mock.calls[0] as [string, { headers: Headers }];
     expect(init.headers.get("x-webstudio-asset-source")).toBe("url");
+  });
+
+  test("passes source video dimensions with URL uploads", async () => {
+    request.mockResolvedValue(
+      Response.json({ uploadedAssets: [{ id: "asset" }] })
+    );
+
+    await submitAssetUpload({
+      authToken: undefined,
+      uploadName: "video.mp4",
+      fileOrUrl: new URL("https://example.com/video.mp4"),
+      width: 1920,
+      height: 1080,
+      onCompleted: vi.fn(),
+      onError: vi.fn(),
+      request,
+    });
+
+    expect(request.mock.calls[0]?.[0]).toBe(
+      "/rest/assets/uploads/video.mp4?width=1920&height=1080"
+    );
   });
 
   test("keeps the selected folder throughout upload preparation", async () => {

--- a/apps/builder/app/builder/shared/assets/upload-assets.tsx
+++ b/apps/builder/app/builder/shared/assets/upload-assets.tsx
@@ -33,6 +33,10 @@ import {
 } from "./asset-utils";
 
 type AssetActionResponse = AssetUploadResult | { errors: string };
+type UploadAssetsOptions = {
+  folderId?: string;
+  dimensions?: { width: number; height: number };
+};
 
 const safeDeleteAssets = (assetIds: Asset["id"][], projectId: string) => {
   const currentProjectId = $project.get()?.id;
@@ -235,6 +239,8 @@ const submitAssetUpload = async ({
   authToken,
   uploadName,
   fileOrUrl,
+  width,
+  height,
   onCompleted,
   onError,
   request = fetch,
@@ -242,6 +248,8 @@ const submitAssetUpload = async ({
   authToken: undefined | string;
   uploadName: string;
   fileOrUrl: File | URL;
+  width?: number;
+  height?: number;
   onCompleted: (data: AssetUploadResult) => void;
   onError: (error: string) => void;
   request?: typeof fetch;
@@ -262,17 +270,13 @@ const submitAssetUpload = async ({
       headers.set("x-webstudio-asset-source", "url");
     }
 
-    let width = undefined;
-    let height = undefined;
-
-    if (mimeType.startsWith("video/") && fileOrUrl instanceof File) {
-      const videoSize = await getVideoDimensions(fileOrUrl);
-      width = videoSize.width;
-      height = videoSize.height;
-    }
+    const dimensions =
+      mimeType.startsWith("video/") && fileOrUrl instanceof File
+        ? await getVideoDimensions(fileOrUrl)
+        : { width, height };
 
     const uploadResponse = await request(
-      restAssetsUploadPath({ name: uploadName, width, height }),
+      restAssetsUploadPath({ name: uploadName, ...dimensions }),
       {
         method: "POST",
         body,
@@ -395,21 +399,24 @@ const processingQueue: [
   filesData: UploadingFileData[],
   projectId: string,
   authToken: string | undefined,
+  dimensions: UploadAssetsOptions["dimensions"],
 ][] = [];
 
 const processUpload = async (
   filesData: UploadingFileData[],
   projectId: string,
-  authToken: string | undefined
+  authToken: string | undefined,
+  dimensions: UploadAssetsOptions["dimensions"]
 ) => {
-  processingQueue.push([filesData, projectId, authToken]);
+  processingQueue.push([filesData, projectId, authToken, dimensions]);
 
   if (processingQueue.length > 1) {
     return;
   }
 
   while (processingQueue.length > 0) {
-    const [filesData, projectId, authToken] = processingQueue.shift()!;
+    const [filesData, projectId, authToken, dimensions] =
+      processingQueue.shift()!;
 
     const currentProjectId = $project.get()?.id;
     if (currentProjectId !== projectId) {
@@ -442,6 +449,7 @@ const processUpload = async (
         uploadName: fileData.uploadName,
         fileOrUrl:
           fileData.source === "file" ? fileData.file : new URL(fileData.url),
+        ...dimensions,
         onCompleted: (data) => {
           URL.revokeObjectURL(fileData.objectURL);
           handleAfterSubmit(assetId, data, projectId, fileData.folderId);
@@ -462,7 +470,7 @@ const processUpload = async (
 export const uploadAssets = async <T extends File | URL>(
   type: AssetType,
   filesOrUrls: T[],
-  options: { folderId?: string } = {}
+  options: UploadAssetsOptions = {}
 ): Promise<Map<T, string>> => {
   const projectId = $project.get()?.id;
   const authToken = $authToken.get();
@@ -541,7 +549,7 @@ export const uploadAssets = async <T extends File | URL>(
 
   addUploadingFilesData(ticketedFilesData);
 
-  processUpload(ticketedFilesData, projectId, authToken);
+  processUpload(ticketedFilesData, projectId, authToken, options.dimensions);
 
   const res = new Map();
 
@@ -571,6 +579,63 @@ export const uploadAssets = async <T extends File | URL>(
   }
 
   return res;
+};
+
+export const importAssets = async (
+  projectId: string,
+  sources: { asset: Asset; url?: string }[],
+  dependencies: {
+    upload?: (
+      type: AssetType,
+      urls: URL[],
+      options: Parameters<typeof uploadAssets>[2]
+    ) => Promise<Map<URL, string>>;
+    waitForUpload?: typeof waitForAssetUpload;
+  } = {}
+) => {
+  const upload = dependencies.upload ?? uploadAssets;
+  const waitForUpload = dependencies.waitForUpload ?? waitForAssetUpload;
+  const importedAssets = new Map<Asset["id"], Asset>();
+
+  for (const source of sources) {
+    if ($project.get()?.id !== projectId) {
+      throw new Error("Project changed while importing assets");
+    }
+    const url = source.url === undefined ? undefined : new URL(source.url);
+    const existingAsset = $assets.get().get(source.asset.id);
+    if (
+      (url === undefined || url.origin === window.location.origin) &&
+      existingAsset?.projectId === projectId &&
+      existingAsset.name === source.asset.name &&
+      existingAsset.type === source.asset.type
+    ) {
+      importedAssets.set(source.asset.id, existingAsset);
+      continue;
+    }
+    if (url === undefined) {
+      throw new Error("Asset source URL is missing");
+    }
+    const options =
+      source.asset.type === "video"
+        ? {
+            dimensions: {
+              width: source.asset.meta.width,
+              height: source.asset.meta.height,
+            },
+          }
+        : {};
+    const assetId = (await upload(source.asset.type, [url], options)).get(url);
+    if (assetId === undefined) {
+      throw new Error("Failed to import asset");
+    }
+    const importedAsset = await waitForUpload(assetId);
+    if (importedAsset.type !== source.asset.type) {
+      throw new Error("Imported asset type does not match its source");
+    }
+    importedAssets.set(source.asset.id, importedAsset);
+  }
+
+  return importedAssets;
 };
 
 export const uploadSingleAsset = async (

--- a/apps/builder/app/builder/shared/commands.test.ts
+++ b/apps/builder/app/builder/shared/commands.test.ts
@@ -370,6 +370,7 @@ describe("cut", () => {
 
     expect(JSON.parse(writeText.mock.calls[0]?.[0] ?? "")).toMatchObject({
       "@webstudio/instances/v0.1": {
+        sourceOrigin: "http://localhost:3000",
         rootInstanceIds: ["box1", "box2"],
       },
     });

--- a/apps/builder/app/shared/builder-api.ts
+++ b/apps/builder/app/shared/builder-api.ts
@@ -1,7 +1,10 @@
 import { createRecursiveProxy } from "@trpc/server/shared";
 import invariant from "tiny-invariant";
 import { toast } from "@webstudio-is/design-system";
-import { uploadAssets } from "~/builder/shared/assets/upload-assets";
+import {
+  importAssets,
+  uploadAssets,
+} from "~/builder/shared/assets/upload-assets";
 import { showTokenConflictDialog } from "./token-conflict-dialog";
 import { showRootStyleConflictDialog } from "./root-style-conflict-dialog";
 import { showDesignTokenImportDialog } from "./design-token-import-dialog";
@@ -34,6 +37,7 @@ const _builderApi = {
 
     return new Map([...urlToIds.entries()].map(([url, id]) => [url.href, id]));
   },
+  importAssets,
   showDesignTokenImportDialog,
   showTokenConflictDialog,
   showRootStyleConflictDialog,

--- a/apps/builder/app/shared/copy-paste/asset-transfer-utils.test.ts
+++ b/apps/builder/app/shared/copy-paste/asset-transfer-utils.test.ts
@@ -1,0 +1,141 @@
+import { expect, test, vi } from "vitest";
+import type { Asset, WebstudioFragment } from "@webstudio-is/sdk";
+import { transferFragmentAssets } from "./asset-transfer-utils";
+
+const imageAsset = {
+  id: "source-image",
+  projectId: "source-project",
+  name: "hero.png",
+  type: "image",
+  size: 128,
+  format: "png",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  description: null,
+  meta: { width: 1200, height: 800 },
+} satisfies Asset;
+
+const fontAsset = {
+  id: "source-font",
+  projectId: "source-project",
+  name: "heading.woff2",
+  type: "font",
+  size: 64,
+  format: "woff2",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  description: null,
+  meta: { family: "Source heading", style: "normal", weight: 600 },
+} satisfies Asset;
+
+const fragment = {
+  children: [{ type: "id", value: "image" }],
+  instances: [
+    { type: "instance", id: "image", component: "Image", children: [] },
+  ],
+  assets: [imageAsset, fontAsset],
+  dataSources: [],
+  resources: [],
+  props: [
+    {
+      id: "image-src",
+      instanceId: "image",
+      name: "src",
+      type: "asset",
+      value: imageAsset.id,
+    },
+  ],
+  breakpoints: [],
+  styleSourceSelections: [],
+  styleSources: [],
+  styles: [
+    {
+      styleSourceId: "local",
+      breakpointId: "base",
+      property: "backgroundImage",
+      value: {
+        type: "layers",
+        value: [
+          {
+            type: "image",
+            value: { type: "asset", value: imageAsset.id },
+          },
+        ],
+      },
+    },
+    {
+      styleSourceId: "local",
+      breakpointId: "base",
+      property: "fontFamily",
+      value: {
+        type: "fontFamily",
+        value: [fontAsset.meta.family, "sans-serif"],
+      },
+    },
+  ],
+} satisfies WebstudioFragment;
+
+test("imports and remaps every fragment asset reference", async () => {
+  const importedImage = {
+    ...imageAsset,
+    id: "imported-image",
+    projectId: "target-project",
+  } satisfies Asset;
+  const importedFont = {
+    ...fontAsset,
+    id: "imported-font",
+    projectId: "target-project",
+    meta: { ...fontAsset.meta, family: "Imported heading" },
+  } satisfies Asset;
+  const importAssets = vi.fn(
+    async () =>
+      new Map<Asset["id"], Asset>([
+        [imageAsset.id, importedImage],
+        [fontAsset.id, importedFont],
+      ])
+  );
+
+  const result = await transferFragmentAssets({
+    sourceOrigin: "https://source.example.com",
+    projectId: "target-project",
+    fragments: [fragment],
+    importAssets,
+  });
+
+  expect(importAssets).toHaveBeenCalledWith("target-project", [
+    {
+      asset: imageAsset,
+      url: "https://source.example.com/cgi/image/hero.png?format=raw",
+    },
+    {
+      asset: fontAsset,
+      url: "https://source.example.com/cgi/asset/heading.woff2?format=raw",
+    },
+  ]);
+  expect(result.success).toBe(true);
+  if (result.success === false) {
+    return;
+  }
+  expect(result.fragments.get(fragment)).toEqual({
+    ...fragment,
+    assets: [],
+    props: [expect.objectContaining({ value: importedImage.id })],
+    styles: [
+      expect.objectContaining({
+        value: {
+          type: "layers",
+          value: [
+            {
+              type: "image",
+              value: { type: "asset", value: importedImage.id },
+            },
+          ],
+        },
+      }),
+      expect.objectContaining({
+        value: {
+          type: "fontFamily",
+          value: [importedFont.meta.family, "sans-serif"],
+        },
+      }),
+    ],
+  });
+});

--- a/apps/builder/app/shared/copy-paste/asset-transfer-utils.ts
+++ b/apps/builder/app/shared/copy-paste/asset-transfer-utils.ts
@@ -1,0 +1,91 @@
+import {
+  getAssetUrl,
+  type Asset,
+  type WebstudioFragment,
+} from "@webstudio-is/sdk";
+import { produce } from "immer";
+import { replaceAssetMutable } from "@webstudio-is/project-build/runtime";
+import { builderApi } from "../builder-api";
+
+const assetTransferError =
+  "Could not transfer assets from the source Webstudio deployment. Make sure it is reachable and try again.";
+
+export const transferFragmentAssets = async ({
+  sourceOrigin,
+  projectId,
+  fragments,
+  importAssets = builderApi.importAssets,
+}: {
+  sourceOrigin: string | undefined;
+  projectId: string;
+  fragments: WebstudioFragment[];
+  importAssets?: typeof builderApi.importAssets;
+}) => {
+  if (fragments.every((fragment) => fragment.assets.length === 0)) {
+    return {
+      success: true,
+      fragments: new Map(fragments.map((fragment) => [fragment, fragment])),
+      assetIds: new Map<Asset["id"], Asset["id"]>(),
+    } as const;
+  }
+
+  const assets = new Map(
+    fragments.flatMap((fragment) =>
+      fragment.assets.map((asset) => [asset.id, asset] as const)
+    )
+  );
+
+  let importedAssets: Map<Asset["id"], Asset>;
+  try {
+    importedAssets = await importAssets(
+      projectId,
+      Array.from(assets.values(), (asset) => ({
+        asset,
+        url:
+          sourceOrigin === undefined
+            ? undefined
+            : getAssetUrl(asset, sourceOrigin).href,
+      }))
+    );
+  } catch {
+    return { success: false, error: assetTransferError } as const;
+  }
+  if (importedAssets.size !== assets.size) {
+    return { success: false, error: assetTransferError } as const;
+  }
+
+  const assetIds = new Map<Asset["id"], Asset["id"]>();
+  const transferredFragments = new Map<WebstudioFragment, WebstudioFragment>();
+  for (const fragment of fragments) {
+    const transferredFragment = produce(fragment, (draft) => {
+      for (const sourceAsset of fragment.assets) {
+        const importedAsset = importedAssets.get(sourceAsset.id);
+        if (importedAsset === undefined) {
+          throw new Error("Imported asset is missing");
+        }
+        assetIds.set(sourceAsset.id, importedAsset.id);
+        replaceAssetMutable({
+          props: draft.props,
+          styles: draft.styles,
+          replacement: {
+            fromAssetId: sourceAsset.id,
+            toAssetId: importedAsset.id,
+            fromFontFamily:
+              sourceAsset.type === "font" ? sourceAsset.meta.family : undefined,
+            toFontFamily:
+              importedAsset.type === "font"
+                ? importedAsset.meta.family
+                : undefined,
+          },
+        });
+      }
+      draft.assets = [];
+    });
+    transferredFragments.set(fragment, transferredFragment);
+  }
+  return {
+    success: true,
+    fragments: transferredFragments,
+    assetIds,
+  } as const;
+};

--- a/apps/builder/app/shared/copy-paste/plugin-instance.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.test.ts
@@ -2,6 +2,7 @@ import { describe, test, expect, vi } from "vitest";
 import { enableMapSet } from "immer";
 import { toast } from "@webstudio-is/design-system";
 import type {
+  Asset,
   Instance,
   Instances,
   Prop,
@@ -24,7 +25,7 @@ import * as baseComponentMetas from "@webstudio-is/sdk-components-react/metas";
 import { componentMetas } from "@webstudio-is/sdk-components-registry/metas";
 import { registerContainers } from "../sync/sync-stores";
 import { $registeredComponentMetas } from "../nano-states";
-import { $instances } from "~/shared/sync/data-stores";
+import { $assets, $instances } from "~/shared/sync/data-stores";
 import {
   $dataSources,
   $pages,
@@ -152,6 +153,7 @@ describe("copy and cut guards", () => {
 
     expect(JSON.parse(clipboardData ?? "")).toMatchObject({
       "@webstudio/instances/v0.1": {
+        sourceOrigin: window.location.origin,
         rootInstanceIds: ["box1", "box2"],
         fragment: {
           children: [
@@ -202,6 +204,82 @@ describe("copy and cut guards", () => {
     expect($allSelectedInstanceSelectors.get()).toEqual([
       [pastedRootIds?.[0], "body0"],
       [pastedRootIds?.[1], "body0"],
+    ]);
+  });
+
+  test("transfers assets from another deployment before inserting", async () => {
+    $instances.set(
+      toMap([createInstance("body0", "Body", [])] satisfies Instance[])
+    );
+    $assets.set(new Map());
+    selectInstance(["body0"]);
+    const sourceAsset = {
+      id: "source-asset",
+      projectId: "source-project",
+      name: "hero.png",
+      type: "image",
+      size: 128,
+      format: "png",
+      createdAt: "2026-01-01T00:00:00.000Z",
+      description: null,
+      meta: { width: 1200, height: 800 },
+    } satisfies Asset;
+    const importedAsset = {
+      ...sourceAsset,
+      id: "imported-asset",
+      projectId: "my-project",
+    } satisfies Asset;
+    initBuilderApi();
+    const importAssets = vi
+      .spyOn(window.__webstudio__$__builderApi, "importAssets")
+      .mockRejectedValueOnce(new Error("Source is unavailable"))
+      .mockImplementation(
+        async () => new Map([[sourceAsset.id, importedAsset]])
+      );
+    const clipboardData = JSON.stringify({
+      "@webstudio/instance/v0.1": {
+        sourceOrigin: "https://source.example.com",
+        instanceSelector: ["image", "source-body"],
+        children: [{ type: "id", value: "image" }],
+        instances: [createInstance("image", "Image", [])],
+        assets: [sourceAsset],
+        dataSources: [],
+        resources: [],
+        props: [
+          {
+            id: "image-src",
+            instanceId: "image",
+            name: "src",
+            type: "asset",
+            value: sourceAsset.id,
+          },
+        ],
+        breakpoints: [],
+        styleSourceSelections: [],
+        styleSources: [],
+        styles: [],
+      },
+    });
+
+    expect(await instanceText.onPaste?.(clipboardData)).toEqual({
+      success: false,
+      error:
+        "Could not transfer assets from the source Webstudio deployment. Make sure it is reachable and try again.",
+    });
+    expect($instances.get().get("body0")?.children).toEqual([]);
+
+    expect(await instanceText.onPaste?.(clipboardData)).toEqual(pasteHandled);
+    expect($instances.get().get("body0")?.children).toEqual([
+      { type: "id", value: expect.any(String) },
+    ]);
+    expect(importAssets).toHaveBeenLastCalledWith("my-project", [
+      {
+        asset: sourceAsset,
+        url: "https://source.example.com/cgi/image/hero.png?format=raw",
+      },
+    ]);
+    expect(Array.from($props.get().values())).toEqual([
+      expect.objectContaining({ type: "asset", value: importedAsset.id }),
     ]);
   });
 

--- a/apps/builder/app/shared/copy-paste/plugin-instance.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-instance.ts
@@ -26,7 +26,7 @@ import {
   type WebstudioFragment,
   isComponentDetachable,
 } from "@webstudio-is/sdk";
-import { $instances } from "~/shared/sync/data-stores";
+import { $instances, $project } from "~/shared/sync/data-stores";
 import {
   type InstanceSelector,
   sortInstancePathsForChildMutation,
@@ -47,6 +47,7 @@ import { pasteHandled, pasteIgnored, type Plugin } from "./copy-paste";
 import { breakpointPasteLimitWarning } from "@webstudio-is/project-build/runtime";
 import { resolveFragmentTokenConflicts } from "../resolve-token-conflicts";
 import { reportFragmentContentModelWarnings } from "./fragment-utils";
+import { transferFragmentAssets } from "./asset-transfer-utils";
 
 const invalidPasteDataMessage =
   "Could not paste Webstudio instance data. The clipboard data appears to be incomplete or invalid.";
@@ -54,7 +55,7 @@ const invalidPasteDataMessage =
 const getTreeData = (
   instanceSelector: InstanceSelector,
   { showToast = true }: { showToast?: boolean } = {}
-) => {
+): InstanceTransferData | undefined => {
   const instances = $instances.get();
   const [targetInstanceId] = instanceSelector;
   const instance = instances.get(targetInstanceId);
@@ -73,6 +74,7 @@ const getTreeData = (
   }
 
   return {
+    sourceOrigin: window.location.origin,
     instanceSelector,
     ...extractWebstudioFragment(getWebstudioData(), targetInstanceId),
   };
@@ -87,8 +89,13 @@ const stringifyMultiRoot = (data: InstancesTransferData) => {
 };
 
 const stringifyMultiRootSelection = (selectedData: InstanceTransferData[]) => {
+  const firstData = selectedData[0];
+  if (firstData === undefined) {
+    return;
+  }
   const rootInstanceIds = selectedData.map((data) => data.instanceSelector[0]);
   return stringifyMultiRoot({
+    sourceOrigin: firstData.sourceOrigin,
     rootInstanceIds,
     fragment: mergeWebstudioFragments(rootInstanceIds, selectedData),
   });
@@ -173,7 +180,7 @@ const findPasteTargetForFragment = (
 };
 
 const findPasteTarget = (
-  data: InstanceTransferData
+  data: WebstudioFragment & { instanceSelector: string[] }
 ): undefined | Insertable => {
   const instances = $instances.get();
 
@@ -207,10 +214,14 @@ const insertPastedFragment = async ({
   fragment,
   pasteTarget,
   selectRootInstances,
+  sourceOrigin,
+  projectId,
 }: {
   fragment: WebstudioFragment;
   pasteTarget: Insertable;
   selectRootInstances: (rootInstanceIds: Instance["id"][]) => void;
+  sourceOrigin: string | undefined;
+  projectId: string;
 }) => {
   try {
     const contentModelWarnings = getFragmentContentModelWarnings({
@@ -219,13 +230,31 @@ const insertPastedFragment = async ({
     });
     const conflictResolution = await resolveFragmentTokenConflicts(fragment);
     if (conflictResolution === "cancel") {
-      return;
+      return pasteHandled;
+    }
+    const transferred = await transferFragmentAssets({
+      sourceOrigin,
+      projectId,
+      fragments: [fragment],
+    });
+    if (transferred.success === false) {
+      return transferred;
+    }
+    if ($project.get()?.id !== projectId) {
+      return {
+        success: false,
+        error: "Project changed while pasting.",
+      } as const;
+    }
+    const transferredFragment = transferred.fragments.get(fragment);
+    if (transferredFragment === undefined) {
+      return pasteHandled;
     }
     const result = await executeRuntimeMutationAsync({
       id: "instances.insertFragment",
       input: {
         parentInstanceId: pasteTarget.parentSelector[0],
-        fragment,
+        fragment: transferredFragment,
         conflictResolution,
         insertIndex:
           typeof pasteTarget.position === "number"
@@ -236,18 +265,17 @@ const insertPastedFragment = async ({
     });
     const rootInstanceIds = result?.result.rootInstanceIds;
     if (rootInstanceIds === undefined || rootInstanceIds.length === 0) {
-      return false;
+      return pasteHandled;
     }
     if (result?.result.didMergeBreakpointsDueToLimit === true) {
       toast.warn(breakpointPasteLimitWarning);
     }
     reportFragmentContentModelWarnings(contentModelWarnings);
     selectRootInstances(rootInstanceIds);
-  } catch (error) {
-    // User cancelled
-    return false;
+    return pasteHandled;
+  } catch {
+    return pasteHandled;
   }
-  return true;
 };
 
 const handlePasteInstance = async (clipboardData: string) => {
@@ -257,6 +285,10 @@ const handlePasteInstance = async (clipboardData: string) => {
   }
   if (transferData.valid === false) {
     return { success: false, error: invalidPasteDataMessage } as const;
+  }
+  const projectId = $project.get()?.id;
+  if (projectId === undefined) {
+    return pasteHandled;
   }
   if (transferData.type === "multi-root") {
     const pasteRootInstanceIds = getPasteRootInstanceIds(transferData.data);
@@ -274,9 +306,11 @@ const handlePasteInstance = async (clipboardData: string) => {
     if (pasteTarget === undefined) {
       return pasteHandled;
     }
-    await insertPastedFragment({
+    return insertPastedFragment({
       fragment,
       pasteTarget,
+      sourceOrigin: transferData.data.sourceOrigin ?? window.location.origin,
+      projectId,
       selectRootInstances: (rootInstanceIds) => {
         selectInstances(
           rootInstanceIds.map((newRootInstanceId) => [
@@ -286,7 +320,6 @@ const handlePasteInstance = async (clipboardData: string) => {
         );
       },
     });
-    return pasteHandled;
   }
   const fragment = transferData.data;
 
@@ -294,9 +327,11 @@ const handlePasteInstance = async (clipboardData: string) => {
   if (pasteTarget === undefined) {
     return pasteHandled;
   }
-  await insertPastedFragment({
+  return insertPastedFragment({
     fragment,
     pasteTarget,
+    sourceOrigin: transferData.data.sourceOrigin ?? window.location.origin,
+    projectId,
     selectRootInstances: (rootInstanceIds) => {
       const newRootInstanceId = rootInstanceIds[0];
       if (newRootInstanceId === undefined) {
@@ -305,7 +340,6 @@ const handlePasteInstance = async (clipboardData: string) => {
       selectInstances([[newRootInstanceId, ...pasteTarget.parentSelector]]);
     },
   });
-  return pasteHandled;
 };
 
 const handleCopyInstance = () => {

--- a/apps/builder/app/shared/copy-paste/plugin-page.test.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-page.test.ts
@@ -5,6 +5,7 @@ import {
   encodeDataSourceVariable,
   ROOT_FOLDER_ID,
   ROOT_INSTANCE_ID,
+  type Asset,
   type DataSource,
   type Instance,
 } from "@webstudio-is/sdk";
@@ -349,6 +350,208 @@ test("copies page data across projects", async () => {
   expect($dataSources.get().has("source-variable")).toBe(false);
 });
 
+test("transfers assets copied from another deployment before inserting the page", async () => {
+  $project.set({ id: "source-project" } as Project);
+  resetBuildStores();
+
+  const sourcePages = createDefaultPages({
+    homePageId: "source-page",
+    rootInstanceId: "source-root",
+  });
+  const sourceAsset = {
+    id: "source-asset",
+    projectId: "source-project",
+    name: "hero.png",
+    type: "image",
+    size: 128,
+    format: "png",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    description: null,
+    meta: { width: 1200, height: 800 },
+  } satisfies Asset;
+  const importedAsset = {
+    ...sourceAsset,
+    id: "imported-asset",
+    projectId: "target-project",
+  } satisfies Asset;
+  const sourcePage = sourcePages.pages.get("source-page");
+  if (sourcePage === undefined) {
+    throw new Error("Expected source page");
+  }
+  sourcePage.meta.socialImageAssetId = sourceAsset.id;
+  sourcePage.marketplace = { thumbnailAssetId: sourceAsset.id };
+  $pages.set(sourcePages);
+  $selectedPageId.set(sourcePages.homePageId);
+  $instances.set(
+    new Map([
+      [
+        "source-root",
+        {
+          type: "instance",
+          id: "source-root",
+          component: "Body",
+          children: [],
+        } satisfies Instance,
+      ],
+    ])
+  );
+  $assets.set(new Map([[sourceAsset.id, sourceAsset]]));
+  const clipboardData = JSON.parse(copyPageData("source-page") ?? "");
+  expect(clipboardData["@webstudio/page/v0.1"].sourceOrigin).toBe(
+    window.location.origin
+  );
+  clipboardData["@webstudio/page/v0.1"].sourceOrigin =
+    "https://source.example.com";
+
+  $project.set({ id: "target-project" } as Project);
+  resetBuildStores();
+  const targetPages = createDefaultPages({
+    homePageId: "target-page",
+    rootInstanceId: "target-root",
+  });
+  $pages.set(targetPages);
+  $selectedPageId.set(targetPages.homePageId);
+  $instances.set(
+    new Map([
+      [
+        "target-root",
+        {
+          type: "instance",
+          id: "target-root",
+          component: "Body",
+          children: [],
+        } satisfies Instance,
+      ],
+    ])
+  );
+  const importAssets = vi
+    .spyOn(window.__webstudio__$__builderApi, "importAssets")
+    .mockImplementation(async (projectId, sources) => {
+      expect(projectId).toBe("target-project");
+      expect(sources).toEqual([
+        {
+          asset: sourceAsset,
+          url: "https://source.example.com/cgi/image/hero.png?format=raw",
+        },
+      ]);
+      $assets.set(new Map([[importedAsset.id, importedAsset]]));
+      return new Map([[sourceAsset.id, importedAsset]]);
+    });
+
+  const incompleteClipboardData = structuredClone(clipboardData);
+  incompleteClipboardData["@webstudio/page/v0.1"].bodyFragment.assets = [];
+  expect(
+    await handlePastePage(
+      JSON.stringify(incompleteClipboardData),
+      ROOT_FOLDER_ID
+    )
+  ).toEqual({
+    success: false,
+    error:
+      "Could not paste Webstudio page data. The clipboard data appears to be incomplete or invalid.",
+  });
+  expect(importAssets).not.toHaveBeenCalled();
+
+  expect(
+    await handlePastePage(JSON.stringify(clipboardData), ROOT_FOLDER_ID)
+  ).toEqual(pasteHandled);
+  const pastedPage = Array.from($pages.get()?.pages.values() ?? []).find(
+    (page) => page.id !== "target-page"
+  );
+  expect(pastedPage?.meta.socialImageAssetId).toBe(importedAsset.id);
+  expect(pastedPage?.marketplace?.thumbnailAssetId).toBe(importedAsset.id);
+  expect(importAssets).toHaveBeenCalledOnce();
+  expect($assets.get().has(sourceAsset.id)).toBe(false);
+});
+
+test("preserves legacy page metadata assets that exist in the destination", async () => {
+  $project.set({ id: "source-project" } as Project);
+  resetBuildStores();
+  const sourcePages = createDefaultPages({
+    homePageId: "source-page",
+    rootInstanceId: "source-root",
+  });
+  const sourcePage = sourcePages.pages.get("source-page");
+  if (sourcePage === undefined) {
+    throw new Error("Expected source page");
+  }
+  const sourceAsset = {
+    id: "legacy-meta-asset",
+    projectId: "source-project",
+    name: "social.png",
+    type: "image",
+    size: 128,
+    format: "png",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    meta: { width: 1200, height: 630 },
+  } satisfies Asset;
+  sourcePage.meta.socialImageAssetId = sourceAsset.id;
+  sourcePage.marketplace = { thumbnailAssetId: sourceAsset.id };
+  $pages.set(sourcePages);
+  $selectedPageId.set(sourcePages.homePageId);
+  $instances.set(
+    new Map([
+      [
+        "source-root",
+        {
+          type: "instance",
+          id: "source-root",
+          component: "Body",
+          children: [],
+        } satisfies Instance,
+      ],
+    ])
+  );
+  $assets.set(new Map([[sourceAsset.id, sourceAsset]]));
+  const currentData = JSON.parse(copyPageData("source-page") ?? "")[
+    "@webstudio/page/v0.1"
+  ];
+  delete currentData.sourceOrigin;
+  currentData.bodyFragment.assets = [];
+  const clipboardData = JSON.stringify({
+    "@webstudio/page/v0.1": currentData,
+  });
+
+  $project.set({ id: "target-project" } as Project);
+  resetBuildStores();
+  const targetPages = createDefaultPages({
+    homePageId: "target-page",
+    rootInstanceId: "target-root",
+  });
+  $pages.set(targetPages);
+  $selectedPageId.set(targetPages.homePageId);
+  $instances.set(
+    new Map([
+      [
+        "target-root",
+        {
+          type: "instance",
+          id: "target-root",
+          component: "Body",
+          children: [],
+        } satisfies Instance,
+      ],
+    ])
+  );
+  $assets.set(
+    new Map([[sourceAsset.id, { ...sourceAsset, projectId: "target-project" }]])
+  );
+  const importAssets = vi.spyOn(
+    window.__webstudio__$__builderApi,
+    "importAssets"
+  );
+
+  expect(await handlePastePage(clipboardData, ROOT_FOLDER_ID)).toEqual(
+    pasteHandled
+  );
+  const pastedPage = Array.from($pages.get()?.pages.values() ?? []).find(
+    (page) => page.id !== "target-page"
+  );
+  expect(pastedPage?.meta.socialImageAssetId).toBe(sourceAsset.id);
+  expect(pastedPage?.marketplace?.thumbnailAssetId).toBe(sourceAsset.id);
+  expect(importAssets).not.toHaveBeenCalled();
+});
+
 test.each([
   ["ours", "blue"],
   ["theirs", "red"],
@@ -410,6 +613,23 @@ test("cancels page paste when global root style resolution is cancelled", async 
     styleSourceId: "source-local",
     color: "red",
   });
+  const sourceAsset = {
+    id: "source-asset",
+    projectId: "source-project",
+    name: "hero.png",
+    type: "image",
+    size: 128,
+    format: "png",
+    createdAt: "2026-01-01T00:00:00.000Z",
+    description: null,
+    meta: { width: 1200, height: 800 },
+  } satisfies Asset;
+  const sourcePage = $pages.get()?.pages.get("source-page");
+  if (sourcePage === undefined) {
+    throw new Error("Expected source page");
+  }
+  sourcePage.meta.socialImageAssetId = sourceAsset.id;
+  $assets.set(new Map([[sourceAsset.id, sourceAsset]]));
   const clipboardData = copyPageData("source-page");
 
   const targetPages = setupProjectWithRootStyle({
@@ -424,10 +644,15 @@ test("cancels page paste when global root style resolution is cancelled", async 
     window.__webstudio__$__builderApi,
     "showRootStyleConflictDialog"
   ).mockResolvedValue("cancel");
+  const importAssets = vi.spyOn(
+    window.__webstudio__$__builderApi,
+    "importAssets"
+  );
 
   await handlePastePage(clipboardData ?? "", ROOT_FOLDER_ID);
 
   expect($pages.get()?.pages.size).toBe(initialPageCount);
+  expect(importAssets).not.toHaveBeenCalled();
   expect($styles.get().get("target-local:base:color:")?.value).toEqual({
     type: "keyword",
     value: "blue",

--- a/apps/builder/app/shared/copy-paste/plugin-page.ts
+++ b/apps/builder/app/shared/copy-paste/plugin-page.ts
@@ -33,12 +33,18 @@ import { $selectedPage } from "../nano-states";
 import { getPageActionTarget } from "../page-action-target";
 import { pasteHandled, pasteIgnored, type Plugin } from "./copy-paste";
 import { breakpointPasteLimitWarning } from "@webstudio-is/project-build/runtime";
+import { transferFragmentAssets } from "./asset-transfer-utils";
 
 const invalidPasteDataMessage =
   "Could not paste Webstudio page data. The clipboard data appears to be incomplete or invalid.";
 
 const stringify = (data: PageTransferItem) => {
-  return JSON.stringify({ [pageTransferDataVersion]: data });
+  return JSON.stringify({
+    [pageTransferDataVersion]: {
+      ...data,
+      sourceOrigin: window.location.origin,
+    },
+  });
 };
 
 const getDefaultTargetFolderId = () => {
@@ -75,27 +81,62 @@ const mergeWebstudioFragments = (
   } satisfies WebstudioFragment;
 };
 
+const includeMetaAssets = (
+  fragment: WebstudioFragment,
+  assetIds: Array<string | undefined>,
+  assets: ReturnType<typeof getWebstudioData>["assets"]
+) => {
+  const fragmentAssets = new Map(
+    fragment.assets.map((asset) => [asset.id, asset])
+  );
+  for (const assetId of assetIds) {
+    const asset = assetId === undefined ? undefined : assets.get(assetId);
+    if (asset !== undefined) {
+      fragmentAssets.set(asset.id, asset);
+    }
+  }
+  return { ...fragment, assets: Array.from(fragmentAssets.values()) };
+};
+
 const addPageType = (
-  data: ReturnType<typeof createPageCopyData>
+  data: ReturnType<typeof createPageCopyData>,
+  assets: ReturnType<typeof getWebstudioData>["assets"]
 ): PageTransferData => ({
   ...data,
+  bodyFragment: includeMetaAssets(
+    data.bodyFragment,
+    [
+      data.page.meta.socialImageAssetId,
+      data.page.marketplace?.thumbnailAssetId,
+    ],
+    assets
+  ),
   type: "page",
 });
 
 const addTemplateType = (
-  data: ReturnType<typeof createTemplateCopyData>
+  data: ReturnType<typeof createTemplateCopyData>,
+  assets: ReturnType<typeof getWebstudioData>["assets"]
 ): TemplateTransferData => ({
   ...data,
+  bodyFragment: includeMetaAssets(
+    data.bodyFragment,
+    [data.template.meta.socialImageAssetId],
+    assets
+  ),
   type: "template",
 });
 
 const addFolderType = (
-  data: NonNullable<ReturnType<typeof createFolderCopyData>>
+  data: NonNullable<ReturnType<typeof createFolderCopyData>>,
+  assets: ReturnType<typeof getWebstudioData>["assets"]
 ): FolderTransferData => ({
   type: "folder",
   folder: data.folder,
   children: data.children.map((child) =>
-    "folder" in child ? addFolderType(child) : addPageType(child)
+    "folder" in child
+      ? addFolderType(child, assets)
+      : addPageType(child, assets)
   ),
 });
 
@@ -107,7 +148,63 @@ const getPageCopyData = (
   if (page === undefined) {
     return;
   }
-  return addPageType(createPageCopyData({ data, page }));
+  return addPageType(createPageCopyData({ data, page }), data.assets);
+};
+
+const remapPageTransferAssets = (
+  item: PageTransferItem,
+  fragments: Map<WebstudioFragment, WebstudioFragment>,
+  assetIds: Map<string, string>
+): PageTransferItem => {
+  const remapAssetId = (assetId: string | undefined) => {
+    return assetId === undefined
+      ? undefined
+      : (assetIds.get(assetId) ?? assetId);
+  };
+  if (item.type === "folder") {
+    return {
+      ...item,
+      children: item.children.map((child) =>
+        remapPageTransferAssets(child, fragments, assetIds)
+      ) as FolderTransferData["children"],
+    };
+  }
+  if (item.type === "page") {
+    const socialImageAssetId = item.page.meta.socialImageAssetId;
+    const thumbnailAssetId = item.page.marketplace?.thumbnailAssetId;
+    return {
+      ...item,
+      rootFragment: fragments.get(item.rootFragment) ?? item.rootFragment,
+      bodyFragment: fragments.get(item.bodyFragment) ?? item.bodyFragment,
+      page: {
+        ...item.page,
+        marketplace:
+          item.page.marketplace === undefined
+            ? undefined
+            : {
+                ...item.page.marketplace,
+                thumbnailAssetId: remapAssetId(thumbnailAssetId),
+              },
+        meta: {
+          ...item.page.meta,
+          socialImageAssetId: remapAssetId(socialImageAssetId),
+        },
+      },
+    };
+  }
+  const socialImageAssetId = item.template.meta.socialImageAssetId;
+  return {
+    ...item,
+    rootFragment: fragments.get(item.rootFragment) ?? item.rootFragment,
+    bodyFragment: fragments.get(item.bodyFragment) ?? item.bodyFragment,
+    template: {
+      ...item.template,
+      meta: {
+        ...item.template.meta,
+        socialImageAssetId: remapAssetId(socialImageAssetId),
+      },
+    },
+  };
 };
 
 const handleCopyPage = () => {
@@ -138,7 +235,9 @@ export const copyTemplateData = (templateId: PageTemplate["id"]) => {
   if (template === undefined) {
     return;
   }
-  return stringify(addTemplateType(createTemplateCopyData({ data, template })));
+  return stringify(
+    addTemplateType(createTemplateCopyData({ data, template }), data.assets)
+  );
 };
 
 export const copyFolderData = (folderId: Folder["id"]) => {
@@ -147,7 +246,7 @@ export const copyFolderData = (folderId: Folder["id"]) => {
   if (folderData === undefined) {
     return;
   }
-  return stringify(addFolderType(folderData));
+  return stringify(addFolderType(folderData, data.assets));
 };
 
 export const handlePastePage = async (
@@ -161,7 +260,8 @@ export const handlePastePage = async (
   if (transferData.valid === false) {
     return { success: false, error: invalidPasteDataMessage } as const;
   }
-  const item = transferData.data;
+  const { sourceOrigin, ...transferItem } = transferData.data;
+  let item: PageTransferItem = transferItem;
 
   const pages = $pages.get();
   const folderId = targetFolderId ?? getDefaultTargetFolderId();
@@ -179,8 +279,31 @@ export const handlePastePage = async (
     if (projectId === undefined) {
       return pasteHandled;
     }
-    const pageItems = collectPageTransferItems(item);
-    const conflicts = pageItems.flatMap((item) =>
+    const sourcePageItems = collectPageTransferItems(item);
+    if (sourceOrigin !== undefined) {
+      const assetIds = new Set(
+        sourcePageItems.flatMap((item) => [
+          ...item.rootFragment.assets.map((asset) => asset.id),
+          ...item.bodyFragment.assets.map((asset) => asset.id),
+        ])
+      );
+      const hasMissingMetaAsset = sourcePageItems.some((item) => {
+        const metaAssetIds =
+          item.type === "page"
+            ? [
+                item.page.meta.socialImageAssetId,
+                item.page.marketplace?.thumbnailAssetId,
+              ]
+            : [item.template.meta.socialImageAssetId];
+        return metaAssetIds.some(
+          (assetId) => assetId !== undefined && assetIds.has(assetId) === false
+        );
+      });
+      if (hasMissingMetaAsset) {
+        return { success: false, error: invalidPasteDataMessage } as const;
+      }
+    }
+    const conflicts = sourcePageItems.flatMap((item) =>
       detectFragmentTokenConflicts({
         fragment: mergeWebstudioFragments(item.rootFragment, item.bodyFragment),
         targetData,
@@ -191,7 +314,7 @@ export const handlePastePage = async (
       return pasteHandled;
     }
     const rootStyleTargetData = getWebstudioData();
-    const firstPageLikeItem = pageItems[0];
+    const firstPageLikeItem = sourcePageItems[0];
     const rootStyleConflictResolution =
       firstPageLikeItem === undefined
         ? undefined
@@ -202,7 +325,28 @@ export const handlePastePage = async (
     if (rootStyleConflictResolution === "cancel") {
       return pasteHandled;
     }
-
+    const transferred = await transferFragmentAssets({
+      sourceOrigin: sourceOrigin ?? window.location.origin,
+      projectId,
+      fragments: sourcePageItems.flatMap((item) => [
+        item.rootFragment,
+        item.bodyFragment,
+      ]),
+    });
+    if (transferred.success === false) {
+      return transferred;
+    }
+    if ($project.get()?.id !== projectId) {
+      return {
+        success: false,
+        error: "Project changed while pasting.",
+      } as const;
+    }
+    item = remapPageTransferAssets(
+      item,
+      transferred.fragments,
+      transferred.assetIds
+    );
     const result = executeRuntimeMutation({
       id: "pageTransfer.insert",
       input: {
@@ -227,11 +371,11 @@ export const handlePastePage = async (
       );
       return pasteHandled;
     }
+
+    return pasteHandled;
   } catch {
     return pasteHandled;
   }
-
-  return pasteHandled;
 };
 
 export const pageText: Plugin = {

--- a/docs/university/foundations/page-templates.md
+++ b/docs/university/foundations/page-templates.md
@@ -76,6 +76,10 @@ Right-click a page or folder and choose **Copy**, then right-click the destinati
 
 When pasted, Webstudio creates new internal IDs and automatically adjusts names, paths, folder slugs, tokens, assets, variables, and styles as needed to fit the destination project.
 
+{% hint style="info" %}
+When copying between separate Webstudio deployments, the destination downloads referenced asset files from the source before inserting the content. The source deployment must remain publicly reachable until the paste finishes. Use the [CLI](../cli.md) to sync and import the complete project when moving an entire site.
+{% endhint %}
+
 ## Content mode
 
 Content editors can create pages from existing page templates when they have editing access. This gives editors a controlled page creation workflow without giving them full design control.

--- a/packages/project-build/src/runtime/data-formats/instance-transfer.test.ts
+++ b/packages/project-build/src/runtime/data-formats/instance-transfer.test.ts
@@ -1,23 +1,25 @@
 import { expect, test } from "vitest";
 import { parseInstanceTransferData } from "./instance-transfer";
 
+const fragment = {
+  children: [{ type: "id", value: "box" }],
+  instances: [{ type: "instance", id: "box", component: "Box", children: [] }],
+  assets: [],
+  dataSources: [],
+  resources: [],
+  props: [],
+  breakpoints: [],
+  styleSourceSelections: [],
+  styleSources: [],
+  styles: [],
+};
+
 test("validates instance transfer data", () => {
   const valid = parseInstanceTransferData(
     JSON.stringify({
       "@webstudio/instance/v0.1": {
         instanceSelector: ["box", "body"],
-        children: [{ type: "id", value: "box" }],
-        instances: [
-          { type: "instance", id: "box", component: "Box", children: [] },
-        ],
-        assets: [],
-        dataSources: [],
-        resources: [],
-        props: [],
-        breakpoints: [],
-        styleSourceSelections: [],
-        styleSources: [],
-        styles: [],
+        ...fragment,
       },
     })
   );
@@ -37,5 +39,24 @@ test("validates instance transfer data", () => {
   expect(parseInstanceTransferData("plain text")).toEqual({
     owned: false,
     valid: false,
+  });
+});
+
+test("accepts optional source origin metadata", () => {
+  const result = parseInstanceTransferData(
+    JSON.stringify({
+      "@webstudio/instance/v0.1": {
+        sourceOrigin: "https://source.example.com",
+        instanceSelector: ["box", "body"],
+        ...fragment,
+      },
+    })
+  );
+
+  expect(result).toMatchObject({
+    owned: true,
+    valid: true,
+    type: "single-root",
+    data: { sourceOrigin: "https://source.example.com" },
   });
 });

--- a/packages/project-build/src/runtime/data-formats/instance-transfer.ts
+++ b/packages/project-build/src/runtime/data-formats/instance-transfer.ts
@@ -6,10 +6,12 @@ export const instanceTransferDataVersion = "@webstudio/instance/v0.1";
 export const instancesTransferDataVersion = "@webstudio/instances/v0.1";
 
 export const instanceTransferData = webstudioFragment.extend({
+  sourceOrigin: z.string().url().optional(),
   instanceSelector: z.array(z.string()),
 });
 
 export const instancesTransferData = z.object({
+  sourceOrigin: z.string().url().optional(),
   rootInstanceIds: z.array(z.string()),
   fragment: webstudioFragment,
 });

--- a/packages/project-build/src/runtime/data-formats/page-transfer.test.ts
+++ b/packages/project-build/src/runtime/data-formats/page-transfer.test.ts
@@ -1,19 +1,34 @@
 import { expect, test } from "vitest";
-import { parsePageTransferData } from "./page-transfer";
+import { pageTransferItemInput, parsePageTransferData } from "./page-transfer";
+
+const fragment = {
+  children: [],
+  instances: [],
+  assets: [],
+  dataSources: [],
+  resources: [],
+  props: [],
+  breakpoints: [],
+  styleSourceSelections: [],
+  styleSources: [],
+  styles: [],
+};
+
+const pageTransferItem = {
+  type: "page" as const,
+  page: {
+    id: "page",
+    name: "Page",
+    path: "/page",
+    title: `"Page"`,
+    meta: {},
+    rootInstanceId: "body",
+  },
+  rootFragment: fragment,
+  bodyFragment: fragment,
+};
 
 test("validates page transfer data", () => {
-  const fragment = {
-    children: [],
-    instances: [],
-    assets: [],
-    dataSources: [],
-    resources: [],
-    props: [],
-    breakpoints: [],
-    styleSourceSelections: [],
-    styleSources: [],
-    styles: [],
-  };
   const valid = parsePageTransferData(
     JSON.stringify({
       "@webstudio/page/v0.1": {
@@ -46,4 +61,33 @@ test("validates page transfer data", () => {
     owned: false,
     valid: false,
   });
+});
+
+test("accepts optional source origin metadata", () => {
+  const result = parsePageTransferData(
+    JSON.stringify({
+      "@webstudio/page/v0.1": {
+        ...pageTransferItem,
+        sourceOrigin: "https://source.example.com",
+      },
+    })
+  );
+
+  expect(result).toMatchObject({
+    owned: true,
+    valid: true,
+    data: {
+      type: "page",
+      sourceOrigin: "https://source.example.com",
+    },
+  });
+});
+
+test("keeps clipboard source metadata out of the runtime input", () => {
+  expect(
+    pageTransferItemInput.parse({
+      ...pageTransferItem,
+      sourceOrigin: "https://source.example.com",
+    })
+  ).toEqual(pageTransferItem);
 });

--- a/packages/project-build/src/runtime/data-formats/page-transfer.ts
+++ b/packages/project-build/src/runtime/data-formats/page-transfer.ts
@@ -80,12 +80,17 @@ export const pageTransferItemInput = z.union([
   pageTransferFolderInput,
 ]);
 
+const pageClipboardTransferItemInput = pageTransferItemInput.and(
+  z.object({ sourceOrigin: z.string().url().optional() })
+);
 export const pageTransferDataVersion = "@webstudio/page/v0.1";
 
 export const parsePageTransferData = (serializedData: string) => {
   const transferData = parseDataEnvelope({
     serializedData,
-    schemas: [[pageTransferDataVersion, pageTransferItemInput]] as const,
+    schemas: [
+      [pageTransferDataVersion, pageClipboardTransferItemInput],
+    ] as const,
   });
   if (transferData.valid === false) {
     return transferData;


### PR DESCRIPTION
Closes #6227

## What changed

Cross-deployment copy/paste now transfers referenced assets into the destination project before inserting instances, pages, templates, or folders.

- Add optional source deployment metadata to the existing v0.1 clipboard formats.
- Keep old v0.1 payloads readable and keep new payloads readable by older builders, which ignore the additive field.
- Reuse the existing asset upload-by-URL flow for images, fonts, videos, and files.
- Preserve source video dimensions through the existing upload route.
- Replace source asset IDs and font-family references with destination values before runtime insertion.
- Include and remap page social images and marketplace thumbnails.
- Reject current clipboard payloads whose page metadata references omitted assets.
- Leave the public `pageTransfer.insert` runtime input unchanged.
- Abort insertion with a paste error when an asset cannot be imported.

No clipboard version increase, custom network fetcher, address blocklist, rollback framework, or global paste wrapper is introduced. If a multi-asset import partially uploads before a later upload fails, the completed uploads may remain unused.

## Checklist

- [x] Rebased onto `main`
- [x] Preserve the existing v0.1 clipboard format
- [x] Transfer and remap instance assets
- [x] Transfer and remap page, template, and folder assets
- [x] Preserve video metadata
- [x] Keep runtime page-transfer API compatible
- [x] Add regression coverage
- [x] Review documentation impact and update page-copy documentation
- [x] Run Builder tests and typecheck
- [x] Run project-build tests and typecheck
- [x] Run lint, package-boundary, and generated-API checks

## Verification

- Builder full suite: 219 files, 2,552 tests passed
- Project-build full suite: 78 files, 2,129 tests passed
- Final affected suite: 84 tests passed
- New regressions were confirmed failing before the fixes and passing afterward
- Builder and project-build typechecks passed
- `pnpm lint` passed
- `pnpm check:package-boundaries` passed
- `pnpm check:generated-api` passed
- Fixture inputs and generated fixture bundles are unaffected