### PR TITLE
fix: Gate Builder releases on the published CLI contract

### DIFF
--- a/.github/actions/vercel/action.yaml
+++ b/.github/actions/vercel/action.yaml
@@ -134,6 +134,13 @@ runs:
 
       shell: bash
 
+    - name: Verify published CLI contract against staged Builder
+      if: ${{ inputs.production-staged == 'true' }}
+      run: pnpm --filter webstudio check:published-cli-contract
+      shell: bash
+      env:
+        WEBSTUDIO_CLI_CONTRACT_BUILDER_ORIGIN: ${{ steps.deploy.outputs.domain }}
+
     - name: Set Alias
       id: alias
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     outputs:
+      publish_attempted: ${{ steps.publish-attempted.outputs.value }}
       registry_baseline: ${{ steps.registry-baseline.outputs.value }}
       version: ${{ steps.version.outputs.value }}
     permissions:
@@ -106,6 +107,8 @@ jobs:
           EOF
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - id: publish-attempted
+        run: echo "value=true" >> "$GITHUB_OUTPUT"
       - run: pnpm -r publish --access public --no-git-checks
 
       - name: Wait for exact CLI registry artifact
@@ -158,6 +161,37 @@ jobs:
           name: cli-release-smoke-${{ needs.publish.outputs.version }}
           path: artifacts/cli-release-smoke.json
           if-no-files-found: error
