### PR TITLE
fix: close navigation overlays for anchor links

### DIFF
--- a/packages/sdk-components-react-radix/package.json
+++ b/packages/sdk-components-react-radix/package.json
@@ -39,6 +39,7 @@
     "build:args": "NODE_OPTIONS=--conditions=webstudio generate-arg-types './src/*.tsx !./src/*.stories.tsx !./src/*.ws.ts !./src/*.template.tsx !./src/*.test.{ts,tsx}' -e asChild -e modal -e defaultOpen -e defaultChecked && oxfmt \"**/*.props.ts\"",
     "build:stories": "tsx --conditions=webstudio src/generate-stories.ts && oxfmt \"src/__generated__/*.stories.tsx\"",
     "dts": "tsc --project tsconfig.dts.json",
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
@@ -65,6 +66,7 @@
     "await-interaction-response": "^0.0.2"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.2.0",
     "@types/react": "^18.2.70",
     "@types/react-dom": "^18.2.25",
     "@webstudio-is/css-data": "workspace:*",
@@ -74,6 +76,7 @@
     "@webstudio-is/template": "workspace:*",
     "@webstudio-is/tsconfig": "workspace:*",
     "react": "18.3.0-canary-14898b6a9-20240318",
-    "react-dom": "18.3.0-canary-14898b6a9-20240318"
+    "react-dom": "18.3.0-canary-14898b6a9-20240318",
+    "vitest": "^3.1.2"
   }
 }

--- a/packages/sdk-components-react-radix/src/dialog.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.tsx
@@ -16,43 +16,17 @@ import {
   getClosestInstance,
   type Hook,
 } from "@webstudio-is/react-sdk/runtime";
-
-/**
- * Naive heuristic to determine if a click event will cause navigate
- */
-const willNavigate = (event: MouseEvent) => {
-  const { target } = event;
-
-  if (target instanceof HTMLAnchorElement === false) {
-    return false;
-  }
-
-  if (target.hasAttribute("href") === false) {
-    return false;
-  }
-
-  if (target.href === "#") {
-    return false;
-  }
-
-  if (target.hasAttribute("target") && target.target === "_blank") {
-    return false;
-  }
-
-  if (event.ctrlKey || event.metaKey) {
-    return false;
-  }
-
-  return true;
-};
+import {
+  getLinkActivation,
+  NavigationOverlayContext,
+  useNavigationOverlay,
+} from "./navigation-overlay";
 
 // wrap in forwardRef because Root is functional component without ref
 export const Dialog = forwardRef<
   HTMLDivElement,
   Omit<ComponentProps<typeof DialogPrimitive.Root>, "defaultOpen">
 >((props, _ref) => {
-  const { renderer } = useContext(ReactSdkContext);
-
   const currentOpen = props.open ?? false;
   const [open, setOpen] = useState(currentOpen);
   // synchronize external value with local one when changed
@@ -62,45 +36,18 @@ export const Dialog = forwardRef<
     await interactionResponse();
     setOpen(open);
   }, []);
-
-  /**
-   * Close the dialog when a navigable link within it is clicked.
-   */
-  useEffect(() => {
-    if (renderer !== undefined) {
-      return;
-    }
-
-    if (open === false) {
-      return;
-    }
-
-    const handleClick = (event: MouseEvent) => {
-      const { target } = event;
-
-      if (willNavigate(event) === false) {
-        return;
-      }
-
-      if (target instanceof HTMLAnchorElement === false) {
-        return false;
-      }
-
-      if (target.closest('[role="dialog"]')) {
-        onOpenChangeHandler?.(false);
-      }
-    };
-
-    window.addEventListener("click", handleClick);
-    return () => window.removeEventListener("click", handleClick);
-  }, [open, onOpenChangeHandler, renderer]);
+  const close = useCallback(() => {
+    void onOpenChangeHandler(false);
+  }, [onOpenChangeHandler]);
 
   return (
-    <DialogPrimitive.Root
-      {...props}
-      onOpenChange={onOpenChangeHandler}
-      open={open}
-    />
+    <NavigationOverlayContext.Provider value={close}>
+      <DialogPrimitive.Root
+        {...props}
+        onOpenChange={onOpenChangeHandler}
+        open={open}
+      />
+    </NavigationOverlayContext.Provider>
   );
 });
 
@@ -137,45 +84,24 @@ export const DialogOverlay = forwardRef<
 export const DialogContent = forwardRef<
   HTMLDivElement,
   ComponentProps<typeof DialogPrimitive.Content>
