### PR TITLE
fix: Paste in Firefox navigator

### DIFF
--- a/apps/builder/app/shared/copy-paste/copy-paste.test.ts
+++ b/apps/builder/app/shared/copy-paste/copy-paste.test.ts
@@ -156,18 +156,6 @@ class TestDataTransfer {
   }
 }
 
-class TestClipboardEvent extends Event {
-  clipboardData?: DataTransfer;
-
-  constructor(
-    type: string,
-    options: EventInit & { clipboardData?: DataTransfer }
-  ) {
-    super(type, options);
-    this.clipboardData = options.clipboardData;
-  }
-}
-
 class FirefoxClipboardEvent extends Event {
   clipboardData = new TestDataTransfer() as unknown as DataTransfer;
 
@@ -1248,6 +1236,7 @@ test("copies selected instance to clipboard", async () => {
 
 test("copies multi-selected instances to clipboard and emits paste for every root", async () => {
   resetStores();
+  setupPage();
   const abortController = new AbortController();
   initCopyPaste({ signal: abortController.signal });
   let clipboardText = "";
@@ -1261,7 +1250,7 @@ test("copies multi-selected instances to clipboard and emits paste for every roo
     },
   });
   vi.stubGlobal("DataTransfer", TestDataTransfer);
-  vi.stubGlobal("ClipboardEvent", TestClipboardEvent);
+  vi.stubGlobal("ClipboardEvent", FirefoxClipboardEvent);
   $project.set({ id: "project-id" } as Project);
   $instances.set(
     new Map<Instance["id"], Instance>([
@@ -1321,7 +1310,6 @@ test("copies multi-selected instances to clipboard and emits paste for every roo
 
   selectInstance(["target", "body-id"]);
   await emitPaste();
-  await waitForClipboardEvent();
 
   expect($instances.get().get("target")?.children).toEqual([
     { type: "id", value: expect.any(String) },
@@ -1332,6 +1320,7 @@ test("copies multi-selected instances to clipboard and emits paste for every roo
 
 const setupEmitPasteProject = () => {
   resetStores();
+  setupPage();
   $project.set({ id: "project-id" } as Project);
   $instances.set(
     new Map<Instance["id"], Instance>([
@@ -1374,24 +1363,6 @@ const setupEmitPasteClipboard = () => {
   vi.stubGlobal("ClipboardEvent", FirefoxClipboardEvent);
 };
 
-test("emits paste without relying on synthetic clipboard event data", async () => {
-  setupEmitPasteProject();
-  setupEmitPasteClipboard();
-  const abortController = new AbortController();
-  initCopyPaste({ signal: abortController.signal });
-
-  selectInstance(["source", "body-id"]);
-  await copyInstance();
-  selectInstance(["target", "body-id"]);
-  await emitPaste();
-  await waitForClipboardEvent();
-
-  expect($instances.get().get("target")?.children).toEqual([
-    { type: "id", value: expect.any(String) },
-  ]);
-  abortController.abort();
-});
-
 test("content mode emits paste through the content mode handler", async () => {
   setupEmitPasteProject();
   setupEmitPasteClipboard();
@@ -1402,7 +1373,6 @@ test("content mode emits paste through the content mode handler", async () => {
   await copyInstance();
   selectInstance(["target", "body-id"]);
   await emitPaste();
-  await waitForClipboardEvent();
 
   expect($instances.get().get("target")?.children).toEqual([
     { type: "id", value: expect.any(String) },
@@ -1419,7 +1389,6 @@ test("content mode reports clipboard text it cannot paste through emit paste", a
 
   selectInstance(["target", "body-id"]);
   await emitPaste();
-  await waitForClipboardEvent();
 
   expect(toastInfo).toHaveBeenCalledWith(
     "This clipboard data cannot be pasted here."
@@ -1442,7 +1411,6 @@ test("does not emit paste when copy permission is disabled", async () => {
   });
   selectInstance(["target", "body-id"]);
   await emitPaste();
-  await waitForClipboardEvent();
 
   expect($instances.get().get("target")?.children).toEqual([]);
   abortController.abort();
@@ -1464,7 +1432,6 @@ test("does not emit paste while editing canvas text", async () => {
   });
   selectInstance(["target", "body-id"]);
   await emitPaste();
-  await waitForClipboardEvent();
 
   expect($instances.get().get("target")?.children).toEqual([]);
   abortController.abort();

--- a/apps/builder/app/shared/copy-paste/copy-paste.test.ts
+++ b/apps/builder/app/shared/copy-paste/copy-paste.test.ts
@@ -114,10 +114,14 @@ const setupRootCssVariable = (property: `--${string}`, value: string) => {
   );
 };
 
+const disconnectClipboardData = new WeakMap<ClipboardEvent, () => void>();
+
 const createClipboardEvent = (type: "copy" | "cut" | "paste") => {
   const data = new Map<string, string>();
+  let connected = true;
   const clipboardData = {
-    getData: (mimeType: string) => data.get(mimeType) ?? "",
+    getData: (mimeType: string) =>
+      connected ? (data.get(mimeType) ?? "") : "",
     setData: (mimeType: string, value: string) => {
       data.set(mimeType, value);
     },
@@ -127,7 +131,17 @@ const createClipboardEvent = (type: "copy" | "cut" | "paste") => {
     cancelable: true,
   }) as ClipboardEvent;
   Object.defineProperty(event, "clipboardData", { value: clipboardData });
+  if (type === "paste") {
+    disconnectClipboardData.set(event, () => {
+      connected = false;
+    });
+  }
   return { clipboardData, event };
+};
+
+const dispatchClipboardEvent = (event: ClipboardEvent) => {
+  document.dispatchEvent(event);
+  disconnectClipboardData.get(event)?.();
 };
 
 class TestDataTransfer {
@@ -151,6 +165,14 @@ class TestClipboardEvent extends Event {
   ) {
     super(type, options);
     this.clipboardData = options.clipboardData;
+  }
+}
+
+class FirefoxClipboardEvent extends Event {
+  clipboardData = new TestDataTransfer() as unknown as DataTransfer;
+
+  constructor(type: string, options: EventInit) {
+    super(type, options);
   }
 }
 
@@ -187,7 +209,7 @@ const pastePlainText = async (
   initCopyPaste({ signal: abortController.signal });
   const { clipboardData, event } = createClipboardEvent("paste");
   clipboardData.setData("text/plain", JSON.stringify(value));
-  document.dispatchEvent(event);
+  dispatchClipboardEvent(event);
   await waitForClipboardEvent();
   abortController.abort();
   return event;
@@ -232,7 +254,7 @@ test("writes asynchronously prepared page data from a clipboard event", async ()
   initCopyPaste({ signal: abortController.signal });
   const { event } = createClipboardEvent("copy");
 
-  document.dispatchEvent(event);
+  dispatchClipboardEvent(event);
   await waitForClipboardEvent();
 
   expect(event.defaultPrevented).toBe(true);
@@ -284,7 +306,7 @@ test("copies selected instance through clipboard event", () => {
   selectInstance(["box-id", "body-id"]);
   const { clipboardData, event } = createClipboardEvent("copy");
 
-  document.dispatchEvent(event);
+  dispatchClipboardEvent(event);
 
   expect(event.defaultPrevented).toBe(true);
   expect(clipboardData.getData("text/plain")).toContain(
@@ -337,7 +359,7 @@ test("copies multi-selected instances through clipboard event", () => {
   ]);
   const { clipboardData, event } = createClipboardEvent("copy");
 
-  document.dispatchEvent(event);
+  dispatchClipboardEvent(event);
 
   expect(event.defaultPrevented).toBe(true);
   expect(JSON.parse(clipboardData.getData("text/plain"))).toMatchObject({
@@ -378,7 +400,7 @@ test("content mode copies selected instances through clipboard event", () => {
   selectInstance(["box-id", "body-id"]);
   const { clipboardData, event } = createClipboardEvent("copy");
 
-  document.dispatchEvent(event);
+  dispatchClipboardEvent(event);
 
   expect(event.defaultPrevented).toBe(true);
   expect(clipboardData.getData("text/plain")).toContain(
@@ -395,7 +417,7 @@ test("content mode reports unsupported copy selection", () => {
   initCopyPasteForContentEditMode({ signal: abortController.signal });
   const { event } = createClipboardEvent("copy");
 
-  document.dispatchEvent(event);
+  dispatchClipboardEvent(event);
 
   expect(event.defaultPrevented).toBe(false);
   expect(toastInfo).toHaveBeenCalledWith(
@@ -436,13 +458,13 @@ test("content mode pastes instance clipboard data through clipboard event", asyn
   selectInstance(["box-id", "body-id"]);
   const { clipboardData: copyData, event: copyEvent } =
     createClipboardEvent("copy");
-  document.dispatchEvent(copyEvent);
+  dispatchClipboardEvent(copyEvent);
   const clipboardText = copyData.getData("text/plain");
   selectInstance(["body-id"]);
   const { clipboardData, event } = createClipboardEvent("paste");
   clipboardData.setData("text/plain", clipboardText);
 
-  document.dispatchEvent(event);
+  dispatchClipboardEvent(event);
   await waitForClipboardEvent();
 
   expect(event.defaultPrevented).toBe(true);
@@ -510,7 +532,7 @@ test("pastes multi-selected instance clipboard data through clipboard event", as
   ]);
   const { clipboardData: copyData, event: copyEvent } =
     createClipboardEvent("copy");
-  document.dispatchEvent(copyEvent);
+  dispatchClipboardEvent(copyEvent);
   const clipboardText = copyData.getData("text/plain");
   expect(JSON.parse(clipboardText)).toMatchObject({
     "@webstudio/instances/v0.1": {
@@ -521,7 +543,7 @@ test("pastes multi-selected instance clipboard data through clipboard event", as
   selectInstance(["target", "body-id"]);
   const { clipboardData, event } = createClipboardEvent("paste");
   clipboardData.setData("text/plain", clipboardText);
-  document.dispatchEvent(event);
+  dispatchClipboardEvent(event);
   await waitForClipboardEvent();
 
   const targetChildren = $instances.get().get("target")?.children;
@@ -554,7 +576,7 @@ test("does not paste malformed webstudio instance json as plain text", async () 
     `{"@webstudio/instance/v0.1":{"instanceSelector":["missing-id","body-id"]`
   );
 
-  document.dispatchEvent(event);
+  dispatchClipboardEvent(event);
   await waitForClipboardEvent();
 
   expect(event.defaultPrevented).toBe(true);
@@ -578,7 +600,7 @@ test("reports malformed Webflow json through generic paste", async () => {
     JSON.stringify({ type: "@webflow/XscpData" })
   );
 
-  document.dispatchEvent(event);
+  dispatchClipboardEvent(event);
   await waitForClipboardEvent();
 
   expect(event.defaultPrevented).toBe(true);
@@ -981,7 +1003,7 @@ test("does not intercept native paste while editing text", async () => {
     `{"@webstudio/instance/v0.1":{"instanceSelector":["missing-id","body-id"]`
   );
 
-  document.dispatchEvent(event);
+  dispatchClipboardEvent(event);
   await waitForClipboardEvent();
 
   expect(event.defaultPrevented).toBe(false);
@@ -1034,7 +1056,7 @@ test("cuts multi-selected instances through clipboard event", () => {
   ]);
   const { clipboardData, event } = createClipboardEvent("cut");
 
-  document.dispatchEvent(event);
+  dispatchClipboardEvent(event);
 
   expect(event.defaultPrevented).toBe(true);
   expect(JSON.parse(clipboardData.getData("text/plain"))).toMatchObject({
@@ -1055,7 +1077,7 @@ test("content mode blocks cut through clipboard event", () => {
   initCopyPasteForContentEditMode({ signal: abortController.signal });
   const { event } = createClipboardEvent("cut");
 
-  document.dispatchEvent(event);
+  dispatchClipboardEvent(event);
 
   expect(event.defaultPrevented).toBe(false);
   expect(toastInfo).toHaveBeenCalledWith(
@@ -1072,7 +1094,7 @@ test("content mode reports unsupported paste clipboard data", async () => {
   const { clipboardData, event } = createClipboardEvent("paste");
   clipboardData.setData("text/plain", "plain text");
 
-  document.dispatchEvent(event);
+  dispatchClipboardEvent(event);
   await waitForClipboardEvent();
 
   expect(event.defaultPrevented).toBe(true);
@@ -1094,7 +1116,7 @@ test("content mode reports malformed webstudio instance clipboard data", async (
     `{"@webstudio/instance/v0.1":{"instanceSelector":["missing-id","body-id"]`
   );
 
-  document.dispatchEvent(event);
+  dispatchClipboardEvent(event);
   await waitForClipboardEvent();
 
   expect(event.defaultPrevented).toBe(true);
@@ -1179,7 +1201,7 @@ test("does not intercept native copy while editing canvas text", () => {
   });
   const { clipboardData, event } = createClipboardEvent("copy");
 
-  document.dispatchEvent(event);
+  dispatchClipboardEvent(event);
 
   expect(event.defaultPrevented).toBe(false);
   expect(clipboardData.getData("text/plain")).toBe("");
@@ -1305,6 +1327,146 @@ test("copies multi-selected instances to clipboard and emits paste for every roo
     { type: "id", value: expect.any(String) },
     { type: "id", value: expect.any(String) },
   ]);
+  abortController.abort();
+});
+
+const setupEmitPasteProject = () => {
+  resetStores();
+  $project.set({ id: "project-id" } as Project);
+  $instances.set(
+    new Map<Instance["id"], Instance>([
+      [
+        "body-id",
+        {
+          type: "instance",
+          id: "body-id",
+          component: "Body",
+          children: [
+            { type: "id", value: "source" },
+            { type: "id", value: "target" },
+          ],
+        },
+      ],
+      [
+        "source",
+        { type: "instance", id: "source", component: "Box", children: [] },
+      ],
+      [
+        "target",
+        { type: "instance", id: "target", component: "Box", children: [] },
+      ],
+    ])
+  );
+};
+
+const setupEmitPasteClipboard = () => {
+  let clipboardText = "";
+  vi.stubGlobal("navigator", {
+    ...navigator,
+    clipboard: {
+      writeText: vi.fn(async (text: string) => {
+        clipboardText = text;
+      }),
+      readText: vi.fn(async () => clipboardText),
+    },
+  });
+  vi.stubGlobal("DataTransfer", TestDataTransfer);
+  vi.stubGlobal("ClipboardEvent", FirefoxClipboardEvent);
+};
+
+test("emits paste without relying on synthetic clipboard event data", async () => {
+  setupEmitPasteProject();
+  setupEmitPasteClipboard();
+  const abortController = new AbortController();
+  initCopyPaste({ signal: abortController.signal });
+
+  selectInstance(["source", "body-id"]);
+  await copyInstance();
+  selectInstance(["target", "body-id"]);
+  await emitPaste();
+  await waitForClipboardEvent();
+
+  expect($instances.get().get("target")?.children).toEqual([
+    { type: "id", value: expect.any(String) },
+  ]);
+  abortController.abort();
+});
+
+test("content mode emits paste through the content mode handler", async () => {
+  setupEmitPasteProject();
+  setupEmitPasteClipboard();
+  const abortController = new AbortController();
+  initCopyPasteForContentEditMode({ signal: abortController.signal });
+
+  selectInstance(["source", "body-id"]);
+  await copyInstance();
+  selectInstance(["target", "body-id"]);
+  await emitPaste();
+  await waitForClipboardEvent();
+
+  expect($instances.get().get("target")?.children).toEqual([
+    { type: "id", value: expect.any(String) },
+  ]);
+  abortController.abort();
+});
+
+test("content mode reports clipboard text it cannot paste through emit paste", async () => {
+  setupEmitPasteProject();
+  setupEmitPasteClipboard();
+  const toastInfo = setupToastInfo();
+  const abortController = new AbortController();
+  initCopyPasteForContentEditMode({ signal: abortController.signal });
+
+  selectInstance(["target", "body-id"]);
+  await emitPaste();
+  await waitForClipboardEvent();
+
+  expect(toastInfo).toHaveBeenCalledWith(
+    "This clipboard data cannot be pasted here."
+  );
+  abortController.abort();
+});
+
+test("does not emit paste when copy permission is disabled", async () => {
+  setupEmitPasteProject();
+  setupEmitPasteClipboard();
+  const abortController = new AbortController();
+  initCopyPaste({ signal: abortController.signal });
+
+  selectInstance(["source", "body-id"]);
+  await copyInstance();
+  $authTokenPermissions.set({
+    canClone: true,
+    canCopy: false,
+    canPublish: false,
+  });
+  selectInstance(["target", "body-id"]);
+  await emitPaste();
+  await waitForClipboardEvent();
+
+  expect($instances.get().get("target")?.children).toEqual([]);
+  abortController.abort();
+});
+
+test("does not emit paste while editing canvas text", async () => {
+  setupEmitPasteProject();
+  setupEmitPasteClipboard();
+  const abortController = new AbortController();
+  initCopyPaste({ signal: abortController.signal });
+
+  selectInstance(["source", "body-id"]);
+  await copyInstance();
+  $textEditingInstanceSelector.set({
+    selector: ["target", "body-id"],
+    reason: "click",
+    mouseX: 0,
+    mouseY: 0,
+  });
+  selectInstance(["target", "body-id"]);
+  await emitPaste();
+  await waitForClipboardEvent();
+
+  expect($instances.get().get("target")?.children).toEqual([]);
   abortController.abort();
 });
 

--- a/apps/builder/app/shared/copy-paste/copy-paste.ts
+++ b/apps/builder/app/shared/copy-paste/copy-paste.ts
@@ -109,6 +109,45 @@ const reportPasteResult = (result: PasteResult) => {
   }
 };
 
+const textMimeType = "text/plain";
+
+const readClipboardData = (
+  mimeTypes: Array<string>,
+  clipboardData: null | DataTransfer
+) => {
+  const dataByMimeType = new Map<string, string>();
+  for (const mimeType of mimeTypes) {
+    if (dataByMimeType.has(mimeType) === false) {
+      dataByMimeType.set(
+        mimeType,
+        clipboardData?.getData(mimeType).trim() ?? ""
+      );
+    }
+  }
+  return dataByMimeType;
+};
+
+let pasteClipboardText: undefined | ((text: string) => Promise<void>);
+
+const registerPasteClipboardText = (
+  handler: (text: string) => Promise<void>,
+  signal: AbortSignal
+) => {
+  pasteClipboardText = handler;
+  signal.addEventListener("abort", () => {
+    if (pasteClipboardText === handler) {
+      pasteClipboardText = undefined;
+    }
+  });
+};
+
+const validatePasteCommand = () => {
+  if ($textEditingInstanceSelector.get() != null) {
+    return false;
+  }
+  return validateCopyPermission();
+};
+
 const initPlugins = ({
   plugins,
   signal,
@@ -159,17 +198,12 @@ const initPlugins = ({
     }
   };
 
-  const handlePaste = async (event: ClipboardEvent) => {
-    if (validateClipboardEvent(event) === false) {
-      return;
-    }
-    event.preventDefault();
-
+  const pasteData = async (dataByMimeType: Map<string, string>) => {
     for (const { mimeType, onPaste } of plugins) {
       if (onPaste === undefined) {
         continue;
       }
-      const data = event.clipboardData?.getData(mimeType).trim();
+      const data = dataByMimeType.get(mimeType);
       if (data === undefined || data === "") {
         continue;
       }
@@ -181,11 +215,32 @@ const initPlugins = ({
     }
   };
 
+  const handlePaste = async (event: ClipboardEvent) => {
+    if (validateClipboardEvent(event) === false) {
+      return;
+    }
+    event.preventDefault();
+    await pasteData(
+      readClipboardData(
+        plugins.map((plugin) => plugin.mimeType),
+        event.clipboardData
+      )
+    );
+  };
+
+  const handlePasteText = async (text: string) => {
+    if (validatePasteCommand() === false) {
+      return;
+    }
+    await pasteData(new Map([[textMimeType, text.trim()]]));
+  };
+
   document.addEventListener("copy", handleCopy, { signal });
   document.addEventListener("cut", handleCut, { signal });
   // Capture is required so we get the element before content-editable removes it
   // This way we can detect when we are inside content-editable and ignore the event
   document.addEventListener("paste", handlePaste, { capture: true, signal });
+  registerPasteClipboardText(handlePasteText, signal);
 };
 
 export const initCopyPaste = ({ signal }: { signal: AbortSignal }) => {
@@ -238,7 +293,11 @@ export const initCopyPasteForContentEditMode = ({
     if (validateClipboardEvent(event) === false) {
       return;
     }
-    const jsonData = event.clipboardData?.getData(instanceJson.mimeType).trim();
+    const dataByMimeType = readClipboardData(
+      [instanceJson.mimeType, instanceText.mimeType],
+      event.clipboardData
+    );
+    const jsonData = dataByMimeType.get(instanceJson.mimeType);
     if (jsonData) {
       event.preventDefault();
       const result = await instanceJson.onPaste(jsonData);
@@ -249,7 +308,7 @@ export const initCopyPasteForContentEditMode = ({
       showUnsupportedPasteMessage();
       return;
     }
-    const textData = event.clipboardData?.getData(instanceText.mimeType).trim();
+    const textData = dataByMimeType.get(instanceText.mimeType);
     if (textData) {
       event.preventDefault();
       const result = await instanceText.onPaste(textData);
@@ -258,6 +317,23 @@ export const initCopyPasteForContentEditMode = ({
         return;
       }
       showUnsupportedPasteMessage();
+      return;
+    }
+    showUnsupportedPasteMessage();
+  };
+
+  const handlePasteText = async (text: string) => {
+    if (validatePasteCommand() === false) {
+      return;
+    }
+    const textData = text.trim();
+    if (textData === "") {
+      showUnsupportedPasteMessage();
+      return;
+    }
+    const result = await instanceText.onPaste(textData);
+    if (isPasteHandled(result)) {
+      reportPasteResult(result);
       return;
     }
     showUnsupportedPasteMessage();
@@ -278,6 +354,7 @@ export const initCopyPasteForContentEditMode = ({
     capture: true,
     signal,
   });
+  registerPasteClipboardText(handlePasteText, signal);
 };
 
 const writeClipboardText = async (
@@ -321,18 +398,7 @@ export const emitPaste = async () => {
   if (text === undefined) {
     return;
   }
-
-  // Create and dispatch a paste event to go through the normal handlePaste flow
-  const dataTransfer = new DataTransfer();
-  dataTransfer.setData("text/plain", text);
-
-  const pasteEvent = new ClipboardEvent("paste", {
-    clipboardData: dataTransfer,
-    bubbles: true,
-    cancelable: true,
-  });
-
-  document.dispatchEvent(pasteEvent);
+  await pasteClipboardText?.(text);
 };
 
 export const cutInstance = () => {


### PR DESCRIPTION
## Summary

- Read every clipboard mime type before the first await in both paste handlers.
- Call the paste handler registered by the active mode from `emitPaste` instead of dispatching a synthetic clipboard event.
- Add regression coverage for both paths: a clipboard event that disconnects after dispatch, and a Firefox-shaped `ClipboardEvent`.

## Root cause

Two independent Firefox behaviors, one per entry point.

Keyboard paste: the plugin loop re-read `event.clipboardData` on every iteration. Firefox disconnects a paste event's `DataTransfer` as soon as the handler yields, so once `pageText` — first in the list, and async — awaited, every later plugin read an empty string and `instanceText` never received the payload. Chrome keeps the data readable across microtasks, which is why this only surfaced in Firefox. Introduced in #5798, which put `pageText` at the head of the plugin list.

Context menu paste: `emitPaste` dispatched `new ClipboardEvent("paste", { clipboardData })`. Gecko's `ClipboardEventInit` has no `clipboardData` member, so the event arrived with a non-null but empty `clipboardData`. `validateClipboardEvent` only rejects a null one, so the paste silently did nothing — no toast, no error.

Measured in Firefox 134 against Chrome and Edge 152: `getData` after one microtask returns the payload in Chromium and an empty string in Firefox; a synthetic event's `getData` likewise returns the payload in Chromium and an empty string in Firefox.

No behavior change in Chromium. Every plugin returns `pasteIgnored` before its first await, so reading all mime types up front yields the same input the loop received before.

## Verification

- `pnpm --filter @webstudio-is/builder exec vitest run app/shared/copy-paste app/builder/shared/asset-manager app/shared/commands-emitter.test.ts` — 335 tests passed.
- `pnpm --filter @webstudio-is/builder typecheck` — passed.
- `pnpm exec oxlint --deny-warnings apps/builder/app/shared/copy-paste/` — passed.
- `pnpm exec oxfmt --check apps/builder/app/shared/copy-paste/copy-paste.ts apps/builder/app/shared/copy-paste/copy-paste.test.ts` — passed.
- Reverted each fix in turn against the new tests: 13 failures for the keyboard path, 2 for the context menu, all passing again once restored.
- e2e runs Chromium only, and the previous test `DataTransfer` never disconnected, so neither path was covered before.

Closes #6288
