### PR TITLE
fix: Avoid Builder E2E registry throttling

### DIFF
--- a/apps/builder/dev/backend.sh
+++ b/apps/builder/dev/backend.sh
@@ -46,7 +46,20 @@ builder_backend_down() {
 }
 
 builder_backend_pull_db() {
-  builder_compose pull --policy missing db
+  local max_attempts="${BUILDER_DOCKER_PULL_ATTEMPTS:-4}"
+  local attempt=1
+
+  until builder_compose pull --policy missing db; do
+    if [ "$attempt" -ge "$max_attempts" ]; then
+      echo "Failed to pull the database image after ${max_attempts} attempts" >&2
+      return 1
+    fi
+
+    local delay_seconds="$((5 * (1 << (attempt - 1)) + RANDOM % 6))"
+    echo "Database image pull failed; retrying in ${delay_seconds}s" >&2
+    sleep "$delay_seconds"
+    attempt="$((attempt + 1))"
+  done
 }
 
 builder_backend_start_db() {

--- a/apps/builder/dev/backend.sh
+++ b/apps/builder/dev/backend.sh
@@ -46,20 +46,7 @@ builder_backend_down() {
 }
 
 builder_backend_pull_db() {
-  local max_attempts="${BUILDER_DOCKER_PULL_ATTEMPTS:-4}"
-  local attempt=1
-
-  until builder_compose pull --policy missing db; do
-    if [ "$attempt" -ge "$max_attempts" ]; then
-      echo "Failed to pull the database image after ${max_attempts} attempts" >&2
-      return 1
-    fi
-
-    local delay_seconds="$((5 * (1 << (attempt - 1)) + RANDOM % 6))"
-    echo "Database image pull failed; retrying in ${delay_seconds}s" >&2
-    sleep "$delay_seconds"
-    attempt="$((attempt + 1))"
-  done
+  builder_compose pull --policy missing db
 }
 
 builder_backend_start_db() {

--- a/apps/builder/docker-compose.yaml
+++ b/apps/builder/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: public.ecr.aws/supabase/postgres:15.8.1.085
+    image: ghcr.io/supabase/postgres:15.8.1.085@sha256:af083ef64d0408c8f098ee6f5c364a59b26f36fbc0f3a334a62c5c1d57362e9b
     environment:
       # The image initializes its required roles as supabase_admin. Supplying
       # POSTGRES_USER overrides that bootstrap user and breaks its init scripts.


### PR DESCRIPTION
## Summary

- pull the pinned Supabase Postgres image from its official GHCR package instead of anonymous Public ECR
- pin the multi-platform index digest shared by both registries

## Technical choice

The existing Public ECR and GHCR tags resolve to the same multi-platform index digest, so changing registries preserves the amd64 and arm64 image contents. GHCR public pulls require no long-lived CI credentials.

## Checklist

- [x] Verify Public ECR and GHCR resolve to the same image digest
- [x] Switch the Compose database image to the pinned GHCR digest
- [x] Validate shell syntax and rendered Compose configuration
- [x] Review documentation impact; no user-facing documentation is affected
- [x] Review fixture impact; no fixture inputs or outputs are affected

## Verification

- `bash -n apps/builder/dev/backend.sh apps/builder/e2e/run-local.sh`
- `docker compose ... config --images`
- `docker buildx imagetools inspect` digest comparison for both registries
- `git diff --check`

The full Builder E2E suite was not run locally because the change only selects an identical image from a different registry.

Closes #6230
