### PR TITLE
fix: Create page templates without explicit titles

### DIFF
--- a/packages/project-build/src/runtime/page-copy.test.tsx
+++ b/packages/project-build/src/runtime/page-copy.test.tsx
@@ -5,6 +5,7 @@ import {
   encodeDataVariableId,
   elementComponent,
   getHomePage,
+  pageTemplate,
   type Asset,
   type DataSource,
   type Instance,
@@ -1585,6 +1586,29 @@ describe("insert page copy", () => {
         },
       ]),
     });
+  });
+
+  test("creates a valid page template when title is omitted", () => {
+    const data = getWebstudioDataStub();
+    const ids = ["templateId", "templateBodyId"];
+
+    const result = createPageTemplate(
+      data,
+      { name: "Landing Template" },
+      { createId: () => ids.shift() ?? "extraId" }
+    );
+    const updated = applyBuilderPatchTransactions(data, [
+      { id: "create-page-template", payload: result.payload },
+    ]).state as WebstudioData;
+
+    expect(
+      pageTemplate.parse(updated.pages.pageTemplates?.get("templateId"))
+    ).toEqual(
+      expect.objectContaining({
+        name: "Landing Template",
+        title: '"Landing Template"',
+      })
+    );
   });
 
   test("updates page templates through page field validation semantics", () => {

--- a/packages/project-build/src/runtime/page-copy.ts
+++ b/packages/project-build/src/runtime/page-copy.ts
@@ -1020,7 +1020,7 @@ export const createPageTemplate = (
     draft.pages.pageTemplates.set(templateId, {
       id: templateId,
       name: input.name,
-      title: input.title ?? "",
+      title: input.title ?? JSON.stringify(input.name),
       rootInstanceId,
       meta:
         input.meta === undefined


### PR DESCRIPTION
## Summary

Allow `create-page-template` to omit `title` by deriving a fixed title expression from the required template name. Explicit titles remain unchanged.

Closes #6239

## Todo

- [x] Reproduce the name-only mutation failure against the persisted page-template schema
- [x] Derive the omitted title from the template name
- [x] Add and verify a fail-before/pass-after regression test
- [x] Review fixture impact; no fixture inputs or generated outputs are affected
- [x] Review documentation impact; the existing command schema and example already document the optional title, so no documentation update is needed

## Verification

- `pnpm --filter @webstudio-is/project-build test -- src/runtime/page-copy.test.tsx`
- `pnpm --filter @webstudio-is/project-build typecheck`
- `pnpm exec oxfmt --check packages/project-build/src/runtime/page-copy.ts packages/project-build/src/runtime/page-copy.test.tsx`
- `pnpm exec oxlint --deny-warnings packages/project-build/src/runtime/page-copy.ts packages/project-build/src/runtime/page-copy.test.tsx`
- Full package test run: 2,127 passed; three unrelated existing descendant-selector failures remain in `src/runtime/styles.test.ts`
- Agent evaluations were not run because they require separate approval