### PR TITLE
fix: Share split button active state

### DIFF
--- a/packages/design-system/src/components/split-button.browser.test.tsx
+++ b/packages/design-system/src/components/split-button.browser.test.tsx
@@ -81,13 +81,6 @@ const renderSplitButton = ({
   };
 };
 
-const getSegmentBackgrounds = (buttons: HTMLButtonElement[]) =>
-  buttons.map(
-    (segment, index) =>
-      getComputedStyle(segment, index === 0 ? undefined : "::before")
-        .backgroundColor
-  );
-
 test("split button segments share hover in the real menu composition", async () => {
   for (const pressed of [false, true]) {
     const { buttons, container } = renderSplitButton({ pressed });
@@ -99,7 +92,11 @@ test("split button segments share hover in the real menu composition", async () 
     for (const button of buttons) {
       await page.elementLocator(button).hover();
 
-      const backgrounds = getSegmentBackgrounds(buttons);
+      const backgrounds = buttons.map(
+        (segment, index) =>
+          getComputedStyle(segment, index === 0 ? undefined : "::before")
+            .backgroundColor
+      );
       expect(backgrounds[0]).toBe(backgrounds[1]);
       expect(backgrounds[0]).not.toBe("rgba(0, 0, 0, 0)");
     }
@@ -110,7 +107,11 @@ test("split button segments share hover in the real menu composition", async () 
         y: buttons[0].getBoundingClientRect().height / 2,
       },
     });
-    const gapHoverBackgrounds = getSegmentBackgrounds(buttons);
+    const gapHoverBackgrounds = buttons.map(
+      (segment, index) =>
+        getComputedStyle(segment, index === 0 ? undefined : "::before")
+          .backgroundColor
+    );
     expect(gapHoverBackgrounds[0]).toBe(gapHoverBackgrounds[1]);
     expect(gapHoverBackgrounds[0]).not.toBe("rgba(0, 0, 0, 0)");
 
@@ -147,10 +148,14 @@ test("split button segments share hover in the real menu composition", async () 
 
 test("split button segments share the active state", () => {
   const { buttons } = renderSplitButton({ pressed: true });
-  const backgrounds = getSegmentBackgrounds(buttons);
+  const previewBackground = getComputedStyle(buttons[0]).backgroundColor;
+  const menuBackground = getComputedStyle(
+    buttons[1],
+    "::before"
+  ).backgroundColor;
 
-  expect(backgrounds[0]).toBe(backgrounds[1]);
-  expect(backgrounds[0]).not.toBe("rgba(0, 0, 0, 0)");
+  expect(menuBackground).toBe(previewBackground);
+  expect(menuBackground).not.toBe("rgba(0, 0, 0, 0)");
 });
 
 test("split button segments remain independently actionable", async () => {

--- a/packages/design-system/src/components/split-button.browser.test.tsx
+++ b/packages/design-system/src/components/split-button.browser.test.tsx
@@ -146,18 +146,6 @@ test("split button segments share hover in the real menu composition", async () 
   }
 });
 
-test("split button segments share the active state", () => {
-  const { buttons } = renderSplitButton({ pressed: true });
-  const previewBackground = getComputedStyle(buttons[0]).backgroundColor;
-  const menuBackground = getComputedStyle(
-    buttons[1],
-    "::before"
-  ).backgroundColor;
-
-  expect(menuBackground).toBe(previewBackground);
-  expect(menuBackground).not.toBe("rgba(0, 0, 0, 0)");
-});
-
 test("split button segments remain independently actionable", async () => {
   let previewClicks = 0;
   const { buttons } = renderSplitButton({

--- a/packages/design-system/src/components/split-button.browser.test.tsx
+++ b/packages/design-system/src/components/split-button.browser.test.tsx
@@ -81,6 +81,13 @@ const renderSplitButton = ({
   };
 };
 
+const getSegmentBackgrounds = (buttons: HTMLButtonElement[]) =>
+  buttons.map(
+    (segment, index) =>
+      getComputedStyle(segment, index === 0 ? undefined : "::before")
+        .backgroundColor
+  );
+
 test("split button segments share hover in the real menu composition", async () => {
   for (const pressed of [false, true]) {
     const { buttons, container } = renderSplitButton({ pressed });
@@ -92,11 +99,7 @@ test("split button segments share hover in the real menu composition", async () 
     for (const button of buttons) {
       await page.elementLocator(button).hover();
 
-      const backgrounds = buttons.map(
-        (segment, index) =>
-          getComputedStyle(segment, index === 0 ? undefined : "::before")
-            .backgroundColor
-      );
+      const backgrounds = getSegmentBackgrounds(buttons);
       expect(backgrounds[0]).toBe(backgrounds[1]);
       expect(backgrounds[0]).not.toBe("rgba(0, 0, 0, 0)");
     }
@@ -107,11 +110,7 @@ test("split button segments share hover in the real menu composition", async () 
         y: buttons[0].getBoundingClientRect().height / 2,
       },
     });
-    const gapHoverBackgrounds = buttons.map(
-      (segment, index) =>
-        getComputedStyle(segment, index === 0 ? undefined : "::before")
-          .backgroundColor
-    );
+    const gapHoverBackgrounds = getSegmentBackgrounds(buttons);
     expect(gapHoverBackgrounds[0]).toBe(gapHoverBackgrounds[1]);
     expect(gapHoverBackgrounds[0]).not.toBe("rgba(0, 0, 0, 0)");
 
@@ -144,6 +143,14 @@ test("split button segments share hover in the real menu composition", async () 
     act(() => root?.unmount());
     root = undefined;
   }
+});
+
+test("split button segments share the active state", () => {
+  const { buttons } = renderSplitButton({ pressed: true });
+  const backgrounds = getSegmentBackgrounds(buttons);
+
+  expect(backgrounds[0]).toBe(backgrounds[1]);
+  expect(backgrounds[0]).not.toBe("rgba(0, 0, 0, 0)");
 });
 
 test("split button segments remain independently actionable", async () => {

--- a/packages/design-system/src/components/split-button.tsx
+++ b/packages/design-system/src/components/split-button.tsx
@@ -14,11 +14,10 @@ export const SplitButton = styled("div", {
     borderTopLeftRadius: 0,
     borderBottomLeftRadius: 0,
   },
-  "&:has(> button:first-of-type[aria-pressed=true])": {
-    "> button:last-of-type:not(:disabled):not([aria-disabled=true])::before": {
+  "> button[aria-pressed=true] + button:not(:disabled):not([aria-disabled=true])::before":
+    {
       background: cssVar("--overlay-interaction-hover"),
     },
-  },
   "&:hover:not(:has(> button:disabled:hover, > button[aria-disabled=true]:hover))":
     {
       "> button:first-of-type:not(:disabled):not([aria-disabled=true])": {

--- a/packages/design-system/src/components/split-button.tsx
+++ b/packages/design-system/src/components/split-button.tsx
@@ -14,6 +14,11 @@ export const SplitButton = styled("div", {
     borderTopLeftRadius: 0,
     borderBottomLeftRadius: 0,
   },
+  "&:has(> button:first-of-type[aria-pressed=true])": {
+    "> button:last-of-type:not(:disabled):not([aria-disabled=true])::before": {
+      background: cssVar("--overlay-interaction-hover"),
+    },
+  },
   "&:hover:not(:has(> button:disabled:hover, > button[aria-disabled=true]:hover))":
     {
       "> button:first-of-type:not(:disabled):not([aria-disabled=true])": {


### PR DESCRIPTION
Ref #3818

## Summary

- Apply the primary toggle’s pressed surface to both split-button segments.
- Keep both buttons independently actionable and preserve their shared hover behavior.

## Implementation

The split-button directly styles the adjacent menu segment when the primary segment has `aria-pressed`. The menu segment keeps its separate action and expanded hit target, so Builder state and color logic are not duplicated.

## Todo

- [x] Share the active surface across both segments.
- [x] Preserve independent actions, disabled behavior, and shared hover behavior.
- [x] Verify light and dark Storybook rendering.
- [x] Run typecheck and lint.
- [x] Review documentation impact — no documentation changes are required for this restored component behavior.

## Verification

- `pnpm --filter @webstudio-is/design-system typecheck`
- `pnpm lint`

No fixture inputs or generated fixture outputs are affected.