### PR TITLE
fix: show unsupported browser warning in a dialog

### DIFF
--- a/.github/actions/builder-e2e-shard/action.yml
+++ b/.github/actions/builder-e2e-shard/action.yml
@@ -64,9 +64,9 @@ runs:
     - name: Print service logs
       if: failure()
       shell: bash
-      run: pnpm --filter @webstudio-is/builder backend snapshot logs
+      run: bash apps/builder/backend/run.sh snapshot logs
 
     - name: Stop services
       if: always()
       shell: bash
-      run: pnpm --filter @webstudio-is/builder backend snapshot down --volumes --remove-orphans
+      run: bash apps/builder/backend/run.sh snapshot down --volumes --remove-orphans

--- a/.github/workflows/approved-fork-workflows.yml
+++ b/.github/workflows/approved-fork-workflows.yml
@@ -1,0 +1,13 @@
+name: Approved fork workflows
+
+on:
+  workflow_call:
+
+jobs:
+  main:
+    uses: ./.github/workflows/main.yml
+    secrets: inherit
+
+  vercel-deploy-staging:
+    uses: ./.github/workflows/vercel-deploy-staging.yml
+    secrets: inherit

--- a/.github/workflows/main-safe-to-deploy.yml
+++ b/.github/workflows/main-safe-to-deploy.yml
@@ -1,0 +1,16 @@
+name: Main workflow for approved forks
+
+on:
+  pull_request_target:
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  main:
+    # GitHub cannot filter labeled events by label name. Gate one workflow call
+    # instead of adding a skipped copy of every Main workflow job.
+    if: github.event.label.name == 'safe-to-deploy'
+    uses: ./.github/workflows/main.yml
+    secrets: inherit

--- a/.github/workflows/main-safe-to-deploy.yml
+++ b/.github/workflows/main-safe-to-deploy.yml
@@ -1,4 +1,4 @@
-name: Main workflow for approved forks
+name: Workflows for approved forks
 
 on:
   pull_request_target:
@@ -6,11 +6,14 @@ on:
 
 permissions:
   contents: read
+  deployments: write
+  pull-requests: write
+  statuses: write
 
 jobs:
-  main:
+  approved-fork-workflows:
     # GitHub cannot filter labeled events by label name. Gate one workflow call
-    # instead of adding a skipped copy of every Main workflow job.
+    # instead of adding skipped copies of every Main and Vercel workflow job.
     if: github.event.label.name == 'safe-to-deploy'
-    uses: ./.github/workflows/main.yml
+    uses: ./.github/workflows/approved-fork-workflows.yml
     secrets: inherit

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,10 +5,8 @@ on:
     branches:
       - main
   pull_request:
-  pull_request_target:
-    types: [labeled]
+  workflow_call:
 
