### PR TITLE
fix: Restore the login background gradient

### DIFF
--- a/apps/builder/app/auth/login.stories.tsx
+++ b/apps/builder/app/auth/login.stories.tsx
@@ -28,3 +28,6 @@ export const Auth: StoryFn<typeof LoginComponent> = () => {
     </StorySection>
   );
 };
+
+export const Dark = Auth.bind({});
+Dark.globals = { colorScheme: "dark" };

--- a/apps/builder/app/auth/login.tsx
+++ b/apps/builder/app/auth/login.tsx
@@ -56,6 +56,10 @@ export const Login = ({
           minWidth: theme.spacing[20],
           padding: theme.spacing[17],
           borderRadius: theme.spacing[5],
+          backgroundColor: `light-dark(
+            transparent,
+            ${cssVar("--background-primary")}
+          )`,
           [`@media (min-width: ${rawTheme.spacing[35]})`]: {
             backgroundColor: `light-dark(
               oklch(from ${cssVar("--background-primary")} l c h / 50%),

--- a/apps/builder/app/auth/login.tsx
+++ b/apps/builder/app/auth/login.tsx
@@ -7,12 +7,12 @@ import {
   Text,
   theme,
   cssVar,
+  webstudioBrand,
 } from "@webstudio-is/design-system";
 import { GithubIcon, GoogleIcon, WebstudioIcon } from "@webstudio-is/icons";
 import { Form } from "@remix-run/react";
 import { authPath } from "~/shared/router-utils";
 import { SecretLogin } from "./secret-login";
-import { brandColors } from "~/shared/brand-colors";
 
 const globalStyles = globalCss({
   body: {
@@ -44,7 +44,7 @@ export const Login = ({
       css={{
         height: "100vh",
         color: cssVar("--foreground-primary"),
-        background: brandColors.dashboard,
+        background: webstudioBrand.backgroundGradient,
       }}
     >
       <Flex
@@ -58,7 +58,7 @@ export const Login = ({
           borderRadius: theme.spacing[5],
           [`@media (min-width: ${rawTheme.spacing[35]})`]: {
             backgroundColor: `light-dark(
-              ${brandColors.panelTranslucent},
+              oklch(from ${cssVar("--background-primary")} l c h / 50%),
               ${cssVar("--background-primary")}
             )`,
           },

--- a/apps/builder/app/auth/login.tsx
+++ b/apps/builder/app/auth/login.tsx
@@ -44,10 +44,7 @@ export const Login = ({
       css={{
         height: "100vh",
         color: cssVar("--foreground-primary"),
-        background: `linear-gradient(
-          light-dark(transparent, ${cssVar("--overlay-scrim")}),
-          light-dark(transparent, ${cssVar("--overlay-scrim")})
-        ), ${brandColors.dashboard}`,
+        background: brandColors.dashboard,
       }}
     >
       <Flex

--- a/apps/builder/app/builder/shared/loading.tsx
+++ b/apps/builder/app/builder/shared/loading.tsx
@@ -5,10 +5,10 @@ import {
   Flex,
   Progress,
   theme,
+  webstudioBrand,
 } from "@webstudio-is/design-system";
 import { WebstudioIcon } from "@webstudio-is/icons";
 import { useInterval } from "~/shared/hook-utils/use-interval";
-import { brandColors } from "~/shared/brand-colors";
 
 export const LoadingBackground = ({
   show,
@@ -118,9 +118,9 @@ export const Loading = ({ state }: { state: LoadingState }) => {
               left: "50%",
               transform: "translate(-50%, -50%)",
               background: cssVar("--background-primary"),
-              boxShadow: brandColors.progressGlow,
+              boxShadow: webstudioBrand.progressShadow,
             }}
-            indicatorCss={{ background: brandColors.progress }}
+            indicatorCss={{ background: webstudioBrand.progressGradient }}
           />
         </Box>
       )}

--- a/apps/builder/app/dashboard/projects/project-card.tsx
+++ b/apps/builder/app/dashboard/projects/project-card.tsx
@@ -25,7 +25,6 @@ import { Card, CardContent, CardFooter } from "../shared/card";
 import type { User } from "~/shared/db/user.server";
 import { ProjectMenu } from "./project-menu";
 import { formatDate } from "./utils";
-import { brandColors } from "~/shared/brand-colors";
 
 const infoIconStyle = css({ flexShrink: 0, opacity: 0.8 });
 const prefetchImageBackground = declareCssVar(
@@ -159,7 +158,9 @@ export const ProjectCard = ({
                   color="contrast"
                   key={tag.id}
                   css={{
-                    background: brandColors.scrim,
+                    background: `oklch(from ${cssVar(
+                      "--overlay-scrim"
+                    )} l c h / 30%)`,
                     borderRadius: theme.borderRadius[3],
                     paddingInline: theme.spacing[3],
                   }}

--- a/apps/builder/app/shared/error/error-message.client.tsx
+++ b/apps/builder/app/shared/error/error-message.client.tsx
@@ -1,23 +1,27 @@
 import {
   AccessibleIcon,
   css,
+  cssVar,
   Grid,
   LinkButton,
   Text,
   theme,
+  webstudioBrand,
 } from "@webstudio-is/design-system";
 import { WebstudioIcon } from "@webstudio-is/icons";
-import { brandColors } from "~/shared/brand-colors";
 
 const pageStyle = css({
   position: "fixed",
   justifyItems: "center",
   alignContent: "start",
   inset: 0,
-  background: brandColors.dashboard,
+  background: webstudioBrand.backgroundGradient,
   paddingTop: "10vh",
   // prevent global root styles override error color
-  color: brandColors.foreground,
+  color: `light-dark(
+    ${cssVar("--foreground-primary")},
+    ${cssVar("--foreground-on-inverse")}
+  )`,
 });
 
 export const ErrorMessage = ({
@@ -57,7 +61,10 @@ export const ErrorMessage = ({
       >
         <Grid
           css={{
-            background: brandColors.panel,
+            background: `light-dark(
+              ${cssVar("--background-primary")},
+              ${cssVar("--background-inverse")}
+            )`,
             padding: theme.spacing[7],
             borderRadius: theme.spacing[5],
             minWidth: theme.spacing[34],

--- a/packages/design-system/src/brand.ts
+++ b/packages/design-system/src/brand.ts
@@ -1,13 +1,9 @@
-// Webstudio identity artwork is intentionally fixed and is not part of the
+// Fixed Webstudio identity artwork. These values do not follow the
 // user-selectable application theme.
-export const brandColors = {
-  dashboard:
+export const webstudioBrand = {
+  backgroundGradient:
     "radial-gradient(65.88% 47.48% at 50% 50%, #fff 0%, #fff0 100%), linear-gradient(0deg, #fff0 49.46%, #ffffff54 100%), linear-gradient(180deg, #ffae3c00 0%, #e63cfe54 100%), radial-gradient(211.58% 161.63% at 3.13% 100%, #ffae3c4d 0%, #e335ff00 100%), radial-gradient(107.1% 32.15% at 92.96% 5.04%, #35ffb633 0%, #4a4efa33 100%), #ebfffc",
-  foreground: "#000",
-  panel: "#fff",
-  panelTranslucent: "rgba(255, 255, 255, 0.5)",
-  scrim: "#0000004d",
-  progress:
+  progressGradient:
     "linear-gradient(90deg, #39fbbb00 0%, #39fbbb 20%, #4a4efa 40.03%, #e63cfe 60.02%, #ffae3c 80.04%, #ffae3c00 100%)",
-  progressGlow: "0 0 32px #4a4efa80",
+  progressShadow: "0 0 32px #4a4efa80",
 } as const;

--- a/packages/design-system/src/colors/README.md
+++ b/packages/design-system/src/colors/README.md
@@ -155,6 +155,13 @@ rejects duplicate declarations and conflicts with every variable in
 `colors.css`. An unregistered string is rejected by `cssVar()` without requiring
 component variable constants to be exported or imported.
 
+## Fixed brand artwork
+
+`webstudioBrand` exports fixed Webstudio identity gradients and effects that do
+not follow the user-selectable theme. It contains only brand-specific artwork.
+Generic surfaces, content, borders, and overlays must use semantic colors or
+derive a local composition from them instead of being added to the brand API.
+
 ## Validation and type generation
 
 Type generation parses CSS structurally and rejects:

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -2,6 +2,7 @@ export * from "./stitches.config";
 export { cssVar, declareCssVar } from "./css-var";
 export type { ThemeVariableName } from "./colors/__generated__/css-variable-names";
 export { rotateBoundedBackgroundHue } from "./color-utils";
+export { webstudioBrand } from "./brand";
 export { selectionBackground } from "./components/selection-color";
 export { chromeControlStyle } from "./components/chrome-control-style";
 export * from "./components/storybook";


### PR DESCRIPTION
## Summary

Restores the original Webstudio login gradient after the color-system migration added a dark scrim over it. Fixed Webstudio identity artwork now belongs to the Design System, while generic surfaces, content, translucency, and overlays use the semantic color system instead of a Builder-local brand color bag.

## Architecture

- The Design System exports only the fixed Webstudio background gradient, progress gradient, and progress shadow as brand artwork.
- Generic black, white, translucent panel, and scrim entries were removed rather than moved.
- Login and error surfaces use semantic light/dark pairings.
- Project-card tags derive their local 30% scrim from the semantic overlay color.

## Todo

- [x] Restore the original login gradient without a scheme-dependent scrim.
- [x] Move fixed identity artwork into the Design System package.
- [x] Remove the Builder-local brand color registry.
- [x] Replace generic fixed colors with semantic colors or local derivations.
- [x] Add explicit dark-mode Storybook coverage for the login screen.
- [x] Run Design System and Builder typechecks.
- [x] Run Design System tests, scoped lint, formatting, and package-boundary validation.
- [x] Review documentation impact and document ownership in the Design System color README.

## Verification

- Design System tests: 222 passed.
- Design System and Builder typechecks: passed.
- Scoped Oxlint and formatting: passed.
- Package-boundary validation: passed.
- Focused visual regression: 23 affected stories compared; the newly added dark login story is the only difference.
- Fixture impact: no fixture inputs or generated outputs are affected.

Ref #3818