### PR TITLE
feat: Expose Force Mount for Collapsible Content

### DIFF
--- a/docs/university/radix/collapsible.md
+++ b/docs/university/radix/collapsible.md
@@ -30,6 +30,10 @@ To customize the Collapsible component:
 2. **Collapsible Content**: Edit the content section to add whatever elements you want to show/hide when the collapsible is toggled.
 3. **Styling**: Any of the three components can be styled to match your design requirements.
 
+## Keep closed content in the HTML
+
+Select **Collapsible Content** and enable **Force Mount** to keep its content in the HTML while the Collapsible is closed. New Collapsible components enable this setting by default. Disable it to remove closed content from the HTML.
+
 ## Using Collapsible for UI Patterns
 
 The Collapsible component is useful for various UI patterns:

--- a/packages/sdk-components-react-radix/src/__generated__/collapsible.props.ts
+++ b/packages/sdk-components-react-radix/src/__generated__/collapsible.props.ts
@@ -16,4 +16,12 @@ export const propsCollapsible: Record<string, PropMeta> = {
   },
 };
 export const propsCollapsibleTrigger: Record<string, PropMeta> = {};
-export const propsCollapsibleContent: Record<string, PropMeta> = {};
+export const propsCollapsibleContent: Record<string, PropMeta> = {
+  forceMount: {
+    description:
+      "Used to force mounting when more control is needed. Useful when controlling animation with React animation libraries or keeping content available in the DOM.",
+    required: false,
+    control: "boolean",
+    type: "boolean",
+  },
+};

--- a/packages/sdk-components-react-radix/src/collapsible.template.tsx
+++ b/packages/sdk-components-react-radix/src/collapsible.template.tsx
@@ -1,4 +1,9 @@
-import { $, PlaceholderValue, type TemplateMeta } from "@webstudio-is/template";
+import {
+  $,
+  css,
+  PlaceholderValue,
+  type TemplateMeta,
+} from "@webstudio-is/template";
 import { radix } from "./shared/proxy";
 import { getButtonStyle } from "./shared/styles";
 
@@ -14,7 +19,18 @@ export const meta: TemplateMeta = {
           {new PlaceholderValue("Click to toggle content")}
         </$.Button>
       </radix.CollapsibleTrigger>
-      <radix.CollapsibleContent>
+      <radix.CollapsibleContent
+        forceMount={true}
+        ws:style={css`
+          overflow: hidden;
+          &[data-state="closed"] {
+            height: 0;
+          }
+          &[data-state="open"] {
+            height: var(--radix-collapsible-content-height);
+          }
+        `}
+      >
         <$.Text>{new PlaceholderValue("Collapsible Content")}</$.Text>
       </radix.CollapsibleContent>
     </radix.Collapsible>

--- a/packages/sdk-components-react-radix/src/collapsible.test.tsx
+++ b/packages/sdk-components-react-radix/src/collapsible.test.tsx
@@ -1,0 +1,25 @@
+import { renderTemplate } from "@webstudio-is/template";
+import { expect, test } from "vitest";
+import { propsCollapsibleContent } from "./__generated__/collapsible.props";
+import { meta } from "./collapsible.template";
+
+test("enables Force Mount for new Collapsible Content instances", () => {
+  const fragment = renderTemplate(meta.template);
+  const content = fragment.instances.find(
+    ({ component }) =>
+      component ===
+      "@webstudio-is/sdk-components-react-radix:CollapsibleContent"
+  );
+
+  expect(content).toBeDefined();
+  expect(
+    fragment.props.find(
+      ({ instanceId, name }) =>
+        instanceId === content?.id && name === "forceMount"
+    )
+  ).toMatchObject({ type: "boolean", value: true });
+  expect(propsCollapsibleContent.forceMount).toMatchObject({
+    control: "boolean",
+    type: "boolean",
+  });
+});

--- a/packages/sdk-components-react-radix/src/collapsible.tsx
+++ b/packages/sdk-components-react-radix/src/collapsible.tsx
@@ -1,10 +1,9 @@
 import {
   type ReactNode,
-  type ForwardRefExoticComponent,
   forwardRef,
   Children,
   type ComponentProps,
-  type RefAttributes,
+  type ComponentPropsWithoutRef,
   useState,
   useEffect,
 } from "react";
@@ -40,10 +39,16 @@ export const CollapsibleTrigger = forwardRef<
   );
 });
 
-export const CollapsibleContent: ForwardRefExoticComponent<
-  Omit<ComponentProps<typeof Content>, "asChild"> &
-    RefAttributes<HTMLDivElement>
-> = Content;
+export const CollapsibleContent = forwardRef<
+  HTMLDivElement,
+  Omit<ComponentPropsWithoutRef<typeof Content>, "asChild" | "forceMount"> & {
+    /** Used to force mounting when more control is needed. Useful when controlling animation with React animation libraries or keeping content available in the DOM. */
+    forceMount?: boolean;
+  }
+>(({ forceMount, ...props }, ref) => {
+  const contentProps = forceMount ? { forceMount: true as const } : {};
+  return <Content ref={ref} {...contentProps} {...props} />;
+});
 
 /* BUILDER HOOKS */
 


### PR DESCRIPTION
## Problem

Closed Collapsible Content is removed from the HTML, and the Builder does not expose Radix’s Force Mount option.

## Solution

- Expose **Force Mount** as a boolean on Collapsible Content.
- Enable it for newly inserted Collapsible templates.
- Keep closed force-mounted content visually collapsed with template styles.
- Preserve the existing Radix default for existing instances that do not set the prop.
- Add regression coverage for the template default and generated Builder metadata.

## Checklist

- [x] Expose the Force Mount control
- [x] Keep new Collapsible content mounted while closed
- [x] Preserve existing-instance behavior
- [x] Regenerate Collapsible prop metadata from source
- [x] Add regression coverage
- [x] Review documentation impact and update the Collapsible guide
- [x] Verify fixture inputs and outputs are not affected

## Verification

- [x] `pnpm --filter @webstudio-is/sdk-components-react-radix test` — 20 tests passed
- [x] `pnpm --filter @webstudio-is/sdk-components-react-radix typecheck`
- [x] `pnpm --filter @webstudio-is/sdk-components-react-radix build`
- [x] Targeted Oxlint and formatting checks
- [x] `git diff --check`

## Known limitations

Storybook visual verification was not run because it requires separate approval.

Closes #6337