### PR TITLE
fix: stabilize CLI bundle contract after publish

### DIFF
--- a/packages/cli/src/cli-bundle-externals.test.ts
+++ b/packages/cli/src/cli-bundle-externals.test.ts
@@ -9,6 +9,12 @@ describe("CLI bundle externals", () => {
     expect(isExternal("node:fs")).toBe(true);
   });
 
+  test("bundles project contract dependencies to prevent post-release version drift", () => {
+    expect(isExternal("zod")).toBe(false);
+    expect(isExternal("zod/v4")).toBe(false);
+    expect(isExternal("@emotion/hash")).toBe(false);
+  });
+
   test("bundles the component registry without publishing its React dependency tree", () => {
     expect(isExternal("@webstudio-is/sdk-components-registry/framework")).toBe(
       false

--- a/packages/cli/vite.config.ts
+++ b/packages/cli/vite.config.ts
@@ -16,7 +16,10 @@ const externalDependencies = new Set(
   })
 );
 
-const bundledDependencies = new Set(["acorn"]);
+// The project bundle contract is derived from Zod's schema definitions and
+// hashed at runtime. Keep both implementations in the published artifact so a
+// transitive dependency update cannot change bundleVersion after publication.
+const bundledDependencies = new Set(["@emotion/hash", "acorn", "zod"]);
 
 const getPackageName = (id: string) => {
   if (id.startsWith("@")) {


### PR DESCRIPTION
## Summary

- bundle Zod into the published CLI because `bundleVersion` derives from Zod schema internals
- bundle `@emotion/hash`, which produces the contract identifier
- prevent compatible dependency updates at install time from changing an already-published CLI's contract
- add regression coverage for the CLI bundling boundary

## Root cause

`webstudio@0.294.0` externalized `zod` and declared `^4.4.3`. The Builder was built with the lockfile version, while a fresh `npx webstudio@latest` installation resolved Zod 4.5.4. Because the project bundle contract is calculated at runtime from Zod definitions, the Builder expected `bundle-1mym82p` while the freshly installed CLI sent `bundle-8e39e9` despite both being the same Webstudio release.

## Packaged CLI reproduction

Tested the CLI built from the parent commit and this branch in the same isolated `webstudio@0.294.0` installation with Zod 4.5.4. Both builds executed the real local `webstudio sync` command against the same capture server.

- Before: `{"label":"before","zod":"4.5.4","bundleVersion":"bundle-8e39e9"}`
- After: `{"label":"after","zod":"4.5.4","bundleVersion":"bundle-1mym82p"}`
- Live Builder: `{"bundleVersion":"bundle-1mym82p"}`

The fixed local CLI now sends the exact contract required by the live Builder even though the install environment still contains Zod 4.5.4.

## Verification

- isolated before/after packaged CLI test through the real `sync` request path
- `pnpm --filter webstudio exec vitest run src/cli-bundle-externals.test.ts`
- `pnpm --filter webstudio typecheck`
- `pnpm --filter webstudio build`
- verified emitted CLI files contain no external imports from `zod` or `@emotion/hash`
- `pnpm exec oxfmt --check packages/cli/vite.config.ts packages/cli/src/cli-bundle-externals.test.ts`
- `git diff --check`