### PR TITLE
fix: Preserve Global root tokens when importing templates

### DIFF
--- a/apps/builder/e2e/tests/mdx-content-block.[shard-4].e2e.ts
+++ b/apps/builder/e2e/tests/mdx-content-block.[shard-4].e2e.ts
@@ -491,6 +491,15 @@ test("Empty MDX content supports slash menu keyboard and mouse insertion", async
     authToken: fixture.editorToken,
     mode: "content",
   });
+  const revisionPatches: string[] = [];
+  page.on("request", (request) => {
+    if (request.url().includes("/trpc/build.patch")) {
+      const body = request.postData() ?? "";
+      if (body.includes('"namespace":"assets"')) {
+        revisionPatches.push(body);
+      }
+    }
+  });
   await insertTemplateIntoEmptyContentBlock({
     page,
     templateName: "Empty Heading Template",
@@ -607,6 +616,12 @@ test("Empty MDX content supports slash menu keyboard and mouse insertion", async
   }
   await page.mouse.click(5, 5);
   const finalSource = (await finalWrite).request().postData() ?? "";
+  await waitForSyncStatus({ page, status: "idle" });
+  if (revisionPatches.length > 0) {
+    throw new Error(
+      "Saved MDX revisions must not be persisted again by build.patch"
+    );
+  }
   const expectedContentOrder = [
     "# First heading",
     "Keyboard anchor",

--- a/packages/project-build/src/runtime/style-copy.test.ts
+++ b/packages/project-build/src/runtime/style-copy.test.ts
@@ -310,6 +310,87 @@ describe("style source insertion", () => {
     ]);
   });
 
+  test.each([
+    { incoming: [], expected: ["first-token", "second-token", "root-local"] },
+    {
+      incoming: ["incoming-local"],
+      expected: ["first-token", "second-token", "root-local"],
+    },
+    {
+      incoming: ["incoming-token"],
+      expected: ["first-token", "second-token", "root-local", "mapped-token"],
+    },
+    {
+      incoming: ["incoming-token", "reused-token", "incoming-local"],
+      expected: ["first-token", "second-token", "root-local", "mapped-token"],
+    },
+  ])(
+    "preserves root sources when importing $incoming",
+    ({ incoming, expected }) => {
+      const styleSources = toMap([
+        token("first-token", "Spacing"),
+        token("second-token", "Colors"),
+        token("mapped-token", "Imported"),
+        local("root-local"),
+      ]);
+      const styleSourceSelections: StyleSourceSelections = new Map([
+        [
+          ROOT_INSTANCE_ID,
+          {
+            instanceId: ROOT_INSTANCE_ID,
+            values: ["first-token", "second-token", "root-local"],
+          },
+        ],
+      ]);
+      const originalStyle = style("root-local", "base", "color", blue);
+      const styles = styleMap([originalStyle]);
+      const incomingStyles = incoming.includes("incoming-local")
+        ? [style("incoming-local", "incoming-base", "backgroundColor", red)]
+        : [];
+
+      // Repeated page imports must not detach sources or duplicate selections.
+      for (let index = 0; index < 2; index += 1) {
+        insertLocalStyleSourcesWithNewIds({
+          fragmentStyleSources: [
+            local("incoming-local"),
+            token("incoming-token", "Imported"),
+            token("reused-token", "Spacing"),
+          ],
+          fragmentStyleSourceSelections: [
+            { instanceId: ROOT_INSTANCE_ID, values: incoming },
+          ],
+          fragmentStyles: incomingStyles,
+          fragmentInstanceIds: new Set([ROOT_INSTANCE_ID]),
+          newInstanceIds: new Map([[ROOT_INSTANCE_ID, ROOT_INSTANCE_ID]]),
+          styleSources,
+          styleSourceSelections,
+          styles,
+          styleSourceIdMap: new Map([
+            ["incoming-token", "mapped-token"],
+            ["reused-token", "first-token"],
+          ]),
+          mergedBreakpointIds: new Map([["incoming-base", "base"]]),
+        });
+
+        expect(styleSourceSelections.get(ROOT_INSTANCE_ID)?.values).toEqual(
+          expected
+        );
+        expect(styles.get(getStyleDeclKey(originalStyle))).toEqual(
+          originalStyle
+        );
+        if (incomingStyles.length > 0) {
+          const mergedStyle = style(
+            "root-local",
+            "base",
+            "backgroundColor",
+            red
+          );
+          expect(styles.get(getStyleDeclKey(mergedStyle))).toEqual(mergedStyle);
+        }
+      }
+    }
+  );
+
   test("copies local style sources with new ids and maps selections", () => {
     const styleSources: StyleSources = new Map([
       ["existing-token", token("existing-token", "Primary")],

--- a/packages/project-build/src/runtime/style-copy.ts
+++ b/packages/project-build/src/runtime/style-copy.ts
@@ -700,7 +700,14 @@ export const insertLocalStyleSourcesWithNewIds = ({
     }
     styleSourceSelections.set(targetInstanceId, {
       instanceId: targetInstanceId,
-      values: newStyleSourceIds,
+      // Global root is shared by every page, so importing a fragment must
+      // preserve its existing tokens and their cascade order.
+      values:
+        contentMode === false && instanceId === ROOT_INSTANCE_ID
+          ? Array.from(
+              new Set([...existingStyleSourceIds, ...newStyleSourceIds])
+            )
+          : newStyleSourceIds,
     });
   }
 


### PR DESCRIPTION
Inserting the CMS Sitemap marketplace page could detach existing Global root tokens and break styles across existing pages. Preserve the root's existing style-source selections in their original order, then append mapped incoming sources without duplicates. Incoming local declarations continue to merge into the existing root local source.

The MDX save fix is now included in main through `commitAssetContentUpdate`. This PR retains an E2E assertion that saved MDX revisions are not persisted again through `build.patch`.

Closes #6347

Verification and delivery:

- [x] Add four regression cases covering empty, local-only, token-only, and mixed incoming root selections, including repeated imports, token remapping, and local declaration merging. All four failed before the fix and pass after it.
- [x] Rebase onto main and rerun style-copy and page-copy tests: 55 passed. Formatting and diff checks passed.
- [x] Verify the cloned project locally: reproduce the broken Home canvas before the fix and restore it with Undo. After the fix, insert Sitemap and verify Home retains its logo sizing, typography, spacing, rounded corners, and both Global root tokens after reload.
- [x] Verify the MDX E2E assertion fails with duplicate persistence and passes with the fix. Before rebase, all 13 shard 4 tests passed locally with four workers, along with relevant typecheck and lint checks.
- [x] Resolve the rebase conflict using main's shared MDX implementation and remove the duplicate helper from this branch.
- [x] Review documentation impact against marketplace, CSS-variable, and Content Block documentation: no documentation changes required.
- [x] Review fixture impact: no fixture inputs, serialization formats, or generated contracts changed.

No migrations are required. This prevents future imports from dropping root selections; it does not reconstruct selections already lost in previously saved projects.