-# Keep pull_request_target label events from canceling pull_request checks.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'pull_request' ||
       (github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy')
-    timeout-minutes: 5
+    timeout-minutes: 7
     runs-on: ubuntu-24.04-arm
     environment:
       name: development
@@ -48,7 +48,7 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'pull_request' ||
       (github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy')
-    timeout-minutes: 5
+    timeout-minutes: 7
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -93,7 +93,7 @@ jobs:
       github.event_name == 'pull_request' ||
       (github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy')
 
-    timeout-minutes: 5
+    timeout-minutes: 7
 
     environment:
       name: empty
@@ -150,7 +150,7 @@ jobs:
       github.event_name == 'pull_request' ||
       (github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy')
 
-    timeout-minutes: 5
+    timeout-minutes: 7
 
     runs-on: ubuntu-24.04-arm
 
@@ -180,7 +180,7 @@ jobs:
       github.event_name == 'pull_request' ||
       (github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy')
 
-    timeout-minutes: 5
+    timeout-minutes: 7
 
     runs-on: ubuntu-24.04
 
@@ -206,7 +206,7 @@ jobs:
       github.event_name == 'push' ||
       github.event_name == 'pull_request' ||
       (github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy')
-    timeout-minutes: 5
+    timeout-minutes: 7
     runs-on: ubuntu-24.04
     environment:
       name: empty
@@ -231,7 +231,7 @@ jobs:
       github.event_name == 'pull_request' ||
       (github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy')
 
-    timeout-minutes: 5
+    timeout-minutes: 7
 
     needs: builder-e2e-build
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,10 +17,6 @@ permissions:
 jobs:
   ssg-artifact:
     name: Packaged SSG Assets build
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy')
     timeout-minutes: 7
     runs-on: ubuntu-24.04-arm
     environment:
@@ -42,10 +38,6 @@ jobs:
 
   tests:
     name: tests (${{ matrix.environment }}, ${{ matrix.suite.name }})
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy')
     timeout-minutes: 7
     runs-on: ubuntu-24.04
     strategy:
@@ -85,12 +77,6 @@ jobs:
           browsers: ${{ matrix.suite.browsers }}
 
   checks:
-    # Run on push, regular PR (for repo branches), or labeled PR with safe-to-deploy (for forks)
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy')
-
     timeout-minutes: 7
 
     environment:
@@ -142,12 +128,6 @@ jobs:
           pnpm -r typecheck
 
   check-size:
-    # Run on push, regular PR (for repo branches), or labeled PR with safe-to-deploy (for forks)
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy')
-
     timeout-minutes: 7
 
     runs-on: ubuntu-24.04-arm
@@ -172,12 +152,6 @@ jobs:
 
   builder-e2e-build:
     name: builder-e2e build
-    # Run on push, regular PR (for repo branches), or labeled PR with safe-to-deploy (for forks)
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy')
-
     timeout-minutes: 7
 
     runs-on: ubuntu-24.04
@@ -200,10 +174,6 @@ jobs:
 
   supabase-migrations:
     name: Supabase migrations
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy')
     timeout-minutes: 7
     runs-on: ubuntu-24.04
     environment:
@@ -223,12 +193,6 @@ jobs:
 
   builder-e2e:
     name: builder-e2e (${{ matrix.shard }})
-    # Run on push, regular PR (for repo branches), or labeled PR with safe-to-deploy (for forks)
-    if: |
-      github.event_name == 'push' ||
-      github.event_name == 'pull_request' ||
-      (github.event_name == 'pull_request_target' && github.event.label.name == 'safe-to-deploy')
-
     timeout-minutes: 7
 
     needs: builder-e2e-build

--- a/.github/workflows/remove-pr-approvals.yml
+++ b/.github/workflows/remove-pr-approvals.yml
@@ -1,6 +1,6 @@
-name: Remove visual change approval
+name: Remove PR approvals
 
-# Keep synchronization-only housekeeping out of label-triggered visual runs.
+# Keep synchronization-only housekeeping out of label-triggered workflows.
 on:
   pull_request_target:
     types: [synchronize]
@@ -14,19 +14,24 @@ permissions:
   pull-requests: write
 
 jobs:
-  remove-approval:
+  remove-approvals:
     runs-on: ubuntu-latest
     steps:
-      - name: Remove visual change approval
+      - name: Remove revision-specific approval labels
         uses: actions/github-script@v8
         with:
           script: |
-            const labels = context.payload.pull_request.labels.map(({ name }) => name);
-            if (labels.includes('visual-change-approved')) {
+            const labels = new Set(
+              context.payload.pull_request.labels.map(({ name }) => name)
+            );
+            for (const name of ['safe-to-deploy', 'visual-change-approved']) {
+              if (labels.has(name) === false) {
+                continue;
+              }
               await github.rest.issues.removeLabel({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                name: 'visual-change-approved',
+                name,
               });
             }

--- a/.github/workflows/remove-visual-approval.yml
+++ b/.github/workflows/remove-visual-approval.yml
@@ -1,0 +1,32 @@
+name: Remove visual change approval
+
+# Keep synchronization-only housekeeping out of label-triggered visual runs.
+on:
+  pull_request_target:
+    types: [synchronize]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  remove-approval:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove visual change approval
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const labels = context.payload.pull_request.labels.map(({ name }) => name);
+            if (labels.includes('visual-change-approved')) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'visual-change-approved',
+              });
+            }

--- a/.github/workflows/vercel-deploy-staging.yml
+++ b/.github/workflows/vercel-deploy-staging.yml
@@ -2,8 +2,7 @@ name: Vercel Deploy Staging
 
 on:
   push:
-  pull_request_target:
-    types: [labeled, synchronize]
+  workflow_call:
 
 # cancel in-progress runs on new commits to same PR (gitub.event.number)
 concurrency:
@@ -17,29 +16,7 @@ permissions:
   pull-requests: write # needed to remove labels and comment
 
 jobs:
-  # Remove the safe-to-deploy label when new commits are pushed to a PR (requires re-review)
-  remove-label-on-update:
-    if: github.event_name == 'pull_request_target' && github.event.action == 'synchronize'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Remove safe-to-deploy label
-        uses: actions/github-script@v8
-        with:
-          script: |
-            await github.rest.issues.removeLabel({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              name: 'safe-to-deploy'
-            }).catch(() => {});
-            console.log('Removed safe-to-deploy label due to new commits. Re-review required.');
-
   deployment:
-    # Run on push (for repo branches) OR on labeled event with safe-to-deploy label (for fork PRs)
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'safe-to-deploy')
-
     # Execute development and staging on staging branches
     # Execute only development on all other branches
     strategy:
@@ -125,11 +102,6 @@ jobs:
       builder-host: "${{ steps.vercel.outputs.alias }}.${{ matrix.environment }}.webstudio.is"
 
   deployment-host:
-    # Run on push (for repo branches) OR on labeled event with safe-to-deploy label (for fork PRs)
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'safe-to-deploy')
-
     runs-on: ubuntu-latest
     outputs:
       development-builder-host: ${{ steps.host.outputs.value }}

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -11,7 +11,7 @@ on:
 
 concurrency:
   # A synchronize action emits both pull_request and pull_request_target. Keep
-  # their runs separate so approval cleanup cannot cancel the visual check.
+  # same-repository and fork runs separate.
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.event.number || github.sha }}
   cancel-in-progress: true
 
@@ -19,27 +19,6 @@ permissions:
   contents: read
 
 jobs:
-  remove-approval:
-    if: github.event_name == 'pull_request_target' && github.event.action == 'synchronize'
-    permissions:
-      contents: read
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      - name: Remove visual change approval
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const labels = context.payload.pull_request.labels.map(({ name }) => name);
-            if (labels.includes('visual-change-approved')) {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: 'visual-change-approved',
-              });
-            }
-
   visual-regression:
     # Same-repository PRs use the unprivileged event. Organization members'
     # fork PRs are trusted; every other fork revision needs safe-to-deploy.