->((props, ref) => {
+>(({ onClickCapture, onCloseAutoFocus, ...props }, ref) => {
   const preventAutoFocusOnClose = useRef(false);
   const { renderer } = useContext(ReactSdkContext);
-
-  /**
-   * Prevent focusing on the trigger after a navigable link in a dialog is clicked and closes the dialog.
-   */
-  useEffect(() => {
-    if (renderer !== undefined) {
-      return;
-    }
-
-    preventAutoFocusOnClose.current = false;
-
-    const handleClick = (event: MouseEvent) => {
-      const { target } = event;
-
-      if (willNavigate(event) === false) {
-        return;
-      }
-
-      if (target instanceof HTMLAnchorElement === false) {
-        return false;
-      }
-
-      if (target.closest('[role="dialog"]')) {
-        preventAutoFocusOnClose.current = true;
-      }
-    };
-
-    window.addEventListener("click", handleClick);
-    return () => window.removeEventListener("click", handleClick);
-  }, [renderer]);
+  const close = useNavigationOverlay();
 
   return (
     <DialogPrimitive.Content
       ref={ref}
       {...props}
+      onClickCapture={(event) => {
+        onClickCapture?.(event);
+        if (renderer === undefined && getLinkActivation(event)) {
+          preventAutoFocusOnClose.current = true;
+          close?.();
+        }
+      }}
       onCloseAutoFocus={(event) => {
+        onCloseAutoFocus?.(event);
         if (preventAutoFocusOnClose.current) {
           event.preventDefault();
         }

--- a/packages/sdk-components-react-radix/src/dialog.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.tsx
@@ -85,6 +85,8 @@ export const DialogContent = forwardRef<
   HTMLDivElement,
   ComponentProps<typeof DialogPrimitive.Content>
 >(({ onClickCapture, onCloseAutoFocus, ...props }, ref) => {
+  // Hash navigation keeps the page alive, so restoring focus to the trigger
+  // would pull focus away from the newly selected section.
   const preventAutoFocusOnClose = useRef(false);
   const { renderer } = useContext(ReactSdkContext);
   const close = useNavigationOverlay();
@@ -95,6 +97,7 @@ export const DialogContent = forwardRef<
       {...props}
       onClickCapture={(event) => {
         onClickCapture?.(event);
+        // Preview mirrors the published site; Canvas stays open for editing.
         if (renderer !== "canvas" && getLinkActivation(event)) {
           preventAutoFocusOnClose.current = true;
           close?.();

--- a/packages/sdk-components-react-radix/src/dialog.tsx
+++ b/packages/sdk-components-react-radix/src/dialog.tsx
@@ -95,7 +95,7 @@ export const DialogContent = forwardRef<
       {...props}
       onClickCapture={(event) => {
         onClickCapture?.(event);
-        if (renderer === undefined && getLinkActivation(event)) {
+        if (renderer !== "canvas" && getLinkActivation(event)) {
           preventAutoFocusOnClose.current = true;
           close?.();
         }

--- a/packages/sdk-components-react-radix/src/navigation-menu.tsx
+++ b/packages/sdk-components-react-radix/src/navigation-menu.tsx
@@ -4,7 +4,6 @@ import {
   type ComponentPropsWithoutRef,
   useCallback,
   useContext,
-  useEffect,
   useState,
 } from "react";
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
@@ -34,19 +33,21 @@ export const NavigationMenu = forwardRef<
    * This ensures "NavigationMenuViewport" always appears in the HTML tree.
    **/
   const { renderer } = useContext(ReactSdkContext);
-  const currentValue = propsValue ?? defaultValue ?? "";
-  const [openValue, setOpenValue] = useState(currentValue);
-  useEffect(() => setOpenValue(currentValue), [currentValue]);
+  const [uncontrolledValue, setUncontrolledValue] = useState(
+    () => defaultValue ?? ""
+  );
   const handleValueChange = useCallback(
     (value: string) => {
-      setOpenValue(value);
+      if (propsValue === undefined) {
+        setUncontrolledValue(value);
+      }
       onValueChange?.(value);
     },
-    [onValueChange]
+    [onValueChange, propsValue]
   );
   const close = useCallback(() => handleValueChange(""), [handleValueChange]);
 
-  let value = openValue;
+  let value = propsValue ?? uncontrolledValue;
   if (renderer === "canvas") {
     value = value === "" ? "-1" : value;
   }

--- a/packages/sdk-components-react-radix/src/navigation-menu.tsx
+++ b/packages/sdk-components-react-radix/src/navigation-menu.tsx
@@ -4,6 +4,7 @@ import {
   type ComponentPropsWithoutRef,
   useCallback,
   useContext,
+  useRef,
   useState,
 } from "react";
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
@@ -84,7 +85,7 @@ export const NavigationMenuContent = forwardRef<
         if (
           renderer === undefined &&
           anchor !== undefined &&
-          anchor.hasAttribute("data-radix-collection-item") === false
+          anchor.hasAttribute("data-ws-navigation-menu-link") === false
         ) {
           close?.();
         }
@@ -106,11 +107,27 @@ export const NavigationMenuItem = forwardRef<
 export const NavigationMenuLink = forwardRef<
   HTMLAnchorElement,
   ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Link>
->(({ children, ...props }, ref) => {
+>(({ children, onClickCapture, onSelect, ...props }, ref) => {
   const firstChild = Children.toArray(children)[0];
+  const shouldDismissRef = useRef(false);
 
   return (
-    <NavigationMenuPrimitive.Link asChild={true} ref={ref} {...props}>
+    <NavigationMenuPrimitive.Link
+      asChild={true}
+      ref={ref}
+      {...props}
+      data-ws-navigation-menu-link=""
+      onClickCapture={(event) => {
+        onClickCapture?.(event);
+        shouldDismissRef.current = getLinkActivation(event) !== undefined;
+      }}
+      onSelect={(event) => {
+        onSelect?.(event);
+        if (shouldDismissRef.current === false) {
+          event.preventDefault();
+        }
+      }}
+    >
       {firstChild ?? <a>Add link component</a>}
     </NavigationMenuPrimitive.Link>
   );

--- a/packages/sdk-components-react-radix/src/navigation-menu.tsx
+++ b/packages/sdk-components-react-radix/src/navigation-menu.tsx
@@ -82,6 +82,8 @@ export const NavigationMenuContent = forwardRef<
       onClickCapture={(event) => {
         onClickCapture?.(event);
         const anchor = getLinkActivation(event);
+        // Preview mirrors the published site; Canvas stays open for editing.
+        // Radix NavigationMenuLink dismisses itself; plain anchors do not.
         if (
           renderer !== "canvas" &&
           anchor !== undefined &&
@@ -109,6 +111,9 @@ export const NavigationMenuLink = forwardRef<
   ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Link>
 >(({ children, onClickCapture, onSelect, ...props }, ref) => {
   const firstChild = Children.toArray(children)[0];
+  // Radix only preserves the menu for Meta-clicks. Remember the browser-like
+  // activation decision so its custom select event can also preserve the menu
+  // for other modifiers, downloads, and links targeting another context.
   const shouldDismissRef = useRef(false);
 
   return (
@@ -124,6 +129,7 @@ export const NavigationMenuLink = forwardRef<
       onSelect={(event) => {
         onSelect?.(event);
         if (shouldDismissRef.current === false) {
+          // This cancels Radix's custom dismissal event, not native navigation.
           event.preventDefault();
         }
       }}

--- a/packages/sdk-components-react-radix/src/navigation-menu.tsx
+++ b/packages/sdk-components-react-radix/src/navigation-menu.tsx
@@ -2,7 +2,10 @@ import {
   Children,
   forwardRef,
   type ComponentPropsWithoutRef,
+  useCallback,
   useContext,
+  useEffect,
+  useState,
 } from "react";
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu";
 import { getIndexWithinAncestorFromProps } from "@webstudio-is/sdk/runtime";
@@ -11,6 +14,11 @@ import {
   ReactSdkContext,
   type Hook,
 } from "@webstudio-is/react-sdk/runtime";
+import {
+  getLinkActivation,
+  NavigationOverlayContext,
+  useNavigationOverlay,
+} from "./navigation-overlay";
 
 export const NavigationMenu = forwardRef<
   HTMLLIElement,
@@ -18,7 +26,7 @@ export const NavigationMenu = forwardRef<
     ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Root>,
     "orientation" | "aria-orientation"
   >
->(({ value: propsValue, ...props }, ref) => {
+>(({ value: propsValue, defaultValue, onValueChange, ...props }, ref) => {
   /**
    * If the value is an empty string, "NavigationMenuViewport" isn't in the tree.
    * This is Radix's way to differentiate animations. However, in the builder, we can't style non-existing elements.
@@ -26,18 +34,63 @@ export const NavigationMenu = forwardRef<
    * This ensures "NavigationMenuViewport" always appears in the HTML tree.
    **/
   const { renderer } = useContext(ReactSdkContext);
-  let value = propsValue;
+  const currentValue = propsValue ?? defaultValue ?? "";
+  const [openValue, setOpenValue] = useState(currentValue);
+  useEffect(() => setOpenValue(currentValue), [currentValue]);
+  const handleValueChange = useCallback(
+    (value: string) => {
+      setOpenValue(value);
+      onValueChange?.(value);
+    },
+    [onValueChange]
+  );
+  const close = useCallback(() => handleValueChange(""), [handleValueChange]);
+
+  let value = openValue;
   if (renderer === "canvas") {
     value = value === "" ? "-1" : value;
   }
 
-  return <NavigationMenuPrimitive.Root ref={ref} value={value} {...props} />;
+  return (
+    <NavigationOverlayContext.Provider value={close}>
+      <NavigationMenuPrimitive.Root
+        {...props}
+        ref={ref}
+        value={value}
+        onValueChange={handleValueChange}
+      />
+    </NavigationOverlayContext.Provider>
+  );
 });
 
 export const NavigationMenuList = NavigationMenuPrimitive.List;
 
 export const NavigationMenuViewport = NavigationMenuPrimitive.Viewport;
-export const NavigationMenuContent = NavigationMenuPrimitive.Content;
+export const NavigationMenuContent = forwardRef<
+  HTMLDivElement,
+  ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Content>
+>(({ onClickCapture, ...props }, ref) => {
+  const close = useNavigationOverlay();
+  const { renderer } = useContext(ReactSdkContext);
+
+  return (
+    <NavigationMenuPrimitive.Content
+      ref={ref}
+      {...props}
+      onClickCapture={(event) => {
+        onClickCapture?.(event);
+        const anchor = getLinkActivation(event);
+        if (
+          renderer === undefined &&
+          anchor !== undefined &&
+          anchor.hasAttribute("data-radix-collection-item") === false
+        ) {
+          close?.();
+        }
+      }}
+    />
+  );
+});
 
 export const NavigationMenuItem = forwardRef<
   HTMLLIElement,

--- a/packages/sdk-components-react-radix/src/navigation-menu.tsx
+++ b/packages/sdk-components-react-radix/src/navigation-menu.tsx
@@ -83,7 +83,7 @@ export const NavigationMenuContent = forwardRef<
         onClickCapture?.(event);
         const anchor = getLinkActivation(event);
         if (
-          renderer === undefined &&
+          renderer !== "canvas" &&
           anchor !== undefined &&
           anchor.hasAttribute("data-ws-navigation-menu-link") === false
         ) {

--- a/packages/sdk-components-react-radix/src/navigation-overlay.test.tsx
+++ b/packages/sdk-components-react-radix/src/navigation-overlay.test.tsx
@@ -311,3 +311,31 @@ test("keeps navigation overlays interactive on the builder canvas", () => {
 
   expect(screen.getByText("Destination")).toBeDefined();
 });
+
+test("closes navigation overlays in builder preview", () => {
+  render(
+    <ReactSdkContext.Provider
+      value={{
+        assetBaseUrl: "/",
+        imageLoader: ({ src }) => src,
+        resources: {},
+        breakpoints: [],
+        onError: () => {},
+        renderer: "preview",
+      }}
+    >
+      <Popover open>
+        <PopoverTrigger>
+          <button>Open</button>
+        </PopoverTrigger>
+        <PopoverContent>
+          <Link />
+        </PopoverContent>
+      </Popover>
+    </ReactSdkContext.Provider>
+  );
+
+  fireEvent.click(screen.getByText("Destination"));
+
+  expect(screen.queryByText("Destination")).toBeNull();
+});

--- a/packages/sdk-components-react-radix/src/navigation-overlay.test.tsx
+++ b/packages/sdk-components-react-radix/src/navigation-overlay.test.tsx
@@ -1,0 +1,171 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { forwardRef } from "react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, expect, test, vi } from "vitest";
+import { ReactSdkContext } from "@webstudio-is/react-sdk/runtime";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+} from "./dialog";
+import {
+  NavigationMenu,
+  NavigationMenuContent,
+  NavigationMenuItem,
+  NavigationMenuLink,
+  NavigationMenuList,
+  NavigationMenuTrigger,
+} from "./navigation-menu";
+import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+
+afterEach(cleanup);
+
+const Link = forwardRef<
+  HTMLAnchorElement,
+  { download?: boolean; href?: string; target?: string }
+>(({ download, href = "#destination", target, ...props }, ref) => (
+  <a {...props} download={download} href={href} ref={ref} target={target}>
+    <span>Destination</span>
+  </a>
+));
+
+test("closes a popover when a nested link element is activated", () => {
+  render(
+    <Popover open>
+      <PopoverTrigger>
+        <button>Open</button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <Link />
+      </PopoverContent>
+    </Popover>
+  );
+
+  fireEvent.click(screen.getByText("Destination"));
+
+  expect(screen.queryByText("Destination")).toBeNull();
+});
+
+test("closes a navigation menu when a plain link is activated", () => {
+  const onValueChange = vi.fn();
+  render(
+    <NavigationMenu value="menu" onValueChange={onValueChange}>
+      <NavigationMenuList>
+        <NavigationMenuItem value="menu">
+          <NavigationMenuTrigger>
+            <button>Menu</button>
+          </NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <Link />
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  );
+
+  fireEvent.click(screen.getByText("Destination"));
+
+  expect(screen.queryByText("Destination")).toBeNull();
+  expect(onValueChange).toHaveBeenCalledExactlyOnceWith("");
+});
+
+test("preserves Navigation Menu Link dismissal behavior", () => {
+  const onValueChange = vi.fn();
+  render(
+    <NavigationMenu value="menu" onValueChange={onValueChange}>
+      <NavigationMenuList>
+        <NavigationMenuItem value="menu">
+          <NavigationMenuTrigger>
+            <button>Menu</button>
+          </NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <NavigationMenuLink>
+              <Link />
+            </NavigationMenuLink>
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  );
+
+  fireEvent.click(screen.getByText("Destination"));
+
+  expect(screen.queryByText("Destination")).toBeNull();
+  expect(onValueChange).toHaveBeenCalledExactlyOnceWith("");
+});
+
+test("closes a dialog when a nested link element is activated", async () => {
+  render(
+    <Dialog open>
+      <DialogContent>
+        <DialogTitle>Navigation</DialogTitle>
+        <DialogDescription>Choose a destination</DialogDescription>
+        <Link />
+      </DialogContent>
+    </Dialog>
+  );
+
+  fireEvent.click(screen.getByText("Destination"));
+
+  await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+});
+
+test.each([
+  ["a modified click", { ctrlKey: true }, {}],
+  ["a non-primary click", { button: 1 }, {}],
+  ["a download", {}, { download: true }],
+  ["a link opening another context", {}, { target: "_blank" }],
+  ["an empty fragment", {}, { href: "#" }],
+] as const)("keeps a popover open for %s", (_name, eventInit, linkProps) => {
+  render(
+    <Popover open>
+      <PopoverTrigger>
+        <button>Open</button>
+      </PopoverTrigger>
+      <PopoverContent>
+        <Link {...linkProps} />
+      </PopoverContent>
+    </Popover>
+  );
+
+  fireEvent.click(screen.getByText("Destination"), eventInit);
+
+  expect(screen.getByText("Destination")).toBeDefined();
+});
+
+test("keeps navigation overlays interactive on the builder canvas", () => {
+  render(
+    <ReactSdkContext.Provider
+      value={{
+        assetBaseUrl: "/",
+        imageLoader: ({ src }) => src,
+        resources: {},
+        breakpoints: [],
+        onError: () => {},
+        renderer: "canvas",
+      }}
+    >
+      <Popover open>
+        <PopoverTrigger>
+          <button>Open</button>
+        </PopoverTrigger>
+        <PopoverContent>
+          <Link />
+        </PopoverContent>
+      </Popover>
+    </ReactSdkContext.Provider>
+  );
+
+  fireEvent.click(screen.getByText("Destination"));
+
+  expect(screen.getByText("Destination")).toBeDefined();
+});

--- a/packages/sdk-components-react-radix/src/navigation-overlay.test.tsx
+++ b/packages/sdk-components-react-radix/src/navigation-overlay.test.tsx
@@ -259,6 +259,31 @@ test.each([
   expect(screen.getByText("Destination")).toBeDefined();
 });
 
+test("keeps a popover open when the document target opens another context", () => {
+  const base = document.createElement("base");
+  base.target = "_blank";
+  document.head.append(base);
+
+  try {
+    render(
+      <Popover open>
+        <PopoverTrigger>
+          <button>Open</button>
+        </PopoverTrigger>
+        <PopoverContent>
+          <Link />
+        </PopoverContent>
+      </Popover>
+    );
+
+    fireEvent.click(screen.getByText("Destination"));
+
+    expect(screen.getByText("Destination")).toBeDefined();
+  } finally {
+    base.remove();
+  }
+});
+
 test("keeps navigation overlays interactive on the builder canvas", () => {
   render(
     <ReactSdkContext.Provider

--- a/packages/sdk-components-react-radix/src/navigation-overlay.test.tsx
+++ b/packages/sdk-components-react-radix/src/navigation-overlay.test.tsx
@@ -16,6 +16,7 @@ import {
   DialogContent,
   DialogDescription,
   DialogTitle,
+  DialogTrigger,
 } from "./dialog";
 import {
   NavigationMenu,
@@ -26,8 +27,12 @@ import {
   NavigationMenuTrigger,
 } from "./navigation-menu";
 import { Popover, PopoverContent, PopoverTrigger } from "./popover";
+import { getLinkActivation } from "./navigation-overlay";
 
-afterEach(cleanup);
+afterEach(() => {
+  cleanup();
+  window.history.replaceState(null, "", "/");
+});
 
 const Link = forwardRef<
   HTMLAnchorElement,
@@ -38,7 +43,7 @@ const Link = forwardRef<
   </a>
 ));
 
-test("closes a popover when a nested link element is activated", () => {
+test("closes a popover and preserves hash navigation", async () => {
   render(
     <Popover open>
       <PopoverTrigger>
@@ -53,12 +58,13 @@ test("closes a popover when a nested link element is activated", () => {
   fireEvent.click(screen.getByText("Destination"));
 
   expect(screen.queryByText("Destination")).toBeNull();
+  await waitFor(() => expect(window.location.hash).toBe("#destination"));
 });
 
 test("closes a navigation menu when a plain link is activated", () => {
   const onValueChange = vi.fn();
   render(
-    <NavigationMenu value="menu" onValueChange={onValueChange}>
+    <NavigationMenu defaultValue="menu" onValueChange={onValueChange}>
       <NavigationMenuList>
         <NavigationMenuItem value="menu">
           <NavigationMenuTrigger>
@@ -78,10 +84,34 @@ test("closes a navigation menu when a plain link is activated", () => {
   expect(onValueChange).toHaveBeenCalledExactlyOnceWith("");
 });
 
+test("preserves controlled Navigation Menu state", () => {
+  const onValueChange = vi.fn();
+  const menu = (
+    <NavigationMenu value="menu" onValueChange={onValueChange}>
+      <NavigationMenuList>
+        <NavigationMenuItem value="menu">
+          <NavigationMenuTrigger>
+            <button>Menu</button>
+          </NavigationMenuTrigger>
+          <NavigationMenuContent>
+            <Link />
+          </NavigationMenuContent>
+        </NavigationMenuItem>
+      </NavigationMenuList>
+    </NavigationMenu>
+  );
+  render(menu);
+
+  fireEvent.click(screen.getByText("Destination"));
+
+  expect(screen.getByText("Destination")).toBeDefined();
+  expect(onValueChange).toHaveBeenCalledExactlyOnceWith("");
+});
+
 test("preserves Navigation Menu Link dismissal behavior", () => {
   const onValueChange = vi.fn();
   render(
-    <NavigationMenu value="menu" onValueChange={onValueChange}>
+    <NavigationMenu defaultValue="menu" onValueChange={onValueChange}>
       <NavigationMenuList>
         <NavigationMenuItem value="menu">
           <NavigationMenuTrigger>
@@ -106,6 +136,9 @@ test("preserves Navigation Menu Link dismissal behavior", () => {
 test("closes a dialog when a nested link element is activated", async () => {
   render(
     <Dialog open>
+      <DialogTrigger>
+        <button>Open navigation</button>
+      </DialogTrigger>
       <DialogContent>
         <DialogTitle>Navigation</DialogTitle>
         <DialogDescription>Choose a destination</DialogDescription>
@@ -117,7 +150,60 @@ test("closes a dialog when a nested link element is activated", async () => {
   fireEvent.click(screen.getByText("Destination"));
 
   await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+  expect(document.activeElement).not.toBe(
+    screen.getByRole("button", { name: "Open navigation" })
+  );
 });
+
+test.each(["_parent", "_top"])(
+  "closes an overlay for target=%s in the top-level context",
+  (target) => {
+    render(
+      <Popover open>
+        <PopoverTrigger>
+          <button>Open</button>
+        </PopoverTrigger>
+        <PopoverContent>
+          <Link target={target} />
+        </PopoverContent>
+      </Popover>
+    );
+
+    fireEvent.click(screen.getByText("Destination"));
+
+    expect(screen.queryByText("Destination")).toBeNull();
+  }
+);
+
+test.each(["_parent", "_top"])(
+  "keeps an overlay open for target=%s in a child context",
+  (target) => {
+    const iframe = document.createElement("iframe");
+    document.body.append(iframe);
+    const iframeDocument = iframe.contentDocument;
+    if (iframeDocument === null) {
+      throw new Error("Expected iframe document");
+    }
+    const anchor = iframeDocument.createElement("a");
+    const child = iframeDocument.createElement("span");
+    anchor.setAttribute("href", "#destination");
+    anchor.setAttribute("target", target);
+    anchor.append(child);
+
+    expect(
+      getLinkActivation({
+        target: child,
+        button: 0,
+        altKey: false,
+        ctrlKey: false,
+        metaKey: false,
+        shiftKey: false,
+      })
+    ).toBeUndefined();
+
+    iframe.remove();
+  }
+);
 
 test.each([
   ["a modified click", { ctrlKey: true }, {}],

--- a/packages/sdk-components-react-radix/src/navigation-overlay.test.tsx
+++ b/packages/sdk-components-react-radix/src/navigation-overlay.test.tsx
@@ -133,6 +133,37 @@ test("preserves Navigation Menu Link dismissal behavior", () => {
   expect(onValueChange).toHaveBeenCalledExactlyOnceWith("");
 });
 
+test.each([
+  ["a modified click", { ctrlKey: true }, {}],
+  ["a link opening another context", {}, { target: "_blank" }],
+] as const)(
+  "keeps a navigation menu open for %s",
+  (_name, eventInit, linkProps) => {
+    const onValueChange = vi.fn();
+    render(
+      <NavigationMenu defaultValue="menu" onValueChange={onValueChange}>
+        <NavigationMenuList>
+          <NavigationMenuItem value="menu">
+            <NavigationMenuTrigger>
+              <button>Menu</button>
+            </NavigationMenuTrigger>
+            <NavigationMenuContent>
+              <NavigationMenuLink>
+                <Link {...linkProps} />
+              </NavigationMenuLink>
+            </NavigationMenuContent>
+          </NavigationMenuItem>
+        </NavigationMenuList>
+      </NavigationMenu>
+    );
+
+    fireEvent.click(screen.getByText("Destination"), eventInit);
+
+    expect(screen.getByText("Destination")).toBeDefined();
+    expect(onValueChange).not.toHaveBeenCalled();
+  }
+);
+
 test("closes a dialog when a nested link element is activated", async () => {
   render(
     <Dialog open>

--- a/packages/sdk-components-react-radix/src/navigation-overlay.ts
+++ b/packages/sdk-components-react-radix/src/navigation-overlay.ts
@@ -1,0 +1,49 @@
+import {
+  createContext,
+  type MouseEvent as ReactMouseEvent,
+  useContext,
+} from "react";
+
+type LinkActivationEvent = Pick<
+  ReactMouseEvent,
+  "target" | "button" | "altKey" | "ctrlKey" | "metaKey" | "shiftKey"
+>;
+
+export const getLinkActivation = (event: LinkActivationEvent) => {
+  if (
+    event.button !== 0 ||
+    event.altKey ||
+    event.ctrlKey ||
+    event.metaKey ||
+    event.shiftKey ||
+    event.target instanceof Element === false
+  ) {
+    return;
+  }
+
+  const anchor = event.target.closest("a[href]");
+  if (anchor instanceof HTMLAnchorElement === false) {
+    return;
+  }
+
+  if (anchor.hasAttribute("download")) {
+    return;
+  }
+
+  const target = anchor.getAttribute("target")?.toLowerCase();
+  if (target !== undefined && target !== "" && target !== "_self") {
+    return;
+  }
+
+  if (anchor.getAttribute("href") === "#") {
+    return;
+  }
+
+  return anchor;
+};
+
+export const NavigationOverlayContext = createContext<(() => void) | undefined>(
+  undefined
+);
+
+export const useNavigationOverlay = () => useContext(NavigationOverlayContext);

--- a/packages/sdk-components-react-radix/src/navigation-overlay.ts
+++ b/packages/sdk-components-react-radix/src/navigation-overlay.ts
@@ -21,8 +21,11 @@ export const getLinkActivation = (event: LinkActivationEvent) => {
     return;
   }
 
-  const anchor = event.target.closest("a[href]");
-  if (anchor instanceof HTMLAnchorElement === false) {
+  const anchor = event.target.closest<HTMLAnchorElement>("a[href]");
+  if (
+    anchor === null ||
+    anchor.namespaceURI !== "http://www.w3.org/1999/xhtml"
+  ) {
     return;
   }
 
@@ -30,8 +33,18 @@ export const getLinkActivation = (event: LinkActivationEvent) => {
     return;
   }
 
-  const target = anchor.getAttribute("target")?.toLowerCase();
-  if (target !== undefined && target !== "" && target !== "_self") {
+  const target = anchor.getAttribute("target");
+  const targetKeyword = target?.toLowerCase();
+  const currentWindow = anchor.ownerDocument.defaultView;
+  const targetsCurrentContext =
+    target === null ||
+    target === "" ||
+    targetKeyword === "_self" ||
+    (targetKeyword === "_parent" && currentWindow?.parent === currentWindow) ||
+    (targetKeyword === "_top" && currentWindow?.top === currentWindow) ||
+    (targetKeyword?.startsWith("_") === false &&
+      target === currentWindow?.name);
+  if (targetsCurrentContext === false) {
     return;
   }
 

--- a/packages/sdk-components-react-radix/src/navigation-overlay.ts
+++ b/packages/sdk-components-react-radix/src/navigation-overlay.ts
@@ -33,6 +33,8 @@ export const getLinkActivation = (event: LinkActivationEvent) => {
     return;
   }
 
+  // An anchor without target inherits the first document-level <base target>.
+  // HTMLAnchorElement.target only exposes the anchor's own attribute.
   const target =
     anchor.getAttribute("target") ??
     anchor.ownerDocument
@@ -41,6 +43,8 @@ export const getLinkActivation = (event: LinkActivationEvent) => {
     null;
   const targetKeyword = target?.toLowerCase();
   const currentWindow = anchor.ownerDocument.defaultView;
+  // _parent and _top reuse the current context only at the top level. A named
+  // target does so only when it names the current window.
   const targetsCurrentContext =
     target === null ||
     target === "" ||

--- a/packages/sdk-components-react-radix/src/navigation-overlay.ts
+++ b/packages/sdk-components-react-radix/src/navigation-overlay.ts
@@ -33,7 +33,12 @@ export const getLinkActivation = (event: LinkActivationEvent) => {
     return;
   }
 
-  const target = anchor.getAttribute("target");
+  const target =
+    anchor.getAttribute("target") ??
+    anchor.ownerDocument
+      .querySelector<HTMLBaseElement>("base[target]")
+      ?.getAttribute("target") ??
+    null;
   const targetKeyword = target?.toLowerCase();
   const currentWindow = anchor.ownerDocument.defaultView;
   const targetsCurrentContext =

--- a/packages/sdk-components-react-radix/src/popover.tsx
+++ b/packages/sdk-components-react-radix/src/popover.tsx
@@ -83,7 +83,7 @@ export const PopoverContent = forwardRef<
           {...props}
           onClickCapture={(event) => {
             onClickCapture?.(event);
-            if (renderer === undefined && getLinkActivation(event)) {
+            if (renderer !== "canvas" && getLinkActivation(event)) {
               close?.();
             }
           }}

--- a/packages/sdk-components-react-radix/src/popover.tsx
+++ b/packages/sdk-components-react-radix/src/popover.tsx
@@ -83,6 +83,7 @@ export const PopoverContent = forwardRef<
           {...props}
           onClickCapture={(event) => {
             onClickCapture?.(event);
+            // Preview mirrors the published site; Canvas stays open for editing.
             if (renderer !== "canvas" && getLinkActivation(event)) {
               close?.();
             }

--- a/packages/sdk-components-react-radix/src/popover.tsx
+++ b/packages/sdk-components-react-radix/src/popover.tsx
@@ -5,9 +5,20 @@ import {
   Children,
   useState,
   useEffect,
+  useCallback,
+  useContext,
 } from "react";
 import * as PopoverPrimitive from "@radix-ui/react-popover";
-import { getClosestInstance, type Hook } from "@webstudio-is/react-sdk/runtime";
+import {
+  getClosestInstance,
+  ReactSdkContext,
+  type Hook,
+} from "@webstudio-is/react-sdk/runtime";
+import {
+  getLinkActivation,
+  NavigationOverlayContext,
+  useNavigationOverlay,
+} from "./navigation-overlay";
 
 // wrap in forwardRef because Root is functional component without ref
 export const Popover = forwardRef<
@@ -18,8 +29,11 @@ export const Popover = forwardRef<
   const [open, setOpen] = useState(currentOpen);
   // synchronize external value with local one when changed
   useEffect(() => setOpen(currentOpen), [currentOpen]);
+  const close = useCallback(() => setOpen(false), []);
   return (
-    <PopoverPrimitive.Root {...props} open={open} onOpenChange={setOpen} />
+    <NavigationOverlayContext.Provider value={close}>
+      <PopoverPrimitive.Root {...props} open={open} onOpenChange={setOpen} />
+    </NavigationOverlayContext.Provider>
   );
 });
 
@@ -47,19 +61,36 @@ export const PopoverContent = forwardRef<
   ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
 >(
   (
-    { sideOffset = 4, align = "center", hideWhenDetached = true, ...props },
+    {
+      sideOffset = 4,
+      align = "center",
+      hideWhenDetached = true,
+      onClickCapture,
+      ...props
+    },
     ref
-  ) => (
-    <PopoverPrimitive.Portal>
-      <PopoverPrimitive.Content
-        ref={ref}
-        align="center"
-        sideOffset={sideOffset}
-        hideWhenDetached={hideWhenDetached}
-        {...props}
-      />
-    </PopoverPrimitive.Portal>
-  )
+  ) => {
+    const close = useNavigationOverlay();
+    const { renderer } = useContext(ReactSdkContext);
+
+    return (
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          ref={ref}
+          align="center"
+          sideOffset={sideOffset}
+          hideWhenDetached={hideWhenDetached}
+          {...props}
+          onClickCapture={(event) => {
+            onClickCapture?.(event);
+            if (renderer === undefined && getLinkActivation(event)) {
+              close?.();
+            }
+          }}
+        />
+      </PopoverPrimitive.Portal>
+    );
+  }
 );
 
 export const PopoverClose = PopoverPrimitive.Close;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2866,6 +2866,9 @@ importers:
         specifier: ^0.0.2
         version: 0.0.2
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.2.0
+        version: 16.2.0(@testing-library/dom@10.4.0)(@types/react-dom@18.2.25)(@types/react@18.2.79)(react-dom@18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318))(react@18.3.0-canary-14898b6a9-20240318)
       '@types/react':
         specifier: ^18.2.70
         version: 18.2.79
@@ -2896,6 +2899,9 @@ importers:
       react-dom:
         specifier: 18.3.0-canary-14898b6a9-20240318
         version: 18.3.0-canary-14898b6a9-20240318(react@18.3.0-canary-14898b6a9-20240318)
+      vitest:
+        specifier: ^3.1.2
+        version: 3.1.2(@types/debug@4.1.12)(@types/node@22.13.10)(@vitest/browser@3.1.2)(jiti@2.4.2)(jsdom@20.0.3)(lightningcss@1.31.1)(msw@2.13.2(@types/node@22.13.10)(typescript@7.0.2))(tsx@4.19.3)(yaml@2.9.0)
 
   packages/sdk-components-react-remix:
     dependencies:


### PR DESCRIPTION
## Summary

- Close Popover, Navigation Menu, Dialog, and Sheet content when an ordinary same-context link is activated.
- Resolve nested text and icon clicks through the containing anchor.
- Keep modified clicks, downloads, empty fragments, new browsing contexts, and Builder canvas interactions unchanged.
- Preserve Dialog focus handling, controlled Navigation Menu behavior, and existing Navigation Menu Link dismissal.

## Technical choices

- Classify link activation once in the Radix package and share it across overlay components.
- Handle activation on each content component so portalled content closes its owning root without a global window listener.
- Close overlays based on link activation rather than route lifecycle, making hash-only, current-page hash, and cross-page links consistent.
- Preserve Navigation Menu's controlled `value` contract while using `defaultValue` only to initialize uncontrolled state.
- Resolve `_parent`, `_top`, and named targets against the anchor document's current browsing context.
- Do not prevent the link's default behavior; native hash scrolling and framework routing remain responsible for navigation.

## Compatibility

- No schema, migration, data, or public prop changes.
- Existing controlled and uncontrolled Navigation Menu behavior remains intact.
- Existing Navigation Menu Link behavior remains intact.
- Generated fixture inputs and outputs are unaffected.

## Checklist

- [x] Add shared same-context link activation rules.
- [x] Apply dismissal to Popover, Navigation Menu, Dialog, and Sheet runtime components.
- [x] Preserve Dialog focus restoration behavior.
- [x] Preserve controlled and uncontrolled Navigation Menu semantics.
- [x] Cover top-level and child browsing-context targets.
- [x] Assert native fragment navigation remains active.
- [x] Add component regression coverage and demonstrate fail/pass behavior.
- [x] Run targeted lint, tests, type checking, declaration generation, and package build.
- [x] Review documentation impact; no product documentation changes are required because this restores expected navigation behavior without changing the authoring interface.

## Verification

- `pnpm --filter @webstudio-is/sdk-components-react-radix test` — 15 tests passed.
- Regression demonstrations:
  - canceling default activation failed the hash assertion;
  - restoring Dialog trigger focus failed the focus assertion;
  - treating all non-`_self` targets as external failed the top-level `_parent` and `_top` assertions;
  - replacing the controlled value with local state failed the controlled Navigation Menu assertion.
- `pnpm --filter @webstudio-is/sdk-components-react-radix typecheck` — passed.
- `pnpm --filter @webstudio-is/sdk-components-react-radix dts` — passed.
- `pnpm --filter @webstudio-is/sdk-components-react-radix build` — passed.
- Targeted `oxlint --deny-warnings` — passed.
- `git diff --check` — passed.

## Known limitations

- Browser layout scrolling is not covered by a published-site E2E. Component tests verify the native fragment update, overlay state, and Dialog focus outcome directly.

Closes #6242
