### PR TITLE
fix: Restore command, form, and split-button states

### DIFF
--- a/packages/design-system/src/components/button.tsx
+++ b/packages/design-system/src/components/button.tsx
@@ -14,7 +14,10 @@ import { css, styled, theme, type CSS } from "../stitches.config";
 import { LoadingDotsIcon } from "@webstudio-is/icons";
 import { Flex } from "./flex";
 import { cssVar } from "../css-var";
-import { withInteractionOverlay } from "./component-state-color";
+import {
+  neutralControlBackground,
+  withInteractionOverlay,
+} from "./component-state-color";
 
 const colors = [
   "primary",
@@ -28,9 +31,6 @@ export type ButtonColor = (typeof colors)[number];
 
 export type ButtonState = "auto" | "hover" | "focus" | "pressed" | "pending";
 
-const neutralBackground = `color-mix(in oklab, ${cssVar(
-  "--background-primary"
-)} 86%, ${cssVar("--foreground-primary")})`;
 const disabledBackground = `color-mix(in oklab, ${cssVar(
   "--background-primary"
 )} 92%, ${cssVar("--foreground-primary")})`;
@@ -43,8 +43,8 @@ const chromaticPressedOverlay = `oklch(from ${cssVar(
 
 const backgrounds: Record<ButtonColor, string> = {
   primary: cssVar("--background-accent"),
-  neutral: neutralBackground,
-  "neutral-destructive": neutralBackground,
+  neutral: neutralControlBackground,
+  "neutral-destructive": neutralControlBackground,
   destructive: cssVar("--background-negative"),
   ghost: "transparent",
 };

--- a/packages/design-system/src/components/checkbox.tsx
+++ b/packages/design-system/src/components/checkbox.tsx
@@ -8,7 +8,6 @@ import * as Primitive from "@radix-ui/react-checkbox";
 import { CheckMarkIcon, MinusIcon } from "@webstudio-is/icons";
 import { type CSS, css, theme, styled } from "../stitches.config";
 import { cssVar } from "../css-var";
-import { restingControlBoundary } from "./form-control-style";
 
 const checkboxStyle = css({
   all: "unset", // reset <button>
@@ -22,7 +21,11 @@ const checkboxStyle = css({
   borderRadius: theme.borderRadius[3],
   color: cssVar("--foreground-primary"),
   background: cssVar("--background-secondary"),
-  border: `1px solid ${restingControlBoundary}`,
+  border: "1px solid transparent",
+
+  "&:hover": {
+    borderColor: cssVar("--border-default"),
+  },
 
   "&:focus-visible": {
     borderColor: cssVar("--border-focus"),
@@ -31,7 +34,6 @@ const checkboxStyle = css({
   // [data-state] is needed to make selector specificity higher
   "&[data-state]:disabled": {
     color: cssVar("--foreground-disabled"),
-    borderColor: cssVar("--border-default"),
   },
 });
 

--- a/packages/design-system/src/components/command.browser.test.ts
+++ b/packages/design-system/src/components/command.browser.test.ts
@@ -7,6 +7,7 @@ import {
   Command,
   CommandGroup,
   CommandGroupHeading,
+  CommandInput,
   CommandItem,
   CommandList,
 } from "./command";
@@ -73,6 +74,7 @@ test("command panels use the panel surface and readable group headings", () => {
           createElement(
             Command,
             null,
+            createElement(CommandInput),
             createElement(
               CommandList,
               null,
@@ -96,9 +98,18 @@ test("command panels use the panel surface and readable group headings", () => {
     });
 
     const panel = container.querySelector("[cmdk-root]");
+    const inputContainer = container.querySelector(
+      "[data-input-field-input]"
+    )?.parentElement;
     const heading = container.querySelector("[cmdk-group-heading]");
     const panelReference = container.firstElementChild;
-    if (panel === null || heading === null || panelReference === null) {
+    if (
+      panel === null ||
+      inputContainer === null ||
+      inputContainer === undefined ||
+      heading === null ||
+      panelReference === null
+    ) {
       throw new Error("Expected a rendered command group");
     }
 
@@ -106,6 +117,10 @@ test("command panels use the panel surface and readable group headings", () => {
     expect(panelBackground, `${mode} panel surface`).toEqual(
       readColor(getComputedStyle(panelReference).backgroundColor)
     );
+    expect(
+      readColor(getComputedStyle(inputContainer).backgroundColor),
+      `${mode} command input surface`
+    ).toEqual(panelBackground);
     expect(
       contrast(readColor(getComputedStyle(heading).color), panelBackground),
       `${mode} heading contrast`

--- a/packages/design-system/src/components/command.tsx
+++ b/packages/design-system/src/components/command.tsx
@@ -186,6 +186,7 @@ export const CommandBackIcon = styled(ChevronLeftIcon, {
 const CommandInputField = styled(InputField, {
   "--sizes-controlHeight": theme.spacing[15],
   border: "none",
+  backgroundColor: cssVar("--background-primary"),
   paddingInline: theme.spacing[4],
 });
 

--- a/packages/design-system/src/components/component-state-color.ts
+++ b/packages/design-system/src/components/component-state-color.ts
@@ -1,5 +1,9 @@
 import { cssVar } from "../css-var";
 
+export const neutralControlBackground = `color-mix(in oklab, ${cssVar(
+  "--background-primary"
+)} 86%, ${cssVar("--foreground-primary")})`;
+
 export const selectedItemBackground = `light-dark(
   color-mix(in oklab, ${cssVar("--background-accent")} 12%, ${cssVar(
     "--background-primary"

--- a/packages/design-system/src/components/form-control-contrast.browser.test.ts
+++ b/packages/design-system/src/components/form-control-contrast.browser.test.ts
@@ -53,7 +53,7 @@ const contrast = (first: number[], second: number[]) => {
   );
 };
 
-test("compact form controls have visible boundaries", () => {
+test("compact form controls use their intended resting treatment", () => {
   const container = document.createElement("div");
   document.body.append(container);
   root = createRoot(container);
@@ -82,20 +82,14 @@ test("compact form controls have visible boundaries", () => {
     const background = getComputedStyle(
       container.firstElementChild as Element
     ).backgroundColor;
-    const controls = container.querySelectorAll("[data-control]");
-    for (const control of controls) {
-      const boundary = control.firstElementChild;
-      if (boundary === null) {
-        throw new Error("Expected a form control boundary");
-      }
-      expect(
-        contrast(
-          readColor(getComputedStyle(boundary).borderColor),
-          readColor(background)
-        ),
-        `${mode} ${control.getAttribute("data-control")}`
-      ).toBeGreaterThanOrEqual(3);
+    const checkbox = container.querySelector("[data-control] > button");
+    if (checkbox === null) {
+      throw new Error("Expected a checkbox");
     }
+    expect(
+      readColor(getComputedStyle(checkbox).borderColor)[3],
+      `${mode} checkbox resting border`
+    ).toBe(0);
 
     const switchControl = container.querySelector("[data-switch] > button");
     if (switchControl === null) {

--- a/packages/design-system/src/components/form-control-contrast.browser.test.ts
+++ b/packages/design-system/src/components/form-control-contrast.browser.test.ts
@@ -3,6 +3,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { act } from "react-dom/test-utils";
 import { afterEach, expect, test } from "vitest";
 import "../colors/colors.css";
+import { Button } from "./button";
 import { Checkbox } from "./checkbox";
 import { Switch } from "./switch";
 
@@ -32,27 +33,6 @@ const readColor = (color: string) => {
   return Array.from(context.getImageData(0, 0, 1, 1).data);
 };
 
-const luminance = (color: number[]) => {
-  const linearize = (channel: number) => {
-    const value = channel / 255;
-    return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
-  };
-  return (
-    0.2126 * linearize(color[0]) +
-    0.7152 * linearize(color[1]) +
-    0.0722 * linearize(color[2])
-  );
-};
-
-const contrast = (first: number[], second: number[]) => {
-  const firstLuminance = luminance(first);
-  const secondLuminance = luminance(second);
-  return (
-    (Math.max(firstLuminance, secondLuminance) + 0.05) /
-    (Math.min(firstLuminance, secondLuminance) + 0.05)
-  );
-};
-
 test("compact form controls use their intended resting treatment", () => {
   const container = document.createElement("div");
   document.body.append(container);
@@ -74,14 +54,16 @@ test("compact form controls use their intended resting treatment", () => {
             "div",
             { "data-switch": true },
             createElement(Switch, { "aria-label": "Switch" })
+          ),
+          createElement(
+            "div",
+            { "data-neutral-control": true },
+            createElement(Button, { color: "neutral" }, "Neutral")
           )
         )
       );
     });
 
-    const background = getComputedStyle(
-      container.firstElementChild as Element
-    ).backgroundColor;
     const checkbox = container.querySelector("[data-control] > button");
     if (checkbox === null) {
       throw new Error("Expected a checkbox");
@@ -95,12 +77,15 @@ test("compact form controls use their intended resting treatment", () => {
     if (switchControl === null) {
       throw new Error("Expected a switch");
     }
+    const neutralControl = container.querySelector(
+      "[data-neutral-control] > button"
+    );
+    if (neutralControl === null) {
+      throw new Error("Expected a neutral control");
+    }
     expect(
-      contrast(
-        readColor(getComputedStyle(switchControl, "::before").backgroundColor),
-        readColor(background)
-      ),
-      `${mode} switch`
-    ).toBeGreaterThanOrEqual(3);
+      readColor(getComputedStyle(switchControl, "::before").backgroundColor),
+      `${mode} switch resting track`
+    ).toEqual(readColor(getComputedStyle(neutralControl).backgroundColor));
   }
 });

--- a/packages/design-system/src/components/form-control-style.ts
+++ b/packages/design-system/src/components/form-control-style.ts
@@ -1,6 +1,0 @@
-import { cssVar } from "../css-var";
-
-// A resting control boundary must retain 3:1 contrast against its panel.
-export const restingControlBoundary = `color-mix(in oklab, ${cssVar(
-  "--foreground-primary"
-)} 45%, ${cssVar("--background-primary")})`;

--- a/packages/design-system/src/components/split-button.browser.test.tsx
+++ b/packages/design-system/src/components/split-button.browser.test.tsx
@@ -166,6 +166,24 @@ test("split button segments remain independently actionable", async () => {
   await expect.element(page.getByText("Design")).toBeVisible();
 });
 
+test("open menu highlights only the menu segment", async () => {
+  const { buttons } = renderSplitButton();
+  const hoverBackground = document.createElement("div");
+  hoverBackground.style.backgroundColor = "var(--overlay-interaction-hover)";
+  document.body.append(hoverBackground);
+
+  await act(async () => {
+    await page.elementLocator(buttons[1]).click();
+    await page.getByText("Design").hover();
+  });
+
+  expect(buttons[1].getAttribute("aria-expanded")).toBe("true");
+  expect(getComputedStyle(buttons[0]).backgroundColor).toBe("rgba(0, 0, 0, 0)");
+  expect(getComputedStyle(buttons[1], "::before").backgroundColor).toBe(
+    getComputedStyle(hoverBackground).backgroundColor
+  );
+});
+
 test("hovering a disabled segment does not highlight its sibling", async () => {
   for (const disabled of ["preview", "menu"] as const) {
     const { buttons } = renderSplitButton({

--- a/packages/design-system/src/components/split-button.tsx
+++ b/packages/design-system/src/components/split-button.tsx
@@ -52,9 +52,10 @@ export const SplitButtonMenuButton = styled(IconButton, {
     borderTopRightRadius: theme.borderRadius[3],
     borderBottomRightRadius: theme.borderRadius[3],
   },
-  "&:hover::before, &[data-hovered=true]::before, &[data-state=open]::before": {
-    background: cssVar("--overlay-interaction-hover"),
-  },
+  "&:hover::before, &[data-hovered=true]::before, &[aria-expanded=true]::before":
+    {
+      background: cssVar("--overlay-interaction-hover"),
+    },
   "&:active::before": {
     background: cssVar("--overlay-interaction-pressed"),
   },

--- a/packages/design-system/src/components/switch.tsx
+++ b/packages/design-system/src/components/switch.tsx
@@ -7,7 +7,7 @@ import { forwardRef, type ComponentProps, type Ref } from "react";
 import * as Primitive from "@radix-ui/react-switch";
 import { type CSS, css, theme } from "../stitches.config";
 import { cssVar } from "../css-var";
-import { restingControlBoundary } from "./form-control-style";
+import { neutralControlBackground } from "./component-state-color";
 
 const padding = theme.spacing[1];
 const thumbOffset = `calc(${padding} + ${theme.spacing[1]})`;
@@ -29,7 +29,7 @@ const switchStyle = css({
     position: "absolute",
     inset: padding,
     borderRadius: theme.borderRadius.pill,
-    backgroundColor: restingControlBoundary,
+    backgroundColor: neutralControlBackground,
   },
 
   "&[data-state=checked]:not([data-disabled]):before, &[aria-checked=true]:not([data-disabled]):before":


### PR DESCRIPTION
Closes #6312

## Summary

- Restore the Commands & search header to the command panel surface so its embedded input no longer appears darker or exposes rounded bottom-corner cutouts.
- Restore unchecked checkboxes to the borderless resting treatment used by inputs and textareas.
- Restore unchecked switches to the neutral control surface used before the redesign.
- Restore the header split button's open background on the dropdown segment.
- Keep checkbox hover and keyboard-focus boundaries visible.

## Technical choices

- Override the generic `InputField` background only in the command component; ordinary inputs continue using the secondary control surface.
- Use a transparent resting checkbox border to preserve dimensions, then apply the existing default border on hover and focus border on keyboard focus.
- Share the existing neutral button surface recipe with the unchecked Switch track, preserving the historical relationship without adding a new semantic theme variable.
- Match the split-menu trigger's semantic `aria-expanded` state because the nested tooltip owns and overwrites `data-state`.
- Remove the obsolete forced 3:1 resting-boundary recipe.

## Todo

- [x] Audit text inputs, textareas, search, selects, comboboxes, checkbox, radio, switch, toggle, and nested control surfaces.
- [x] Restore the command header's panel-background override.
- [x] Remove the checkbox's high-contrast resting border.
- [x] Restore the unchecked Switch's neutral track surface.
- [x] Preserve checkbox hover and focus feedback.
- [x] Restore the split-button dropdown segment's open background.
- [x] Add light- and dark-mode regression coverage and confirm the tests fail before each fix and pass after it.
- [x] Visually verify affected controls and the open split button in Storybook in light and dark modes.
- [x] Review documentation impact; no user-facing documentation update is required for restoring the previous visual treatment.
- [x] Review fixture impact; no fixture inputs or generated outputs are affected.

## Verification

- `pnpm --filter @webstudio-is/design-system test` — 19 files and 228 tests passed.
- `pnpm --filter @webstudio-is/design-system typecheck`
- Targeted Oxlint, formatting, and `git diff --check`
- Storybook audit and visual review in light and dark modes