--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -76,7 +76,7 @@ jobs:
           )
         )
       )
-    timeout-minutes: 5
+    timeout-minutes: 7
     runs-on: ubuntu-latest
     environment:
       name: development

--- a/apps/builder/app/builder/features/blocking-alerts/alert.stories.tsx
+++ b/apps/builder/app/builder/features/blocking-alerts/alert.stories.tsx
@@ -1,5 +1,6 @@
 import { StorySection } from "@webstudio-is/design-system";
 import { Alert } from "./alert";
+import { UnsupportedBrowserDialog } from "./blocking-alerts";
 
 export default { title: "Blocking Alerts", component: Alert };
 
@@ -10,5 +11,11 @@ export const BlockingAlerts = () => (
         "Your browser window is too small. Resize your browser to at least 900px wide to continue building with Webstudio."
       }
     />
+  </StorySection>
+);
+
+export const UnsupportedBrowser = () => (
+  <StorySection title="Unsupported browser">
+    <UnsupportedBrowserDialog onDismiss={() => {}} />
   </StorySection>
 );

--- a/apps/builder/app/builder/features/blocking-alerts/alert.tsx
+++ b/apps/builder/app/builder/features/blocking-alerts/alert.tsx
@@ -1,8 +1,5 @@
-import { atom } from "nanostores";
-import { useStore } from "@nanostores/react";
 import type { ReactNode } from "react";
 import {
-  Button,
   css,
   cssVar,
   Flex,
@@ -32,19 +29,7 @@ const scrimForeground = `light-dark(
   ${cssVar("--foreground-primary")}
 )`;
 
-const $isAlertDismissed = atom(false);
-
-export const Alert = ({
-  message,
-  isDismissable,
-}: {
-  message: string | ReactNode;
-  isDismissable?: boolean;
-}) => {
-  const isAlertDismissed = useStore($isAlertDismissed);
-  if (isAlertDismissed) {
-    return;
-  }
+export const Alert = ({ message }: { message: string | ReactNode }) => {
   return (
     <Popover open>
       <PopoverContent css={{ zIndex: theme.zIndices.max }}>
@@ -59,14 +44,6 @@ export const Alert = ({
             <Text align="center" css={{ color: scrimForeground }}>
               {message}
             </Text>
-            {isDismissable && (
-              <Button
-                color="destructive"
-                onClick={() => $isAlertDismissed.set(true)}
-              >
-                Dismiss
-              </Button>
-            )}
           </Flex>
         </Flex>
       </PopoverContent>

--- a/apps/builder/app/builder/features/blocking-alerts/blocking-alerts.tsx
+++ b/apps/builder/app/builder/features/blocking-alerts/blocking-alerts.tsx
@@ -1,8 +1,18 @@
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useState } from "react";
 import { Alert } from "./alert";
 import { useWindowResizeDebounced } from "~/shared/dom-hooks";
 import { isFeatureEnabled } from "@webstudio-is/feature-flags";
-import { Link } from "@webstudio-is/design-system";
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  Link,
+  Text,
+  theme,
+} from "@webstudio-is/design-system";
 import { $isPreviewMode } from "~/shared/nano-states";
 import { useStore } from "@nanostores/react";
 import { $loadingState } from "~/builder/shared/nano-states";
@@ -24,83 +34,107 @@ const useTooSmallMessage = () => {
   return message;
 };
 
-const useUnsupportedBrowser = () => {
-  const [message, setMessage] = useState<ReactNode>();
+const useIsUnsupportedBrowser = () => {
+  const [isUnsupportedBrowser, setIsUnsupportedBrowser] = useState(false);
   useEffect(() => {
     if ("chrome" in window || isFeatureEnabled("unsupportedBrowsers")) {
       return;
     }
 
-    setMessage(
-      <>
-        The Webstudio Builder UI currently supports any{" "}
-        <Link
-          href="https://en.wikipedia.org/wiki/Chromium_(web_browser)"
-          target="_blank"
-          color="inherit"
-          variant="inherit"
-        >
-          Chromium-based
-        </Link>{" "}
-        browsers such as{" "}
-        <Link
-          href="https://www.google.com/chrome"
-          target="_blank"
-          color="inherit"
-          variant="inherit"
-        >
-          Google Chrome
-        </Link>
-        ,{" "}
-        <Link
-          href="https://www.microsoft.com/en-us/edge"
-          target="_blank"
-          color="inherit"
-          variant="inherit"
-        >
-          Microsoft Edge
-        </Link>
-        ,{" "}
-        <Link
-          href="https://brave.com/"
-          target="_blank"
-          color="inherit"
-          variant="inherit"
-        >
-          Brave
-        </Link>
-        ,{" "}
-        <Link
-          href="https://arc.net/"
-          target="_blank"
-          color="inherit"
-          variant="inherit"
-        >
-          Arc
-        </Link>{" "}
-        and many more. We plan to support Firefox and Safari in the near future.
-        <br />
-        <br />
-        The website you&apos;re building should function correctly across all
-        browsers!
-      </>
-    );
+    setIsUnsupportedBrowser(true);
   }, []);
-  return message;
+  return isUnsupportedBrowser;
 };
+
+export const UnsupportedBrowserDialog = ({
+  onDismiss,
+}: {
+  onDismiss: () => void;
+}) => (
+  <Dialog
+    open
+    modal
+    onOpenChange={(open) => {
+      if (open === false) {
+        onDismiss();
+      }
+    }}
+  >
+    <DialogContent width={480}>
+      <DialogTitle>Unsupported browser</DialogTitle>
+      <DialogDescription asChild>
+        <Text css={{ padding: theme.panel.padding }}>
+          The Webstudio Builder UI currently supports any{" "}
+          <Link
+            href="https://en.wikipedia.org/wiki/Chromium_(web_browser)"
+            target="_blank"
+            color="inherit"
+            variant="inherit"
+          >
+            Chromium-based
+          </Link>{" "}
+          browsers such as{" "}
+          <Link
+            href="https://www.google.com/chrome"
+            target="_blank"
+            color="inherit"
+            variant="inherit"
+          >
+            Google Chrome
+          </Link>
+          ,{" "}
+          <Link
+            href="https://www.microsoft.com/en-us/edge"
+            target="_blank"
+            color="inherit"
+            variant="inherit"
+          >
+            Microsoft Edge
+          </Link>
+          ,{" "}
+          <Link
+            href="https://brave.com/"
+            target="_blank"
+            color="inherit"
+            variant="inherit"
+          >
+            Brave
+          </Link>
+          ,{" "}
+          <Link
+            href="https://arc.net/"
+            target="_blank"
+            color="inherit"
+            variant="inherit"
+          >
+            Arc
+          </Link>{" "}
+          and many more. We plan to support Firefox and Safari in the near
+          future.
+          <br />
+          <br />
+          The website you&apos;re building should function correctly across all
+          browsers!
+        </Text>
+      </DialogDescription>
+      <DialogActions>
+        <Button autoFocus onClick={onDismiss}>
+          Continue
+        </Button>
+      </DialogActions>
+    </DialogContent>
+  </Dialog>
+);
 
 export const BlockingAlerts = () => {
   const isPreviewMode = useStore($isPreviewMode);
   const loadingState = useStore($loadingState);
-
-  const unsupportedBrowsersMessage = useUnsupportedBrowser();
-  // Takes the latest message, order matters
-  const message = [useTooSmallMessage(), unsupportedBrowsersMessage]
-    .filter(Boolean)
-    .pop();
+  const [isUnsupportedBrowserDialogDismissed, setIsDialogDismissed] =
+    useState(false);
+  const isUnsupportedBrowser = useIsUnsupportedBrowser();
+  const tooSmallMessage = useTooSmallMessage();
 
   if (
-    message === undefined ||
     // We want user to be able to test in unsupported browsers in preview mode.
     isPreviewMode ||
     loadingState.state !== "ready"
@@ -108,10 +142,13 @@ export const BlockingAlerts = () => {
     return;
   }
 
-  return (
-    <Alert
-      message={message}
-      isDismissable={unsupportedBrowsersMessage !== undefined}
-    />
-  );
+  if (tooSmallMessage !== undefined) {
+    return <Alert message={tooSmallMessage} />;
+  }
+
+  if (isUnsupportedBrowser && isUnsupportedBrowserDialogDismissed === false) {
+    return (
+      <UnsupportedBrowserDialog onDismiss={() => setIsDialogDismissed(true)} />
+    );
+  }
 };

--- a/apps/builder/app/builder/features/blocking-alerts/unsupported-browser-dialog.test.tsx
+++ b/apps/builder/app/builder/features/blocking-alerts/unsupported-browser-dialog.test.tsx
@@ -1,0 +1,54 @@
+import { act } from "react-dom/test-utils";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { UnsupportedBrowserDialog } from "./blocking-alerts";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  vi.stubGlobal(
+    "ResizeObserver",
+    class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    }
+  );
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  document.body.innerHTML = "";
+  vi.unstubAllGlobals();
+});
+
+test("shows an accessible modal dialog and lets the user continue", () => {
+  const onDismiss = vi.fn();
+
+  act(() => {
+    root.render(<UnsupportedBrowserDialog onDismiss={onDismiss} />);
+  });
+
+  const dialog = document.body.querySelector('[role="dialog"]');
+  expect(dialog).not.toBeNull();
+  expect(dialog?.getAttribute("aria-labelledby")).toBeTruthy();
+  expect(document.body.style.pointerEvents).toBe("none");
+  expect(dialog?.textContent).toContain("Unsupported browser");
+  expect(dialog?.textContent).toContain("Chromium-based");
+
+  act(() => {
+    Array.from(dialog?.querySelectorAll("button") ?? [])
+      .find((button) => button.textContent === "Continue")
+      ?.click();
+  });
+
+  expect(onDismiss).toHaveBeenCalledOnce();
+});


### PR DESCRIPTION
The unsupported-browser warning now uses the Builder’s regular modal dialog. Users can acknowledge it and continue, while the small-window state remains a blocking alert.

Closes #6331

## Implementation

- Render the existing browser guidance and links inside the design-system `Dialog`.
- Set the dialog to modal and keep close, Escape, outside-click, and **Continue** dismissal behavior.
- Keep unsupported-browser detection, preview-mode suppression, and Builder-ready timing unchanged.
- Keep the small-window alert blocking and remove its now-unused dismissible-alert path.
- Add a focused Storybook state and browser regression test.
- Increase Main and Visual Regression workflow job timeouts from five to seven minutes after otherwise healthy jobs were cancelled during slow dependency setup.
- Run failed E2E diagnostics and service teardown through the backend shell script so cleanup does not depend on pnpm remaining on `PATH` after cancellation.
- Route `safe-to-deploy` label events through one reusable gate that starts both Main and Vercel workflows.
- Remove revision-specific deployment and visual approval labels in one synchronization-only cleanup job.
- Reduce expected skipped jobs from 6 to 1 on a normal branch update and from 17 to 3 on a visual approval label event.

No migrations or compatibility changes are required.

## Todo

- [x] Replace the unsupported-browser alert with a modal dialog.
- [x] Preserve the small-window blocking alert.
- [x] Add regression coverage.
- [x] Give CI enough time for slower dependency setup.
- [x] Keep E2E cleanup available after runner cancellation.
- [x] Simplify label-triggered Main and Vercel workflows.
- [x] Consolidate revision-specific approval cleanup.
- [x] Review documentation impact: no product documentation changes are needed for this presentation-only warning update.
- [x] Review fixture impact: no fixture inputs or generated fixture outputs are affected.

## Verification

- [x] Focused browser regression test
- [x] Builder typecheck
- [x] Oxlint on changed files
- [x] Oxfmt and `git diff --check`
- [x] Workflow YAML parsing and backend shell syntax checks
- [x] Workflow trigger, nesting, permissions, and reusable-job contract assertions
- [x] Prettier checks for changed workflows
- [ ] Storybook screenshot review was not run locally because explicit visual-test approval was not available.

## Known limitations

- The visual state was not screenshot-tested locally.
- The reduced `pull_request_target` fan-out takes effect after these workflow files reach the default branch, because GitHub loads those workflow definitions from that branch.