### PR TITLE
fix: Allow approved fork workflow checkouts

### DIFF
--- a/.github/workflows/fixtures-test.yml
+++ b/.github/workflows/fixtures-test.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'safe-to-deploy' }}
       # Test that everything is working with submodules
       - uses: ./.github/actions/submodules-checkout
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'safe-to-deploy' }}
 
       - uses: ./.github/actions/submodules-checkout
         with:
@@ -69,6 +70,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'safe-to-deploy' }}
 
       - uses: ./.github/actions/test-suite
         with:
@@ -92,6 +94,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'safe-to-deploy' }}
 
       - uses: pnpm/action-setup@v6
 
@@ -139,6 +142,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'safe-to-deploy' }}
 
       - uses: ./.github/actions/submodules-checkout
         with:
@@ -166,6 +170,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'safe-to-deploy' }}
 
       - id: build
         uses: ./.github/actions/builder-e2e-build
@@ -183,6 +188,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'safe-to-deploy' }}
 
       - uses: ./.github/actions/ci-setup
         with:
@@ -210,6 +216,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          allow-unsafe-pr-checkout: ${{ github.event_name == 'pull_request_target' && github.event.action == 'labeled' && github.event.label.name == 'safe-to-deploy' }}
 
       - uses: ./.github/actions/builder-e2e-shard
         with:


### PR DESCRIPTION
Approved fork workflows currently fail before tests start. GitHub rejects the fork-head checkout in the trusted `pull_request_target` context even after the `safe-to-deploy` label is applied.

## Implementation

- Opt into the fork checkout for every reusable Main workflow job only when the event is a `safe-to-deploy` label approval.
- Apply the same guard to the nested fixture workflow.
- Keep normal pushes and regular pull request checkouts unchanged.

## Todo

- [x] Guard all Main workflow checkouts.
- [x] Guard the nested fixture workflow checkout.
- [x] Verify the opt-in remains false for normal pushes and pull requests.
- [x] Review documentation impact: no product documentation is affected.
- [x] Review fixture impact: no fixture inputs or generated outputs are affected.
- [ ] Merge this change into `main`, then reapply `safe-to-deploy` to the affected fork PR.

## Verification

- [x] Prettier check for both changed workflows.
- [x] `git diff --check`.
- [x] Confirmed all seven Main checkouts and the fixture checkout use the guarded opt-in.

## Known limitation

GitHub loads `pull_request_target` workflow definitions from the default branch. The repaired approved-fork run can only be verified after this change reaches `main`.

Ref #6332

Ref #6329