### PR TITLE
fix: Retry bulk style deletions after conflicts

### DIFF
--- a/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
+++ b/packages/project-build/src/contracts/__generated__/runtime-operation-contracts.ts
@@ -62851,7 +62851,7 @@ export const runtimeOperationContractData = [
     ],
     writeNamespaces: ["styles"],
     invalidatesNamespaces: ["styles"],
-    retryOnConflict: false,
+    retryOnConflict: true,
     requiresConfirm: true,
   },
   {

--- a/packages/project-build/src/project-session.test.ts
+++ b/packages/project-build/src/project-session.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { encodeDataVariableId } from "@webstudio-is/sdk";
+import { encodeDataVariableId, getStyleDeclKey } from "@webstudio-is/sdk";
 import type { BuilderNamespace } from "./contracts/namespaces";
 import type { BuilderPatchTransaction } from "./contracts/patch";
 import {
@@ -27,6 +27,7 @@ import { build } from "./state/fixtures.test-utils";
 import { parseWebstudioJsxFragment } from "./runtime/jsx";
 import { executeBuilderRuntimeOperation } from "./runtime/registry";
 import type { BuilderRuntimeMutation } from "./runtime/mutation";
+import { createStyleDecl } from "./runtime/styles";
 
 const compatibilityVersion = "test-session";
 const compatibility: ProjectSessionCompatibility = {
@@ -47,6 +48,31 @@ const createSnapshot = (
     state,
     ...overrides,
   };
+};
+
+const createBulkStyleDeletionSnapshot = (version: number) => {
+  const snapshot = createSnapshot({ version });
+  const styleSourceId = "local-style-source";
+  snapshot.state.styleSources?.set(styleSourceId, {
+    id: styleSourceId,
+    type: "local",
+  });
+  snapshot.state.styleSourceSelections?.set("instance-root", {
+    instanceId: "instance-root",
+    values: [styleSourceId],
+  });
+  const deletions = Array.from({ length: 185 }, (_, index) => {
+    const property = `--variable-${index}`;
+    const declaration = createStyleDecl({
+      styleSourceId,
+      breakpointId: "base",
+      property,
+      value: { type: "keyword", value: "red" },
+    });
+    snapshot.state.styles?.set(getStyleDeclKey(declaration), declaration);
+    return { instanceId: "instance-root", property };
+  });
+  return { snapshot, deletions };
 };
 
 const createPersistedSnapshot = (
@@ -1251,6 +1277,47 @@ describe("project session", () => {
       ["pages", "instances", "dataSources"],
     ]);
     expect(transport.commits).toHaveLength(3);
+  });
+
+  test("retries a bulk CSS variable deletion after a conflict", async () => {
+    const local = createBulkStyleDeletionSnapshot(1);
+    const remote = createBulkStyleDeletionSnapshot(2);
+    const storage = createStorage(
+      createPersistedSnapshot({ version: 1, state: local.snapshot.state })
+    );
+    const transport = createMutableTransport(remote.snapshot);
+    const commitPatch = transport.commitPatch;
+    let attempts = 0;
+    transport.commitPatch = async (input) => {
+      attempts += 1;
+      if (attempts <= 2) {
+        throw Object.assign(new Error("Build version mismatch"), {
+          code: "CONFLICT",
+        });
+      }
+      return await commitPatch(input);
+    };
+    const session = createSession({ storage, transport });
+
+    await session.initialize();
+    const result = await session.mutate("styles.deleteDeclarations", {
+      deletions: local.deletions,
+    });
+
+    expect(result.state.committed).toBe(true);
+    expect(result.version).toBe(3);
+    expect(result.result.styleKeys).toHaveLength(185);
+    expect(result.diagnostics).toEqual([
+      expect.objectContaining({ level: "info", code: "CONFLICT_REFRESHED" }),
+      expect.objectContaining({ level: "info", code: "CONFLICT_RETRY" }),
+    ]);
+    expect(attempts).toBe(3);
+
+    const styles = await session.read<{ declarations: unknown[] }>(
+      "styles.getDeclarations",
+      { propertyFilter: "--", limit: 200 }
+    );
+    expect(styles.result.declarations).toEqual([]);
   });
 
   test("reports a project settings conflict retry as committed", async () => {

--- a/packages/project-build/src/runtime/registry.ts
+++ b/packages/project-build/src/runtime/registry.ts
@@ -1394,6 +1394,7 @@ export const builderRuntimeOperations = [
     mutationContract({
       readNamespaces: ["instances", ...styleNamespaces, "breakpoints"],
       writeNamespaces: ["styles"],
+      retryOnConflict: true,
     }),
     styles.styleDeleteDeclarationsInput,
     ({ state, input }) => styles.deleteStyleDeclarations(state, input)


### PR DESCRIPTION
Closes #6254

## Summary

- Mark `styles.deleteDeclarations` as safe to retry after a confirmed version conflict.
- Recompute the deletion against refreshed style namespaces before the retry.
- Add a regression covering 185 CSS custom-property declarations and the complete conflict/refresh/retry path.
- Regenerate the public runtime operation contract.

## Root cause and behavior

`delete-styles` already accepts and plans a 185-declaration payload. The failure occurs when the remote build changes between the session snapshot and the commit: the session refreshes, but the operation contract currently has `retryOnConflict: false`, so the atomic deletion returns uncommitted and the project version does not advance.

Style declaration deletion is retry-safe because the operation is recomputed from the refreshed snapshot and removes only exact declaration keys that still exist.

The released CLI already writes structured success and failure JSON to stdout; stderr contains lifecycle diagnostics. No stderr parsing change is needed in Webstudio. The issue's stderr acceptance criterion was LLM-authored without captured failure diagnostics in CLI 0.293.0.

## Tradeoffs and compatibility

- Retries only confirmed version conflicts.
- Ambiguous commit results are still not replayed.
- No schema, migration, or user-facing API shape changes.

## Checklist

- [x] Reproduce the 185-declaration CSS-variable deletion through the CLI/MCP dry-run path.
- [x] Reproduce the unchanged-version failure with a conflicting commit.
- [x] Verify the regression fails before the contract change and passes afterward.
- [x] Enable conflict retry for `styles.deleteDeclarations`.
- [x] Regenerate runtime operation contracts.
- [x] Review documentation impact; no documentation update is required for this reliability fix.
- [x] Verify fixture impact; no fixture inputs or outputs are affected.

## Verification

- `pnpm --filter @webstudio-is/project-build test` — 2,132 tests passed.
- `pnpm --filter @webstudio-is/project-build typecheck` — passed.
- Targeted oxlint on changed source/tests — passed.
- `pnpm check:generated-api` — passed; generated files are clean.
- Agent evaluations were not run because they require separate explicit approval.
