### PR TITLE
fix: Scaffold projects with attribute aliases

### DIFF
--- a/packages/react-sdk/src/component-generator.test.tsx
+++ b/packages/react-sdk/src/component-generator.test.tsx
@@ -1,6 +1,7 @@
 import { API, type Snapshot } from "typescript/unstable/sync";
 import { afterAll, beforeAll, expect, test } from "vitest";
 import stripIndent from "strip-indent";
+import { standardAttributesToReactProps } from "@webstudio-is/content-engine/jsx-attributes";
 import {
   createScope,
   elementComponent,
@@ -728,6 +729,13 @@ test("add classes", () => {
 
 test("merges class aliases when generating jsx", () => {
   const data = renderData(<$.Body ws:id="body" className="standard"></$.Body>);
+  data.props.set("duplicate-class", {
+    id: "duplicate-class",
+    instanceId: "body",
+    name: "class",
+    type: "string",
+    value: "replacement",
+  });
   data.props.set("legacy-class-name", {
     id: "legacy-class-name",
     instanceId: "body",
@@ -751,12 +759,67 @@ test("merges class aliases when generating jsx", () => {
       clear(`
         const Page = () => {
         return <Body
-        className={\`atomic \${"standard"} \${"legacy"}\`} />
+        className={\`atomic \${"replacement"} \${"legacy"}\`} />
         }
     `)
     )
   );
 });
+
+test.each(
+  Object.entries(standardAttributesToReactProps).filter(
+    ([standardName, jsxName]) =>
+      standardName !== "class" && standardName !== jsxName
+  )
+)(
+  "keeps the last value when %s and %s map to the same JSX prop",
+  (standardName, jsxName) => {
+    const generate = (attributes: [name: string, value: string][]) => {
+      const data = renderData(<$.Body ws:id="body"></$.Body>);
+      const instance = data.instances.get("body");
+      if (instance === undefined) {
+        throw new Error("Expected Body instance");
+      }
+      data.instances.set("body", { ...instance, tag: "div" });
+      for (const [index, [name, value]] of attributes.entries()) {
+        data.props.set(`${index}-${name}`, {
+          id: `${index}-${name}`,
+          instanceId: "body",
+          name,
+          type: "string",
+          value,
+        });
+      }
+      return generateJsxChildren({
+        scope: createScope(),
+        usedDataSources: new Map(),
+        indexesWithinAncestors: new Map(),
+        metas: new Map(),
+        children: [{ type: "id", value: "body" }],
+        ...data,
+      });
+    };
+    const expected = (value: string) =>
+      clear(`
+        <Body
+        data-ws-tag="div"
+        ${jsxName}={"${value}"} />
+      `);
+
+    expect(
+      generate([
+        [standardName, "standard"],
+        [jsxName, "jsx"],
+      ])
+    ).toBe(expected("jsx"));
+    expect(
+      generate([
+        [jsxName, "jsx"],
+        [standardName, "standard"],
+      ])
+    ).toBe(expected("standard"));
+  }
+);
 
 test("add bind classes and merge classes", () => {
   const hasClass2 = new Variable("variableName", false);

--- a/packages/react-sdk/src/component-generator.test.tsx
+++ b/packages/react-sdk/src/component-generator.test.tsx
@@ -726,6 +726,38 @@ test("add classes", () => {
   );
 });
 
+test("merges class aliases when generating jsx", () => {
+  const data = renderData(<$.Body ws:id="body" className="standard"></$.Body>);
+  data.props.set("legacy-class-name", {
+    id: "legacy-class-name",
+    instanceId: "body",
+    name: "className",
+    type: "string",
+    value: "legacy",
+  });
+
+  expect(
+    generateWebstudioComponent({
+      classesMap: new Map([["body", ["atomic"]]]),
+      scope: createScope(),
+      name: "Page",
+      rootInstanceId: "body",
+      parameters: [],
+      metas: new Map(),
+      ...data,
+    })
+  ).toEqual(
+    validateJSX(
+      clear(`
+        const Page = () => {
+        return <Body
+        className={\`atomic \${"standard"} \${"legacy"}\`} />
+        }
+    `)
+    )
+  );
+});
+
 test("add bind classes and merge classes", () => {
   const hasClass2 = new Variable("variableName", false);
   expect(

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -213,7 +213,7 @@ export const generateJsxElement = ({
   let collectionDataValue: undefined | string;
   let collectionItemValue: undefined | string;
   let collectionItemKeyValue: undefined | string;
-  let classNameValue: undefined | string;
+  const classNameValues: string[] = [];
   // Older projects can contain duplicate props after an asset-derived prop was
   // persisted alongside the authored prop. Keep the last value for a prop
   // name so malformed data cannot produce duplicate JSX attributes.
@@ -239,14 +239,27 @@ export const generateJsxElement = ({
       componentPropNames,
       acceptsHtmlAttributes,
     });
-  const generatedPropNames = new Map(
-    mapAttributeNames({
-      attributes: instanceProps.filter(({ name }) => isAttributeNameSafe(name)),
+  const safeInstanceProps = instanceProps.filter(({ name }) =>
+    isAttributeNameSafe(name)
+  );
+  // Class aliases can coexist because their values are merged into the single
+  // className attribute below. Keep rejecting every other mapped collision.
+  const classPropIds = new Set(
+    safeInstanceProps
+      .filter(({ name }) => getGeneratedPropName(name) === "className")
+      .map(({ id }) => id)
+  );
+  const generatedPropNames = new Map([
+    ...mapAttributeNames({
+      attributes: safeInstanceProps.filter(
+        ({ id }) => classPropIds.has(id) === false
+      ),
       direction: "instance-to-jsx",
       componentPropNames,
       acceptsHtmlAttributes,
-    }).map(({ id, name }) => [id, name])
-  );
+    }).map(({ id, name }) => [id, name] as const),
+    ...Array.from(classPropIds, (id) => [id, "className"] as const),
+  ]);
 
   for (const prop of instanceProps) {
     const propValue = generatePropValue({
@@ -306,7 +319,7 @@ export const generateJsxElement = ({
     // Merge atomic classes with the JSX className produced by the shared
     // instance-to-JSX property adapter.
     if (name === "className" && propValue !== undefined) {
-      classNameValue = propValue;
+      classNameValues.push(propValue);
       continue;
     }
     if (propValue !== undefined) {
@@ -320,9 +333,9 @@ export const generateJsxElement = ({
   }
 
   const classMapArray = classesMap?.get(instance.id);
-  if (classMapArray || classNameValue) {
+  if (classMapArray || classNameValues.length > 0) {
     let classNameTemplate = classMapArray ? classMapArray.join(" ") : "";
-    if (classNameValue) {
+    for (const classNameValue of classNameValues) {
       if (classNameTemplate) {
         classNameTemplate += " ";
       }

--- a/packages/react-sdk/src/component-generator.ts
+++ b/packages/react-sdk/src/component-generator.ts
@@ -25,10 +25,7 @@ import {
 } from "@webstudio-is/sdk";
 import { transpileExpression } from "@webstudio-is/expression";
 import { indexProperty, tagProperty } from "@webstudio-is/sdk/runtime";
-import {
-  getJsxPropName,
-  mapAttributeNames,
-} from "@webstudio-is/content-engine/jsx-attributes";
+import { getJsxPropName } from "@webstudio-is/content-engine/jsx-attributes";
 import { isAttributeNameSafe, showAttribute } from "./props";
 import { generateCollectionIterationCode } from "./collection-utils";
 
@@ -214,19 +211,6 @@ export const generateJsxElement = ({
   let collectionItemValue: undefined | string;
   let collectionItemKeyValue: undefined | string;
   const classNameValues: string[] = [];
-  // Older projects can contain duplicate props after an asset-derived prop was
-  // persisted alongside the authored prop. Keep the last value for a prop
-  // name so malformed data cannot produce duplicate JSX attributes.
-  const instanceProps = Array.from(
-    Array.from(props.values())
-      .filter((prop) => prop.instanceId === instance.id)
-      .reduce((uniqueProps, prop) => {
-        uniqueProps.set(prop.name, prop);
-        return uniqueProps;
-      }, new Map<string, Prop>())
-      .values()
-  );
-  const instancePropNames = new Set(instanceProps.map((prop) => prop.name));
   const projectedResourceProps = new Map<string, unknown>();
   const componentPropNames = new Set(Object.keys(meta?.props ?? {}));
   const acceptsHtmlAttributes =
@@ -239,29 +223,34 @@ export const generateJsxElement = ({
       componentPropNames,
       acceptsHtmlAttributes,
     });
-  const safeInstanceProps = instanceProps.filter(({ name }) =>
-    isAttributeNameSafe(name)
-  );
-  // Class aliases can coexist because their values are merged into the single
-  // className attribute below. Keep rejecting every other mapped collision.
-  const classPropIds = new Set(
-    safeInstanceProps
-      .filter(({ name }) => getGeneratedPropName(name) === "className")
-      .map(({ id }) => id)
-  );
-  const generatedPropNames = new Map([
-    ...mapAttributeNames({
-      attributes: safeInstanceProps.filter(
-        ({ id }) => classPropIds.has(id) === false
-      ),
-      direction: "instance-to-jsx",
-      componentPropNames,
-      acceptsHtmlAttributes,
-    }).map(({ id, name }) => [id, name] as const),
-    ...Array.from(classPropIds, (id) => [id, "className"] as const),
+  // Older projects can contain duplicate props or both standard and React
+  // aliases. Keep the last prop for each generated JSX name. Class aliases are
+  // composable, so keep the last value for each alias and merge them below.
+  const propsByGeneratedName = new Map<string, Prop>();
+  const classProps = new Map<string, Prop>();
+  for (const prop of props.values()) {
+    if (
+      prop.instanceId !== instance.id ||
+      isAttributeNameSafe(prop.name) === false
+    ) {
+      continue;
+    }
+    const name = getGeneratedPropName(prop.name);
+    if (name === "className") {
+      classProps.set(prop.name, prop);
+      continue;
+    }
+    propsByGeneratedName.set(name, prop);
+  }
+  const generatedPropNames = new Set([
+    ...propsByGeneratedName.keys(),
+    ...(classProps.size > 0 ? ["className"] : []),
   ]);
 
-  for (const prop of instanceProps) {
+  for (const [name, prop] of [
+    ...propsByGeneratedName,
+    ...Array.from(classProps.values(), (prop) => ["className", prop] as const),
+  ]) {
     const propValue = generatePropValue({
       scope,
       prop,
@@ -269,26 +258,21 @@ export const generateJsxElement = ({
       usedDataSources,
     });
 
-    if (isAttributeNameSafe(prop.name) === false) {
-      continue;
-    }
-
     if (prop.type === "resource") {
       const propMeta = meta?.props?.[prop.name];
       const resource = resources?.get(prop.value);
       if (propMeta?.type === "resource" && resource !== undefined) {
-        for (const name of propMeta.generatedProps ?? []) {
+        for (const propName of propMeta.generatedProps ?? []) {
+          const generatedPropName = getGeneratedPropName(propName);
           if (
-            instancePropNames.has(name) === false &&
-            isAttributeNameSafe(name)
+            generatedPropNames.has(generatedPropName) === false &&
+            isAttributeNameSafe(propName)
           ) {
-            projectedResourceProps.set(name, resource[name]);
+            projectedResourceProps.set(generatedPropName, resource[propName]);
           }
         }
       }
     }
-
-    const name = generatedPropNames.get(prop.id) ?? prop.name;
 
     // show prop controls conditional rendering and need to be handled separately
     if (prop.name === showAttribute) {
@@ -327,8 +311,7 @@ export const generateJsxElement = ({
     }
   }
 
-  for (const [propName, value] of projectedResourceProps) {
-    const name = getGeneratedPropName(propName);
+  for (const [name, value] of projectedResourceProps) {
     generatedProps += `\n${name}={${JSON.stringify(value)}}`;
   }
 


### PR DESCRIPTION
## Summary

- recover from every standard HTML/SVG and React attribute alias collision during generated JSX export
- keep the last persisted value for non-class collisions, matching existing duplicate-prop recovery
- merge distinct class aliases with generated atomic classes
- keep shared collision validation strict in authoring, import, MDX, and instance-conversion paths

## Implementation

The React SDK generator now normalizes safe instance props before generating JSX. One map keyed by the final JSX name provides deterministic last-value recovery for exact duplicates and non-class aliases. A second map keyed by the original class spelling preserves one value per class alias so those composable values can be merged into the single emitted `className` attribute.

Projected resource props use the same normalized-name set, avoiding a second route to duplicate generated JSX properties.

## Checklist

- [x] Reproduce the reported `class`/`className` failure on unchanged `main`
- [x] Reproduce non-class failures including `tabindex`/`tabIndex`, `for`/`htmlFor`, and `readonly`/`readOnly`
- [x] Cover every current standard-to-React alias pair in both persistence orders
- [x] Preserve exact duplicate-prop last-value behavior
- [x] Merge distinct class aliases with atomic classes
- [x] Keep strict shared validation outside generated JSX recovery
- [x] Review documentation impact; no user-facing documentation changes are required
- [x] Review fixture impact; no fixture inputs or generated fixture outputs are affected
- [x] Run targeted tests, typecheck, lint, build, and direct generator reproducers
- [ ] Run `pnpm evaluations` if explicitly approved

## Verification

- `pnpm --filter @webstudio-is/react-sdk exec vitest run src/component-generator.test.tsx --pool=forks` — 156 passed
- `pnpm --filter @webstudio-is/content-engine exec vitest run src/jsx-attributes.test.ts --pool=forks` — 3 passed
- `pnpm --filter @webstudio-is/react-sdk typecheck`
- `pnpm --filter @webstudio-is/react-sdk build`
- `pnpm exec oxlint --deny-warnings packages/react-sdk/src/component-generator.ts packages/react-sdk/src/component-generator.test.tsx`
- direct generator reproducers now emit one normalized property for `tabIndex`, `htmlFor`, and `readOnly`

The exhaustive regression test is derived from the shared attribute mapping, currently covering 105 non-class pairs in both orders; the separate class test covers exact duplicate recovery, distinct alias merging, and atomic classes.

Agent evaluations were not run because they require explicit approval.

Closes #6299