+
+  rollback-cli-latest:
+    needs: [publish, release-smoke]
+    if: >-
+      ${{
+        always() &&
+        needs.publish.outputs.publish_attempted == 'true' &&
+        (needs.publish.result != 'success' || needs.release-smoke.result != 'success')
+      }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    environment:
+      name: development
+    steps:
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Restore previous CLI latest dist-tag
+        env:
+          FAILED_VERSION: ${{ needs.publish.outputs.version }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          REGISTRY_BASELINE: ${{ needs.publish.outputs.registry_baseline }}
+        run: |
+          npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
+          current_version=$(npm view webstudio@latest version)
+          if [ "$current_version" != "$FAILED_VERSION" ]; then
+            echo "webstudio@latest is now $current_version; not replacing it with the older rollback baseline."
+            exit 0
+          fi
+          npm dist-tag add "webstudio@$REGISTRY_BASELINE" latest
 
   publish-docs:
     needs: [release, publish]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     outputs:
-      publish_attempted: ${{ steps.publish-attempted.outputs.value }}
       registry_baseline: ${{ steps.registry-baseline.outputs.value }}
       version: ${{ steps.version.outputs.value }}
     permissions:
@@ -107,8 +106,6 @@ jobs:
           EOF
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - id: publish-attempted
-        run: echo "value=true" >> "$GITHUB_OUTPUT"
       - run: pnpm -r publish --access public --no-git-checks
 
       - name: Wait for exact CLI registry artifact
@@ -161,37 +158,6 @@ jobs:
           name: cli-release-smoke-${{ needs.publish.outputs.version }}
           path: artifacts/cli-release-smoke.json
           if-no-files-found: error
-
-  rollback-cli-latest:
-    needs: [publish, release-smoke]
-    if: >-
-      ${{
-        always() &&
-        needs.publish.outputs.publish_attempted == 'true' &&
-        (needs.publish.result != 'success' || needs.release-smoke.result != 'success')
-      }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    environment:
-      name: development
-    steps:
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-      - name: Restore previous CLI latest dist-tag
-        env:
-          FAILED_VERSION: ${{ needs.publish.outputs.version }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          REGISTRY_BASELINE: ${{ needs.publish.outputs.registry_baseline }}
-        run: |
-          npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
-          current_version=$(npm view webstudio@latest version)
-          if [ "$current_version" != "$FAILED_VERSION" ]; then
-            echo "webstudio@latest is now $current_version; not replacing it with the older rollback baseline."
-            exit 0
-          fi
-          npm dist-tag add "webstudio@$REGISTRY_BASELINE" latest
 
   publish-docs:
     needs: [release, publish]

--- a/apps/builder/app/routes/rest.cli-compatibility.ts
+++ b/apps/builder/app/routes/rest.cli-compatibility.ts
@@ -1,0 +1,6 @@
+import { json } from "@remix-run/server-runtime";
+import { bundleVersion } from "@webstudio-is/protocol";
+import { privateNoStoreResponseHeaders } from "~/services/cache-control.server";
+
+export const loader = () =>
+  json({ bundleVersion }, { headers: privateNoStoreResponseHeaders });

--- a/apps/builder/app/services/api-compatibility.server.ts
+++ b/apps/builder/app/services/api-compatibility.server.ts
@@ -4,15 +4,25 @@ import {
   type ApiCompatibilityTarget,
 } from "@webstudio-is/trpc-interface/api-compatibility";
 
-export const throwApiClientUpdateRequired = (
-  target: ApiCompatibilityTarget
-): never => {
+export const throwApiClientUpdateRequired = ({
+  expectedVersion,
+  receivedVersion,
+  target,
+}: {
+  expectedVersion: string | number;
+  receivedVersion: string | number | undefined;
+  target: ApiCompatibilityTarget;
+}): never => {
+  const compatibility = createApiCompatibilityPayload({
+    reason: "clientVersionUnsupported",
+    target,
+  });
   throw new TRPCError({
     code: "PRECONDITION_FAILED",
     message: "The API client must be updated before continuing.",
-    cause: createApiCompatibilityPayload({
-      reason: "clientVersionUnsupported",
-      target,
-    }),
+    cause: {
+      ...compatibility,
+      message: `${compatibility.message} Expected bundle version ${expectedVersion}, received ${receivedVersion ?? "missing"}.`,
+    },
   });
 };

--- a/apps/builder/app/services/api-compatibility.server.ts
+++ b/apps/builder/app/services/api-compatibility.server.ts
@@ -17,12 +17,13 @@ export const throwApiClientUpdateRequired = ({
     reason: "clientVersionUnsupported",
     target,
   });
+  const message = `${compatibility.message} Expected bundle version ${expectedVersion}, received ${receivedVersion ?? "missing"}.`;
   throw new TRPCError({
     code: "PRECONDITION_FAILED",
-    message: "The API client must be updated before continuing.",
+    message,
     cause: {
       ...compatibility,
-      message: `${compatibility.message} Expected bundle version ${expectedVersion}, received ${receivedVersion ?? "missing"}.`,
+      message,
     },
   });
 };

--- a/apps/builder/app/services/build-router.server.test.ts
+++ b/apps/builder/app/services/build-router.server.test.ts
@@ -27,9 +27,24 @@ describe("build router project bundle compatibility", () => {
     expect(getApiCompatibilityPayload(error)).toMatchObject({
       reason: "clientVersionUnsupported",
       target: "cli",
+      message: `This version of the Webstudio CLI is incompatible with the current API. Expected bundle version ${bundleVersion}, received missing.`,
       action: { type: "updateCli" },
     });
     expect(() => assertCliBundleVersion(ctx, bundleVersion)).not.toThrow();
+  });
+
+  test("reports expected and received bundle contract versions", () => {
+    const ctx = { apiClient: { type: "cli" } } as never;
+    let error: unknown;
+    try {
+      assertCliBundleVersion(ctx, "bundle-client");
+    } catch (caught) {
+      error = caught;
+    }
+
+    expect(getApiCompatibilityPayload(error)?.message).toBe(
+      `This version of the Webstudio CLI is incompatible with the current API. Expected bundle version ${bundleVersion}, received bundle-client.`
+    );
   });
 
   test("removes agent instructions from non-CLI bundles", async () => {

--- a/apps/builder/app/services/build-router.server.test.ts
+++ b/apps/builder/app/services/build-router.server.test.ts
@@ -35,6 +35,7 @@ describe("build router project bundle compatibility", () => {
 
   test("reports expected and received bundle contract versions", () => {
     const ctx = { apiClient: { type: "cli" } } as never;
+    const message = `This version of the Webstudio CLI is incompatible with the current API. Expected bundle version ${bundleVersion}, received bundle-client.`;
     let error: unknown;
     try {
       assertCliBundleVersion(ctx, "bundle-client");
@@ -42,9 +43,8 @@ describe("build router project bundle compatibility", () => {
       error = caught;
     }
 
-    expect(getApiCompatibilityPayload(error)?.message).toBe(
-      `This version of the Webstudio CLI is incompatible with the current API. Expected bundle version ${bundleVersion}, received bundle-client.`
-    );
+    expect(error).toMatchObject({ message });
+    expect(getApiCompatibilityPayload(error)?.message).toBe(message);
   });
 
   test("removes agent instructions from non-CLI bundles", async () => {

--- a/apps/builder/app/services/build-router.server.ts
+++ b/apps/builder/app/services/build-router.server.ts
@@ -67,7 +67,11 @@ const assertCliBundleVersion = (
   clientBundleVersion: string | number | undefined
 ) => {
   if (ctx.apiClient?.type === "cli" && clientBundleVersion !== bundleVersion) {
-    throwApiClientUpdateRequired("cli");
+    throwApiClientUpdateRequired({
+      expectedVersion: bundleVersion,
+      receivedVersion: clientBundleVersion,
+      target: "cli",
+    });
   }
 };
 

--- a/apps/builder/app/services/cli-compatibility-route.node.test.ts
+++ b/apps/builder/app/services/cli-compatibility-route.node.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "vitest";
+import { bundleVersion } from "@webstudio-is/protocol";
+import { loader } from "~/routes/rest.cli-compatibility";
+
+test("reports the Builder runtime CLI contract without caching it", async () => {
+  const response = loader();
+
+  expect(response.status).toBe(200);
+  expect(response.headers.get("Cache-Control")).toContain("no-store");
+  await expect(response.json()).resolves.toEqual({ bundleVersion });
+});

--- a/apps/builder/e2e/tests/mdx-content-block.[shard-4].e2e.ts
+++ b/apps/builder/e2e/tests/mdx-content-block.[shard-4].e2e.ts
@@ -138,11 +138,9 @@ const insertTemplateIntoEmptyContentBlock = async ({
   await block.hover();
   const insert = page.getByRole("button", { name: "Insert block" }).last();
   await insert.waitFor({ state: "visible" });
-  await insert.focus();
-  await insert.press("Enter");
+  await insert.click();
   const menuItem = page.getByRole("menuitemradio", { name: templateName });
-  await menuItem.focus();
-  await page.keyboard.press("Enter");
+  await menuItem.press("Enter");
 };
 
 const openFixture = async ({

--- a/apps/builder/e2e/tests/mdx-content-block.[shard-4].e2e.ts
+++ b/apps/builder/e2e/tests/mdx-content-block.[shard-4].e2e.ts
@@ -140,7 +140,9 @@ const insertTemplateIntoEmptyContentBlock = async ({
   await insert.waitFor({ state: "visible" });
   await insert.focus();
   await insert.press("Enter");
-  await page.getByRole("menuitemradio", { name: templateName }).click();
+  const menuItem = page.getByRole("menuitemradio", { name: templateName });
+  await menuItem.focus();
+  await page.keyboard.press("Enter");
 };
 
 const openFixture = async ({

--- a/apps/builder/e2e/tests/mdx-content-block.[shard-4].e2e.ts
+++ b/apps/builder/e2e/tests/mdx-content-block.[shard-4].e2e.ts
@@ -140,9 +140,7 @@ const insertTemplateIntoEmptyContentBlock = async ({
   await insert.waitFor({ state: "visible" });
   await insert.focus();
   await insert.press("Enter");
-  await page
-    .getByRole("menuitemradio", { name: templateName })
-    .click({ force: true });
+  await page.getByRole("menuitemradio", { name: templateName }).click();
 };
 
 const openFixture = async ({

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
     "evaluations": "tsx --import ../../scripts/register-react-global.ts --conditions=webstudio evaluations/high-impact/run-local-agent.ts",
     "test": "vitest run",
     "test:ssg-package": "tsx --conditions=webstudio scripts/test-ssg-package.ts",
+    "check:published-cli-contract": "tsx --conditions=webstudio scripts/builder-contract-gate.ts",
     "test:release-smoke": "pnpm build && tsx --conditions=webstudio scripts/release-smoke.ts",
     "test:release-smoke:model": "WEBSTUDIO_RELEASE_SMOKE_MODEL_EVAL_REQUIRED=1 pnpm test:release-smoke",
     "test:release-smoke:registry": "tsx --conditions=webstudio scripts/release-smoke.ts"

--- a/packages/cli/scripts/builder-contract-gate.test.ts
+++ b/packages/cli/scripts/builder-contract-gate.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test, vi } from "vitest";
+import {
+  assertPublishedCliContract,
+  loadBuilderBundleVersion,
+} from "./builder-contract-gate";
+
+describe("published CLI contract gate", () => {
+  test("accepts the exact Builder bundle contract", () => {
+    expect(() =>
+      assertPublishedCliContract({
+        cliVersion: "0.293.0",
+        expectedVersion: "bundle-shared",
+        receivedVersion: "bundle-shared",
+      })
+    ).not.toThrow();
+  });
+
+  test("reports the expected and received bundle contracts", () => {
+    expect(() =>
+      assertPublishedCliContract({
+        cliVersion: "0.293.0",
+        expectedVersion: "bundle-builder",
+        receivedVersion: "bundle-cli",
+      })
+    ).toThrowError(
+      "Published CLI contract mismatch for webstudio@0.293.0. Expected bundle version bundle-builder, received bundle-cli. Publish a matching CLI before deploying Builder."
+    );
+  });
+
+  test("rejects a CLI that does not send a bundle contract", () => {
+    expect(() =>
+      assertPublishedCliContract({
+        cliVersion: "0.293.0",
+        expectedVersion: "bundle-builder",
+        receivedVersion: undefined,
+      })
+    ).toThrowError(
+      "Published CLI contract mismatch for webstudio@0.293.0. Expected bundle version bundle-builder, received missing. Publish a matching CLI before deploying Builder."
+    );
+  });
+
+  test("reads the contract from the staged Builder runtime", async () => {
+    const request = vi.fn(async () =>
+      Response.json({ bundleVersion: "bundle-runtime" })
+    );
+
+    await expect(
+      loadBuilderBundleVersion("https://candidate.example", {
+        attempts: 1,
+        request,
+      })
+    ).resolves.toBe("bundle-runtime");
+    expect(request).toHaveBeenCalledWith(
+      new URL("https://candidate.example/rest/cli-compatibility"),
+      expect.objectContaining({ cache: "no-store" })
+    );
+  });
+
+  test("rejects an invalid staged Builder contract response", async () => {
+    const request = vi.fn(async () => Response.json({}));
+
+    await expect(
+      loadBuilderBundleVersion("https://candidate.example", {
+        attempts: 1,
+        request,
+      })
+    ).rejects.toThrowError(
+      "Could not read the CLI contract from https://candidate.example/rest/cli-compatibility after 1 attempt: Builder CLI compatibility response has no bundle version."
+    );
+  });
+});

--- a/packages/cli/scripts/builder-contract-gate.ts
+++ b/packages/cli/scripts/builder-contract-gate.ts
@@ -1,0 +1,197 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+import { bundleVersion } from "@webstudio-is/protocol";
+import { createPublishedProjectBundleFixture } from "@webstudio-is/protocol/fixtures";
+import { resolveRegistryTarget } from "./release-smoke-registry";
+import { startRuntimeFixtureApi } from "./runtime-fixture-api";
+
+const execFileAsync = promisify(execFile);
+
+export const assertPublishedCliContract = ({
+  cliVersion,
+  expectedVersion,
+  receivedVersion,
+}: {
+  cliVersion: string;
+  expectedVersion: string | number;
+  receivedVersion: string | number | undefined;
+}) => {
+  if (receivedVersion === expectedVersion) {
+    return;
+  }
+  throw new Error(
+    `Published CLI contract mismatch for webstudio@${cliVersion}. Expected bundle version ${expectedVersion}, received ${receivedVersion ?? "missing"}. Publish a matching CLI before deploying Builder.`
+  );
+};
+
+const readBundleVersion = (input: unknown) => {
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    return;
+  }
+  const value = (input as { bundleVersion?: unknown }).bundleVersion;
+  return typeof value === "string" || typeof value === "number"
+    ? value
+    : undefined;
+};
+
+const readNpmJson = async (args: string[]) =>
+  JSON.parse((await execFileAsync("npm", args)).stdout) as unknown;
+
+const contractEndpointPath = "/rest/cli-compatibility";
+const defaultDelay = () =>
+  new Promise<void>((resolveDelay) => setTimeout(resolveDelay, 3_000));
+
+export const loadBuilderBundleVersion = async (
+  origin: string,
+  {
+    attempts = 10,
+    delay = defaultDelay,
+    request = fetch,
+  }: {
+    attempts?: number;
+    delay?: () => Promise<void>;
+    request?: typeof fetch;
+  } = {}
+) => {
+  const endpoint = new URL(contractEndpointPath, origin);
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      const response = await request(endpoint, {
+        cache: "no-store",
+        headers: { Accept: "application/json" },
+        signal: AbortSignal.timeout(10_000),
+      });
+      if (response.ok === false) {
+        throw new Error(
+          `Builder CLI compatibility endpoint returned HTTP ${response.status}.`
+        );
+      }
+      const data = (await response.json()) as unknown;
+      const receivedVersion = readBundleVersion(data);
+      if (receivedVersion === undefined) {
+        throw new Error(
+          "Builder CLI compatibility response has no bundle version."
+        );
+      }
+      return receivedVersion;
+    } catch (error) {
+      lastError = error;
+      if (attempt < attempts) {
+        await delay();
+      }
+    }
+  }
+  const message =
+    lastError instanceof Error ? lastError.message : String(lastError);
+  throw new Error(
+    `Could not read the CLI contract from ${endpoint.href} after ${attempts} ${attempts === 1 ? "attempt" : "attempts"}: ${message}`,
+    { cause: lastError }
+  );
+};
+
+export const checkPublishedCliContract = async ({
+  builderOrigin,
+  expectedVersion,
+  registrySpec = "webstudio@latest",
+}: {
+  builderOrigin?: string;
+  expectedVersion?: string | number;
+  registrySpec?: string;
+} = {}) => {
+  const resolvedExpectedVersion =
+    expectedVersion ??
+    (builderOrigin === undefined
+      ? bundleVersion
+      : await loadBuilderBundleVersion(builderOrigin));
+  const target = await resolveRegistryTarget(registrySpec, {
+    attempts: 3,
+    readNpmJson,
+  });
+  const directory = await mkdtemp(join(tmpdir(), "webstudio-contract-gate-"));
+  let receivedVersion: string | number | undefined;
+  let fixtureOrigin = "";
+  try {
+    const fixtureApi = await startRuntimeFixtureApi(
+      async ({ operationPath, readInput }) => {
+        if (operationPath !== "build.loadProjectBundleByBuildId") {
+          throw new Error(`Unexpected CLI probe operation ${operationPath}.`);
+        }
+        receivedVersion = readBundleVersion(await readInput());
+        return createPublishedProjectBundleFixture({ origin: fixtureOrigin });
+      }
+    );
+    fixtureOrigin = fixtureApi.origin;
+    try {
+      await mkdir(join(directory, ".webstudio"), { recursive: true });
+      let probeError: unknown;
+      try {
+        await execFileAsync(
+          "npm",
+          [
+            "exec",
+            "--yes",
+            "--package",
+            target.installSpec,
+            "--",
+            "webstudio",
+            "sync",
+            "--buildId",
+            "contract-probe",
+            "--origin",
+            fixtureApi.origin,
+            "--authToken",
+            "contract-probe",
+          ],
+          {
+            cwd: directory,
+            maxBuffer: 20 * 1024 * 1024,
+            timeout: 5 * 60_000,
+          }
+        );
+      } catch (error) {
+        probeError = error;
+      }
+
+      assertPublishedCliContract({
+        cliVersion: target.version,
+        expectedVersion: resolvedExpectedVersion,
+        receivedVersion,
+      });
+      if (probeError !== undefined) {
+        const stderr =
+          typeof probeError === "object" &&
+          probeError !== null &&
+          "stderr" in probeError &&
+          typeof probeError.stderr === "string"
+            ? probeError.stderr.trim()
+            : "";
+        throw new Error(
+          `Published CLI webstudio@${target.version} sent the expected bundle version ${resolvedExpectedVersion} but could not complete the read-only sync probe: ${stderr || (probeError instanceof Error ? probeError.message : String(probeError))}`,
+          { cause: probeError }
+        );
+      }
+      console.info(
+        `Published CLI webstudio@${target.version} matches Builder bundle version ${resolvedExpectedVersion}.`
+      );
+    } finally {
+      await fixtureApi.close();
+    }
+  } finally {
+    await rm(directory, { force: true, recursive: true });
+  }
+};
+
+const entrypoint = process.argv[1];
+if (
+  entrypoint !== undefined &&
+  import.meta.url === pathToFileURL(resolve(entrypoint)).href
+) {
+  await checkPublishedCliContract({
+    builderOrigin: process.env.WEBSTUDIO_CLI_CONTRACT_BUILDER_ORIGIN,
+  });
+}

--- a/packages/cli/scripts/builder-contract-gate.ts
+++ b/packages/cli/scripts/builder-contract-gate.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
-import { bundleVersion } from "@webstudio-is/protocol";
+import { getBundleVersion } from "@webstudio-is/protocol";
 import { createPublishedProjectBundleFixture } from "@webstudio-is/protocol/fixtures";
 import { resolveRegistryTarget } from "./release-smoke-registry";
 import { startRuntimeFixtureApi } from "./runtime-fixture-api";
@@ -26,16 +26,6 @@ export const assertPublishedCliContract = ({
   throw new Error(
     `Published CLI contract mismatch for webstudio@${cliVersion}. Expected bundle version ${expectedVersion}, received ${receivedVersion ?? "missing"}. Publish a matching CLI before deploying Builder.`
   );
-};
-
-const readBundleVersion = (input: unknown) => {
-  if (typeof input !== "object" || input === null || Array.isArray(input)) {
-    return;
-  }
-  const value = (input as { bundleVersion?: unknown }).bundleVersion;
-  return typeof value === "string" || typeof value === "number"
-    ? value
-    : undefined;
 };
 
 const readNpmJson = async (args: string[]) =>
@@ -72,7 +62,7 @@ export const loadBuilderBundleVersion = async (
         );
       }
       const data = (await response.json()) as unknown;
-      const receivedVersion = readBundleVersion(data);
+      const receivedVersion = getBundleVersion(data);
       if (receivedVersion === undefined) {
         throw new Error(
           "Builder CLI compatibility response has no bundle version."
@@ -94,21 +84,13 @@ export const loadBuilderBundleVersion = async (
   );
 };
 
-export const checkPublishedCliContract = async ({
+const checkPublishedCliContract = async ({
   builderOrigin,
-  expectedVersion,
-  registrySpec = "webstudio@latest",
 }: {
-  builderOrigin?: string;
-  expectedVersion?: string | number;
-  registrySpec?: string;
-} = {}) => {
-  const resolvedExpectedVersion =
-    expectedVersion ??
-    (builderOrigin === undefined
-      ? bundleVersion
-      : await loadBuilderBundleVersion(builderOrigin));
-  const target = await resolveRegistryTarget(registrySpec, {
+  builderOrigin: string;
+}) => {
+  const expectedVersion = await loadBuilderBundleVersion(builderOrigin);
+  const target = await resolveRegistryTarget("webstudio@latest", {
     attempts: 3,
     readNpmJson,
   });
@@ -121,7 +103,7 @@ export const checkPublishedCliContract = async ({
         if (operationPath !== "build.loadProjectBundleByBuildId") {
           throw new Error(`Unexpected CLI probe operation ${operationPath}.`);
         }
-        receivedVersion = readBundleVersion(await readInput());
+        receivedVersion = getBundleVersion(await readInput());
         return createPublishedProjectBundleFixture({ origin: fixtureOrigin });
       }
     );
@@ -159,7 +141,7 @@ export const checkPublishedCliContract = async ({
 
       assertPublishedCliContract({
         cliVersion: target.version,
-        expectedVersion: resolvedExpectedVersion,
+        expectedVersion,
         receivedVersion,
       });
       if (probeError !== undefined) {
@@ -171,12 +153,12 @@ export const checkPublishedCliContract = async ({
             ? probeError.stderr.trim()
             : "";
         throw new Error(
-          `Published CLI webstudio@${target.version} sent the expected bundle version ${resolvedExpectedVersion} but could not complete the read-only sync probe: ${stderr || (probeError instanceof Error ? probeError.message : String(probeError))}`,
+          `Published CLI webstudio@${target.version} sent the expected bundle version ${expectedVersion} but could not complete the read-only sync probe: ${stderr || (probeError instanceof Error ? probeError.message : String(probeError))}`,
           { cause: probeError }
         );
       }
       console.info(
-        `Published CLI webstudio@${target.version} matches Builder bundle version ${resolvedExpectedVersion}.`
+        `Published CLI webstudio@${target.version} matches Builder bundle version ${expectedVersion}.`
       );
     } finally {
       await fixtureApi.close();
@@ -191,7 +173,13 @@ if (
   entrypoint !== undefined &&
   import.meta.url === pathToFileURL(resolve(entrypoint)).href
 ) {
+  const builderOrigin = process.env.WEBSTUDIO_CLI_CONTRACT_BUILDER_ORIGIN;
+  if (builderOrigin === undefined || builderOrigin === "") {
+    throw new Error(
+      "WEBSTUDIO_CLI_CONTRACT_BUILDER_ORIGIN must identify the staged Builder deployment."
+    );
+  }
   await checkPublishedCliContract({
-    builderOrigin: process.env.WEBSTUDIO_CLI_CONTRACT_BUILDER_ORIGIN,
+    builderOrigin,
   });
 }


### PR DESCRIPTION
Closes #6280

## Summary

- Expose the deployed Builder's CLI-facing bundle contract through a non-cached, read-only endpoint.
- Resolve and execute the exact `webstudio@latest` registry artifact, observe the bundle version sent by its real `sync` request, and require an exact match before assigning the release staging alias.
- Include expected and received bundle versions in runtime and release-gate errors.

## Technical choices

- The existing generated `bundleVersion` remains the single compatibility boundary. Builder-only changes outside that project-bundle contract do not require a CLI release.
- The CLI sync probe runs against a local fixture API and temporary directory. It reads the deployed runtime contract but never reads or modifies a Cloud project.
- Verification runs after Vercel creates the exact production-built deployment and before the release staging alias is assigned. A mismatch therefore leaves production domains untouched.
- Registry resolution requires version and integrity metadata, then executes the resolved immutable version rather than source from the checkout.
- The gate requires the deployed Builder origin and cannot fall back to the checkout's contract.

## Todo

1. [x] Add the deployed Builder contract endpoint.
2. [x] Probe the exact published CLI through its real sync request.
3. [x] Gate the release staging alias on an exact contract match.
4. [x] Report expected and received versions for compatibility failures.
5. [x] Add regression tests and verify the production Builder build.
6. [x] Review documentation and fixture impact.

## Verification

- `pnpm --filter @webstudio-is/builder exec vitest run app/services/build-router.server.test.ts app/services/cli-compatibility-route.node.test.ts` — 12 passed.
- `pnpm --filter webstudio exec vitest run scripts/builder-contract-gate.test.ts scripts/release-smoke-registry.test.ts` — 7 passed.
- Rebased onto `main` at `9ec4c820e1`.
- Builder and CLI typechecks passed.
- `pnpm lint` and changed-file formatting passed.
- `pnpm --filter @webstudio-is/builder build` passed and emitted `/rest/cli-compatibility`.
- The changed GitHub Action parses as valid YAML.
- Real registry probe passed for `webstudio@0.293.0` against `bundle-kzb45v`.
- Real registry probe correctly blocked current Builder contract `bundle-1mym82p` and reported expected `bundle-1mym82p`, received `bundle-kzb45v`.
- Missing staged Builder origin fails closed before registry execution.
- GitHub CI passed all four workflows, including all six Builder E2E shards.
- The formerly failing empty-MDX insertion workflow passed 8 repeated runs with 4 workers locally, then passed in Builder E2E shard 4 in CI.
- Full browser-based release smoke was not run, per the request not to use Chrome. Agent evaluations were not run because no evaluation approval was requested or received.
- Documentation: no user-facing documentation changes are required.
- Fixtures/generated outputs: no fixture inputs or generated outputs are affected.

## Operational boundary

The check needs the exact deployed runtime, so Vercel creates an unaliased `--skip-domain` deployment before verification. A failed check cannot affect production domains or the normal release alias. Repository automation cannot prevent a Vercel administrator from manually promoting an arbitrary deployment outside this release path.