### PR TITLE
fix: Reduce style source padding

### DIFF
--- a/apps/builder/app/builder/features/style-panel/style-source/style-source-control.tsx
+++ b/apps/builder/app/builder/features/style-panel/style-source/style-source-control.tsx
@@ -274,7 +274,7 @@ export const StyleSourceControl = ({
         role="button"
         hasError={error !== undefined}
       >
-        <Flex grow css={{ padding: theme.spacing[2] }}>
+        <Flex grow css={{ padding: theme.spacing[1] }}>
           <StyleSourceButton
             disabled={disabled || isEditing}
             isEditing={isEditing}


### PR DESCRIPTION
## Result

Style source controls now use spacing level 1 for their inner padding instead of spacing level 2.

## Implementation

- [x] Change only the inner padding of `StyleSourceControl`.
- [x] Keep interactions and accessible behavior unchanged.
- [x] Review documentation impact: no documentation changes are needed for this visual spacing correction.
- [x] Verify formatting, lint, and Builder types.

## Verification

- `pnpm exec oxfmt --check apps/builder/app/builder/features/style-panel/style-source/style-source-control.tsx`
- `pnpm exec oxlint --deny-warnings apps/builder/app/builder/features/style-panel/style-source/style-source-control.tsx`
- `pnpm --filter=@webstudio-is/builder typecheck`

No fixture inputs or generated outputs are affected. No known limitations.

Closes #6314