### PR TITLE
fix: improve asset upload retries and diagnostics

### DIFF
--- a/packages/http-client/src/index.test.ts
+++ b/packages/http-client/src/index.test.ts
@@ -1567,6 +1567,18 @@ test("reports retry diagnostics and permits an isolated retry after a partial ba
   const uploadedAsset = createImageAssetFixture({ name: "uploaded.jpg" });
   const retriedAsset = createImageAssetFixture({ name: "retried.jpg" });
   let retriedAssetAttempts = 0;
+  const response = (asset?: typeof uploadedAsset) =>
+    new Response(
+      JSON.stringify(
+        asset === undefined
+          ? { errors: "Internal Assets API error" }
+          : { uploadedAssets: [asset], deduplicated: false }
+      ),
+      {
+        status: asset === undefined ? 500 : 200,
+        headers: { "content-type": "application/json" },
+      }
+    );
   vi.stubGlobal(
     "fetch",
     vi.fn(async (request: URL | RequestInfo) => {
@@ -1574,30 +1586,10 @@ test("reports retry diagnostics and permits an isolated retry after a partial ba
         new URL(request.toString()).pathname.split("/").at(-1) ?? ""
       );
       if (name === "uploaded.jpg") {
-        return new Response(
-          JSON.stringify({
-            uploadedAssets: [uploadedAsset],
-            deduplicated: false,
-          }),
-          { headers: { "content-type": "application/json" } }
-        );
+        return response(uploadedAsset);
       }
       retriedAssetAttempts += 1;
-      return retriedAssetAttempts <= 2
-        ? new Response(
-            JSON.stringify({ errors: "Internal Assets API error" }),
-            {
-              status: 500,
-              headers: { "content-type": "application/json" },
-            }
-          )
-        : new Response(
-            JSON.stringify({
-              uploadedAssets: [retriedAsset],
-              deduplicated: false,
-            }),
-            { headers: { "content-type": "application/json" } }
-          );
+      return response(retriedAssetAttempts <= 2 ? undefined : retriedAsset);
     })
   );
   const descriptor = {

--- a/packages/http-client/src/index.test.ts
+++ b/packages/http-client/src/index.test.ts
@@ -1365,6 +1365,7 @@ test("uploads assets with one retry and aggregated failures", async () => {
           assetName === "image.png" ? "Temporary failure" : "Upload failed",
       }),
       {
+        status: 500,
         headers: { "content-type": "application/json" },
       }
     );
@@ -1377,7 +1378,14 @@ test("uploads assets with one retry and aggregated failures", async () => {
       ...apiParams,
       readAssetData: async (asset) => new Blob([asset.name]),
     })
-  ).rejects.toThrow("Failed to upload assets: other.png: Upload failed");
+  ).rejects.toMatchObject({
+    message: expect.stringContaining(
+      'Asset "other.png" failed after 2 attempts'
+    ),
+    webstudioCode: "ASSET_UPLOAD_RETRY_EXHAUSTED",
+    retryable: true,
+    status: 500,
+  });
 
   expect(fetch).toHaveBeenCalledTimes(4);
 });
@@ -1555,15 +1563,17 @@ test("uploads project asset descriptors with local data readers", async () => {
   expect(videoUrl.searchParams.get("height")).toBe("1080");
 });
 
