### PR TITLE
fix: Report recovered project settings commits

### DIFF
--- a/packages/project-build/src/project-session.test.ts
+++ b/packages/project-build/src/project-session.test.ts
@@ -1237,15 +1237,59 @@ describe("project session", () => {
 
     expect(result.state.committed).toBe(true);
     expect(result.version).toBe(3);
+    expect(serializeProjectSessionMeta(result)).toMatchObject({
+      version: 3,
+      commitStatus: "committed",
+      committed: true,
+      diagnosticCount: 2,
+    });
     expect(result.diagnostics).toEqual([
-      expect.objectContaining({ code: "CONFLICT" }),
-      expect.objectContaining({ code: "CONFLICT_REFRESHED" }),
-      expect.objectContaining({ code: "CONFLICT_RETRY" }),
+      expect.objectContaining({ level: "info", code: "CONFLICT_REFRESHED" }),
+      expect.objectContaining({ level: "info", code: "CONFLICT_RETRY" }),
     ]);
     expect(transport.loadedNamespaces).toEqual([
       ["pages", "instances", "dataSources"],
     ]);
     expect(transport.commits).toHaveLength(3);
+  });
+
+  test("reports a project settings conflict retry as committed", async () => {
+    const storage = createStorage(createPersistedSnapshot());
+    const remote = createSnapshot({ version: 2 });
+    const transport = createMutableTransport(remote);
+    let attempts = 0;
+    const commitPatch = transport.commitPatch;
+    transport.commitPatch = async (input) => {
+      attempts += 1;
+      if (attempts <= 2) {
+        throw Object.assign(new Error("Build version mismatch"), {
+          code: "CONFLICT",
+        });
+      }
+      return await commitPatch(input);
+    };
+    const session = createSession({ storage, transport });
+
+    await session.initialize();
+    const result = await session.mutate("projectSettings.update", {
+      meta: { code: "console.log('committed')" },
+    });
+
+    expect(result.state.committed).toBe(true);
+    expect(result.version).toBe(3);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({
+        level: "info",
+        code: "CONFLICT_REFRESHED",
+      }),
+      expect.objectContaining({ level: "info", code: "CONFLICT_RETRY" }),
+    ]);
+
+    await session.refresh(["projectSettings"]);
+    const settings = await session.read("projectSettings.get", {});
+    expect(settings.result).toMatchObject({
+      meta: { code: "console.log('committed')" },
+    });
   });
 
   test("confirms an ambiguous commit with the same transaction", async () => {

--- a/packages/project-build/src/project-session.ts
+++ b/packages/project-build/src/project-session.ts
@@ -1348,7 +1348,9 @@ export class ProjectSession {
               contract,
               snapshot: latestSnapshot,
               diagnostics: [
-                ...diagnostics,
+                ...diagnostics.filter(
+                  (diagnostic) => diagnostic.level !== "error"
+                ),
                 {
                   level: "info",
                   code: "CONFLICT_RETRY",


### PR DESCRIPTION
## Summary

A stale project-settings mutation could retry and commit successfully while retaining the original `CONFLICT` error diagnostic. CLI and MCP then reported failure even though the requested settings were stored and the project version advanced.

Successful conflict retries now retain only recovery information. Failed retries still preserve their errors.

## Implementation checklist

- [x] Reproduce the stale project-settings conflict before changing the implementation.
- [x] Remove the obsolete error diagnostic only after a retry succeeds.
- [x] Cover `update-project-settings` commit status, resulting version, and remote read-back.
- [x] Confirm the regression fails before the fix and passes after it.
- [x] Review documentation impact; no user documentation changes are required.
- [x] Review generated contracts and fixtures; neither is affected.
- [ ] Confirm CI passes.

## Verification

- ProjectSession suite: 49 tests passed.
- Complete Project Build suite: 2,126 tests passed.
- Project Build typecheck passed.
- CLI ProjectSession adapter suite: 8 tests passed.
- Changed-file lint and formatting passed.
- Agent evaluations were not run because they require separate approval.

Closes #6235