### PR TITLE
docs: update Link target values

### DIFF
--- a/docs/university/core-components/link.md
+++ b/docs/university/core-components/link.md
@@ -43,15 +43,14 @@ The "href" property determines what the Link instance will lead to, such as a UR
 
 ### Target
 
-<figure><img src="../../.gitbook/assets/link-target-property.avif" alt="Link settings with the Target property options open"><figcaption></figcaption></figure>
+The `target` property controls where the link opens. Choose one of these values:
 
-You can use the "Target" property to modify a link instance's behavior and define how linked content is displayed.
+1. **`_self`**: Opens the link in the same tab. This is the default.
+2. **`_blank`**: Opens the link in a new tab or window.
+3. **`_parent`**: Opens the link in the parent browsing context. This is mainly useful inside nested frames.
+4. **`_top`**: Opens the link in the top-level browsing context, replacing any frames.
 
-1. **Self**: When you set "Target" to "Self," the linked content will open in the same window or tab. This is the default behavior for links, and it maintains the browsing context.
-2. **Blank**: If you choose "Blank," the linked content will open in a new tab or window, providing a separate browsing context.
-3. **Parent and Top**: For web pages involving nested frames, "Parent" will direct the linked content to open in the parent frame or window, maintaining the hierarchy of frames.\
-   \
-   On the other hand, selecting "Top" will open the link instance in the top-level window, replacing all frames if there are any. This is useful when you want to break out of any frames and provide a full-page experience.
+To open a link in a new tab, set **Target** to **`_blank`**.
 
 ### Prefetch
 


### PR DESCRIPTION
## Summary

Update the Link documentation to match the current code.

The Builder uses `_self`, `_blank`, `_parent`, and `_top` as the Link `target` values. The old docs described these as `Self`, `Blank`, `Parent`, and `Top`, which could make setting a new-tab link confusing.

## Changes

- Document the four current target values.
- Explain that `_blank` opens a link in a new tab or window.
- Remove the outdated Target screenshot.
- Checked the rest of `docs/` for the same outdated target names; no other related occurrences were found.

## Verification

- `git diff --check` passed.
- Confirmed the values in `packages/sdk-components-react/src/__generated__/link.props.ts` and `packages/sdk-components-react/src/create-link.tsx`.
- Checked that the docs file and navigation file exist.
- `pnpm exec oxfmt --check docs/university/core-components/link.md` did not run because the Markdown file is excluded by the formatter configuration.

## Checklist

- [x] Review the current Builder implementation.
- [x] Review the authoritative docs page.
- [x] Check for similar outdated documentation.
- [x] Review documentation impact: this PR updates the affected page; no other docs need changes.
- [ ] Merge the pull request.