-test("reports successful and failed project asset uploads separately", async () => {
-  const uploadedAsset = createImageAssetFixture({ name: "uploaded.png" });
+test("reports retry diagnostics and permits an isolated retry after a partial batch failure", async () => {
+  const uploadedAsset = createImageAssetFixture({ name: "uploaded.jpg" });
+  const retriedAsset = createImageAssetFixture({ name: "retried.jpg" });
+  let retriedAssetAttempts = 0;
   vi.stubGlobal(
     "fetch",
     vi.fn(async (request: URL | RequestInfo) => {
       const name = decodeURIComponent(
         new URL(request.toString()).pathname.split("/").at(-1) ?? ""
       );
-      if (name === "uploaded.png") {
+      if (name === "uploaded.jpg") {
         return new Response(
           JSON.stringify({
             uploadedAssets: [uploadedAsset],
@@ -1572,36 +1582,60 @@ test("reports successful and failed project asset uploads separately", async () 
           { headers: { "content-type": "application/json" } }
         );
       }
-      return new Response(JSON.stringify({ errors: "Upload failed" }), {
-        headers: { "content-type": "application/json" },
-      });
+      retriedAssetAttempts += 1;
+      return retriedAssetAttempts <= 2
+        ? new Response(
+            JSON.stringify({ errors: "Internal Assets API error" }),
+            {
+              status: 500,
+              headers: { "content-type": "application/json" },
+            }
+          )
+        : new Response(
+            JSON.stringify({
+              uploadedAssets: [retriedAsset],
+              deduplicated: false,
+            }),
+            { headers: { "content-type": "application/json" } }
+          );
     })
   );
+  const descriptor = {
+    name: "retried.jpg",
+    type: "image" as const,
+    format: "jpg",
+    meta: { width: 10, height: 20 },
+  };
 
   await expect(
     uploadProjectAssets({
       ...apiParams,
-      assets: [
-        {
-          name: "uploaded.png",
-          type: "image",
-          format: "png",
-          meta: { width: 10, height: 20 },
-        },
-        {
-          name: "failed.png",
-          type: "image",
-          format: "png",
-          meta: { width: 10, height: 20 },
-        },
-      ],
+      assets: [{ ...descriptor, name: "uploaded.jpg" }, descriptor],
       readAssetData: async (asset) => new Blob([asset.name]),
     })
   ).resolves.toEqual({
     uploaded: [uploadedAsset],
-    failed: [{ index: 1, name: "failed.png", error: "Upload failed" }],
+    failed: [
+      {
+        index: 1,
+        name: "retried.jpg",
+        error: expect.stringContaining("failed after 2 attempts (HTTP 500)"),
+        code: "ASSET_UPLOAD_RETRY_EXHAUSTED",
+        retryable: true,
+        status: 500,
+      },
+    ],
     ambiguous: [],
   });
+
+  await expect(
+    uploadProjectAsset({
+      ...apiParams,
+      asset: descriptor,
+      readAssetData: async () => new Blob([descriptor.name]),
+    })
+  ).resolves.toEqual({ uploaded: [retriedAsset] });
+  expect(retriedAssetAttempts).toBe(3);
 });
 
 test("does not retry a forced upload after an ambiguous server failure", async () => {

--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -394,17 +394,10 @@ const getErrorStatus = (error: unknown) =>
     ? error.status
     : undefined;
 
-const retryOnce = async <Result>(
-  task: () => Promise<Result>,
-  shouldRetry: (error: unknown) => boolean = () => true,
-  delayMs = 0
-) => {
+const retryOnce = async <Result>(task: () => Promise<Result>, delayMs = 0) => {
   try {
     return await task();
-  } catch (error) {
-    if (shouldRetry(error) === false) {
-      throw error;
-    }
+  } catch {
     if (delayMs > 0) {
       await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
@@ -574,9 +567,7 @@ const uploadAssetsSettled = async (
             });
           };
           const uploadedAssets =
-            force === true
-              ? await upload()
-              : await retryOnce(upload, isRetryableAssetUploadError, 100);
+            force === true ? await upload() : await retryOnce(upload, 100);
           results[index] = { status: "fulfilled", uploadedAssets };
         } catch (cause) {
           const error =

--- a/packages/http-client/src/index.ts
+++ b/packages/http-client/src/index.ts
@@ -394,13 +394,47 @@ const getErrorStatus = (error: unknown) =>
     ? error.status
     : undefined;
 
-const retryOnce = async <Result>(task: () => Promise<Result>) => {
+const retryOnce = async <Result>(
+  task: () => Promise<Result>,
+  shouldRetry: (error: unknown) => boolean = () => true,
+  delayMs = 0
+) => {
   try {
     return await task();
-  } catch {
+  } catch (error) {
+    if (shouldRetry(error) === false) {
+      throw error;
+    }
+    if (delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
     return await task();
   }
 };
+
+const isRetryableAssetUploadError = (error: unknown) => {
+  const status = getErrorStatus(error);
+  return (
+    status === undefined || status === 408 || status === 429 || status >= 500
+  );
+};
+
+const assetUploadRetryExhaustedCode = "ASSET_UPLOAD_RETRY_EXHAUSTED";
+
+class AssetUploadRetryError extends Error {
+  readonly webstudioCode = assetUploadRetryExhaustedCode;
+  readonly retryable = true;
+  readonly status: number | undefined;
+
+  constructor(assetName: string, cause: unknown) {
+    const status = getErrorStatus(cause);
+    super(
+      `Asset "${assetName}" failed after 2 attempts${status === undefined ? "" : ` (HTTP ${status})`}. Retry this file by itself. If it still fails, verify that it opens and matches its declared format, then report ${assetUploadRetryExhaustedCode} and the HTTP status.`,
+      { cause }
+    );
+    this.status = status;
+  }
+}
 
 const getBinaryAssetDataHash = async (data: BinaryAssetData) => {
   return getAssetContentHash(
@@ -540,9 +574,15 @@ const uploadAssetsSettled = async (
             });
           };
           const uploadedAssets =
-            force === true ? await upload() : await retryOnce(upload);
+            force === true
+              ? await upload()
+              : await retryOnce(upload, isRetryableAssetUploadError, 100);
           results[index] = { status: "fulfilled", uploadedAssets };
-        } catch (error) {
+        } catch (cause) {
+          const error =
+            force !== true && isRetryableAssetUploadError(cause)
+              ? new AssetUploadRetryError(asset.name, cause)
+              : cause;
           const status = getErrorStatus(error);
           results[index] = {
             status:
@@ -585,6 +625,12 @@ export const uploadAssets = async (
       : []
   );
   if (failed.length > 0) {
+    if (
+      failed.length === 1 &&
+      failed[0]?.error instanceof AssetUploadRetryError
+    ) {
+      throw failed[0].error;
+    }
     throw new Error(
       `Failed to upload assets: ${failed
         .map(({ asset, error }) => `${asset.name}: ${formatError(error)}`)
@@ -708,6 +754,15 @@ export const uploadProjectAssets = async (
               index: result.index,
               name: result.asset.name,
               error: formatError(result.error),
+              ...(result.error instanceof AssetUploadRetryError
+                ? {
+                    code: result.error.webstudioCode,
+                    retryable: result.error.retryable,
+                    ...(result.error.status === undefined
+                      ? {}
+                      : { status: result.error.status }),
+                  }
+                : {}),
             },
           ]
         : []


### PR DESCRIPTION
## Summary
- retry only transient asset upload failures after a short backoff
- return ASSET_UPLOAD_RETRY_EXHAUSTED with retryability and HTTP status for persistent failures
- preserve successful batch uploads and support retrying the failed JPEG alone

## Verification
- pnpm --filter @webstudio-is/http-client test -- src/index.test.ts
- pnpm --filter @webstudio-is/http-client typecheck
- pnpm --filter webstudio test -- src/error-codes.test.ts

Fixes #6363