### PR TITLE
fix: tolerate duplicate props during JSX export

### DIFF
--- a/packages/react-sdk/src/component-generator.test.tsx
+++ b/packages/react-sdk/src/component-generator.test.tsx
@@ -205,6 +205,39 @@ test("generate jsx element with literal props", () => {
   );
 });
 
+test("deduplicates duplicate instance props when generating jsx", () => {
+  const data = renderData(<$.Image ws:id="image" width={100}></$.Image>);
+  const widthProp = Array.from(data.props.values()).find(
+    (prop) => prop.instanceId === "image" && prop.name === "width"
+  );
+  if (widthProp?.type !== "number") {
+    throw new Error("Expected Image width prop");
+  }
+  data.props.set("duplicate-width", {
+    ...widthProp!,
+    id: "duplicate-width",
+    value: 200,
+  });
+
+  expect(
+    generateJsxChildren({
+      scope: createScope(),
+      usedDataSources: new Map(),
+      indexesWithinAncestors: new Map(),
+      metas: new Map(),
+      children: [{ type: "id", value: "image" }],
+      ...data,
+    })
+  ).toEqual(
+    validateJSX(
+      clear(`
+      <Image
+      width={200} />
+    `)
+    )
+  );
+});
+
 test("ignore asset and page props", () => {
   expect(
     generateJsxChildren({

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -214,8 +214,17 @@ export const generateJsxElement = ({
   let collectionItemValue: undefined | string;
   let collectionItemKeyValue: undefined | string;
   let classNameValue: undefined | string;
-  const instanceProps = Array.from(props.values()).filter(
-    (prop) => prop.instanceId === instance.id
+  // Older projects can contain duplicate props after an asset-derived prop was
+  // persisted alongside the authored prop. Keep the last value for a prop
+  // name so malformed data cannot produce duplicate JSX attributes.
+  const instanceProps = Array.from(
+    Array.from(props.values())
+      .filter((prop) => prop.instanceId === instance.id)
+      .reduce((uniqueProps, prop) => {
+        uniqueProps.set(prop.name, prop);
+        return uniqueProps;
+      }, new Map<string, Prop>())
+      .values()
   );
   const instancePropNames = new Set(instanceProps.map((prop) => prop.name));
   const projectedResourceProps = new Map<string, unknown>();


### PR DESCRIPTION
## Summary

- tolerate duplicate persisted props during JSX generation
- preserve the last value for a duplicate prop name
- add regression coverage for duplicate Image width props

## Verification

- `pnpm --filter @webstudio-is/react-sdk exec vitest run src/component-generator.test.tsx --pool=forks`
- `pnpm --filter @webstudio-is/content-engine exec vitest run src/jsx-attributes.test.ts --pool=forks`
- `pnpm --filter @webstudio-is/react-sdk typecheck`